### PR TITLE
feat: automate App Store screenshot capture

### DIFF
--- a/.claude/skills/appstore-screenshots/SKILL.md
+++ b/.claude/skills/appstore-screenshots/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: appstore-screenshots
+description: Capture localized iPhone App Store screenshots from the simulator using the in-app ScreenshotHarness, show them to the user for sign-off, then push to App Store Connect via fastlane. Use when the user asks to refresh, regenerate, retake, or upload App Store screenshots.
+allowed-tools: Bash(bash .claude/skills/appstore-screenshots/scripts/capture.sh:*), Bash(make appstore-push:*), Read(./iOS/fastlane/screenshots/**)
+---
+
+# App Store Screenshot Pipeline
+
+Drives `iOS/App/ScreenshotHarness.swift` (gated by `#if targetEnvironment(simulator)`) to capture every App Store scene for every locale into `iOS/fastlane/screenshots/<locale>/iPhone-6.9/`. Then waits for explicit user sign-off before uploading via `fastlane deliver`.
+
+See GitHub issues [#28](https://github.com/FokkeZB/GluWink/issues/28) (tracker) and [#29](https://github.com/FokkeZB/GluWink/issues/29) (harness) for design context.
+
+## Scenes
+
+| # | Scene name (`-UITest_Scene`) | Marketing intent | Captured by this skill? |
+|---|---|---|---|
+| 01 | `greenShield` | All clear — friendly green face, glucose + carbs visible | Yes |
+| 02 | `redShield` | Needs attention — red face, first check-in row pre-ticked | Yes |
+| 03 | `widgets` | Home Screen widgets (small × 2 + medium + large, mixed states) | Yes — via `WidgetShowcaseView` which renders the real SharedKit tiles |
+| 04 | `settings` | Parent / main-app view — Settings list (Shielding On, data sources, glucose unit) | Yes |
+| 05 | `watch` | Apple Watch app + complications | **No** — needs the Watch simulator path, follow-up |
+| 06 | `setupChecklist` | Welcome panel + "Pick a data source" / "Configure features" rows | Yes |
+
+Locales come from `AppStore/<locale>.md`. Today: `en-US`, `nl-NL`. Adding a new locale Markdown file automatically adds it to the capture matrix.
+
+## Quick Start
+
+```bash
+# Capture every scene × every locale (one build, ~30s end-to-end)
+bash .claude/skills/appstore-screenshots/scripts/capture.sh
+
+# Iterate on one scene without rebuilding
+bash .claude/skills/appstore-screenshots/scripts/capture.sh \
+    --scene redShield --locale en-US --no-build
+
+# Different simulator (default is "iPhone 17 Pro Max", the 6.9" device)
+bash .claude/skills/appstore-screenshots/scripts/capture.sh --device "iPhone 16 Pro Max"
+```
+
+The script writes to `iOS/fastlane/screenshots/<locale>/iPhone-6.9/<NN>_<scene>.png` and locks the simulator status bar to 9:41, full battery, full bars before each shot.
+
+## Workflow
+
+1. **Capture.** Run the script with no args. Use `--no-build` if a fresh `xcodebuild` already happened in this session.
+2. **Review every PNG.** Read each file in the agent client and check:
+   - Status bar reads `9:41`, full bars, full battery (charged charging glyph).
+   - Glucose / carb numbers match the harness presets (greenShield: 6.4 mmol/L + 25 g; redShield: 14.8 mmol/L + 30 g).
+   - Title text is in the right language and reads cleanly (titles are randomized per launch — re-run a single scene if you got an awkward one, the harness re-rolls).
+   - No `SetupChecklistCard` visible on greenShield / redShield / settings / widgets (only on `setupChecklist`).
+3. **Show the user a summary** with file paths and any concerns (e.g. "the redShield title came out as 'Take a look!' — want me to re-roll?"). **Do not push** without explicit sign-off.
+4. **On approval:** flip `iOS/fastlane/Deliverfile` line 16 from `skip_screenshots true` to `false` (and any other steps from issue #28 → "Flipping the upload switch") if not already done, then `make appstore-push`.
+
+## Re-rolling a single scene
+
+Titles are picked from a numbered list at render time (see `QUIRKS.md` → "Numbered string lists for random titles"). To re-roll without rebuilding:
+
+```bash
+bash .claude/skills/appstore-screenshots/scripts/capture.sh \
+    --scene greenShield --locale en-US --no-build
+```
+
+Repeat until the title reads well in marketing context.
+
+## Adding a new locale
+
+1. Create `AppStore/<locale>.md` (see `AppStore/README.md` → "Contributing a new translation").
+2. Re-run `capture.sh`. The script discovers the new locale automatically.
+3. Confirm Apple's strings (system buttons, time format) localized correctly. If not, the system language code (`<locale>` minus the region) may not be supported by iOS — pick the closest one and override in the script's `language_code_for_locale` helper.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `CoreSimulatorService connection became invalid` | simctl can't talk to the host service | Run any `xcrun simctl …` once outside the agent sandbox; opening Xcode also fixes it |
+| Captures show wrong language | `-AppleLanguages` ignored by some screens | Confirm the locale file exists in the iOS bundle (`iOS/App/<lang>.lproj/`) |
+| `SetupChecklistCard` showing on greenShield / redShield | Build is stale (harness fix not yet compiled) | Drop `--no-build` and rerun |
+| `home` scene looks identical to `greenShield` | They are, intentionally — see scene table | Either pick one in App Store Connect or evolve the `home` preset in `ScreenshotHarness.swift` |
+| Status bar shows real values | `simctl status_bar override` didn't apply | Boot the sim once (`xcrun simctl boot "iPhone 17 Pro Max"`) and rerun |
+| Build error about `ScreenshotHarness` | Old branch / harness file missing | Confirm `iOS/App/ScreenshotHarness.swift` exists; the App target uses synced groups so it should compile automatically |
+| Setup checklist scene looks half-configured | Previous `settings` run left flags in the App Group | Rerun the whole deck (no `--scene`); the harness resets data-source / shielding flags on every launch |
+
+## Side effects on the simulator
+
+The settings scene writes `mockModeEnabled`, `shieldingEnabled`, and `healthKitEverDelivered` to the shared App Group so the rows render as "configured". The harness resets those flags to `false` on every non-settings launch, so running the full deck leaves the sim in a clean state. But if you capture only `--scene settings` and then launch the app normally (no `-UITest_Scene`), you'll see shielding + demo mode turned on until you uninstall/reinstall.
+
+## What this skill does NOT do (yet)
+
+- **Apple Watch (scene 05)**: needs the Watch simulator and the `WatchApp` scheme. Same harness pattern would work; not yet wired.
+- **Caption rendering / device frames**: tracked under issue #31 (`fastlane frameit` driven from the Markdown captions).
+- **Auto-upload**: this skill stops at "PNGs on disk + user reviewed". The push step is the existing `make appstore-push`, which only includes screenshots once `Deliverfile` line 16 flips to `skip_screenshots false` (see issue #28 → "Flipping the upload switch").

--- a/.claude/skills/appstore-screenshots/scripts/capture.sh
+++ b/.claude/skills/appstore-screenshots/scripts/capture.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Capture App Store screenshots from the iOS Simulator using the in-app
+# `ScreenshotHarness` (see iOS/App/ScreenshotHarness.swift).
+#
+# Builds once, boots the right simulator, then loops over every
+# (locale, scene) pair the user requested and writes PNGs into
+# `iOS/fastlane/screenshots/<locale>/iPhone-6.9/NN_<scene>.png`.
+#
+# Designed to be invoked by an agent following the appstore-screenshots
+# skill, but safe to run by hand.
+#
+# Usage:
+#   capture.sh                       # all locales × all iPhone scenes
+#   capture.sh --scene redShield     # one scene, every locale
+#   capture.sh --locale en-US        # one locale, every scene
+#   capture.sh --scene redShield --locale en-US
+#   capture.sh --no-build            # skip rebuild (faster iteration)
+#   capture.sh --device 'iPhone 17 Pro Max'
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+DERIVED_DATA="/tmp/glucoach-screenshots-dd"
+BUNDLE_ID="nl.fokkezb.GluWink"
+DEFAULT_DEVICE="iPhone 17 Pro Max"
+
+# Scene order matches AppStore/README.md → Screenshots. The numeric prefix
+# both orders the files for human review and matches the order the App Store
+# Connect listing shows them. Scene 05 (Apple Watch) isn't yet automated —
+# it needs the Watch simulator path.
+declare -a IPHONE_SCENES=(
+    "01:greenShield"
+    "02:redShield"
+    "03:widgets"
+    "04:settings"
+    "06:setupChecklist"
+)
+
+scene=""
+locale=""
+device="$DEFAULT_DEVICE"
+do_build=1
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --scene) scene="$2"; shift 2 ;;
+        --locale) locale="$2"; shift 2 ;;
+        --device) device="$2"; shift 2 ;;
+        --no-build) do_build=0; shift ;;
+        -h|--help)
+            sed -n '3,18p' "$0"
+            exit 0
+            ;;
+        *) echo "Unknown arg: $1" >&2; exit 64 ;;
+    esac
+done
+
+# Discover locales from AppStore/<locale>.md (the canonical list — every
+# locale present here should get a screenshot pass).
+discover_locales() {
+    local files=("$REPO_ROOT"/AppStore/*.md)
+    for f in "${files[@]}"; do
+        local base="${f##*/}"
+        base="${base%.md}"
+        [[ "$base" == "README" ]] && continue
+        echo "$base"
+    done
+}
+
+if [[ -n "$locale" ]]; then
+    locales=("$locale")
+else
+    # bash 3.2 (macOS default) has no `mapfile`, hence the manual loop.
+    locales=()
+    while IFS= read -r line; do
+        locales+=("$line")
+    done < <(discover_locales)
+fi
+
+if [[ -n "$scene" ]]; then
+    matched=()
+    for entry in "${IPHONE_SCENES[@]}"; do
+        IFS=':' read -r num name <<< "$entry"
+        if [[ "$name" == "$scene" ]]; then
+            matched+=("$entry")
+        fi
+    done
+    if [[ ${#matched[@]} -eq 0 ]]; then
+        echo "Unknown scene: $scene" >&2
+        echo "Known scenes: $(printf '%s ' "${IPHONE_SCENES[@]##*:}")" >&2
+        exit 64
+    fi
+    scenes=("${matched[@]}")
+else
+    scenes=("${IPHONE_SCENES[@]}")
+fi
+
+# Map App Store locale code (en-US, nl-NL) to system language code (en, nl).
+# Apple's locale picker uses the system codes, not the App Store ones.
+language_code_for_locale() {
+    case "$1" in
+        *-*) echo "${1%%-*}" ;;
+        *) echo "$1" ;;
+    esac
+}
+
+posix_locale_for_locale() {
+    case "$1" in
+        *-*) echo "${1%-*}_${1#*-}" ;;
+        *) echo "$1" ;;
+    esac
+}
+
+echo "==> Booting simulator: $device"
+xcrun simctl boot "$device" 2>/dev/null || true
+xcrun simctl bootstatus "$device" -b >/dev/null
+
+if [[ "$do_build" -eq 1 ]]; then
+    echo "==> Building (this is the slow step)"
+    xcodebuild \
+        -project "$REPO_ROOT/iOS/App.xcodeproj" \
+        -scheme App \
+        -configuration Debug \
+        -destination "platform=iOS Simulator,name=$device" \
+        -derivedDataPath "$DERIVED_DATA" \
+        -quiet \
+        build
+fi
+
+APP_PATH="$DERIVED_DATA/Build/Products/Debug-iphonesimulator/App.app"
+if [[ ! -d "$APP_PATH" ]]; then
+    echo "ERROR: build product not found at $APP_PATH" >&2
+    echo "Run without --no-build at least once." >&2
+    exit 1
+fi
+
+echo "==> Installing $APP_PATH"
+xcrun simctl install booted "$APP_PATH"
+
+echo "==> Locking status bar to 9:41, full bars, full battery"
+xcrun simctl status_bar booted override \
+    --time '9:41' \
+    --batteryState charged \
+    --batteryLevel 100 \
+    --cellularBars 4 \
+    --wifiBars 3 \
+    --dataNetwork wifi
+
+# Capture loop ---------------------------------------------------------------
+for loc in "${locales[@]}"; do
+    lang="$(language_code_for_locale "$loc")"
+    posix="$(posix_locale_for_locale "$loc")"
+    out_dir="$REPO_ROOT/iOS/fastlane/screenshots/$loc/iPhone-6.9"
+    mkdir -p "$out_dir"
+
+    for entry in "${scenes[@]}"; do
+        IFS=':' read -r num name <<< "$entry"
+        out="$out_dir/${num}_${name}.png"
+
+        xcrun simctl terminate booted "$BUNDLE_ID" 2>/dev/null || true
+        xcrun simctl launch booted "$BUNDLE_ID" \
+            --args \
+            -UITest_Scene "$name" \
+            -AppleLanguages "($lang)" \
+            -AppleLocale "$posix" \
+            >/dev/null
+
+        # Two seconds is enough for a SwiftUI render on a warm sim. Bump
+        # if a scene starts looking partially drawn (e.g. an asynchronous
+        # data-source row landing late).
+        sleep 2
+
+        xcrun simctl io booted screenshot "$out" >/dev/null 2>&1
+        echo "  $loc  $name  ->  ${out#$REPO_ROOT/}"
+    done
+done
+
+xcrun simctl terminate booted "$BUNDLE_ID" 2>/dev/null || true
+
+echo
+echo "Done. Review the PNGs under iOS/fastlane/screenshots/ before pushing."
+echo "Tip: read each file in your agent client to eyeball them, or open them in Finder."

--- a/AppStore/README.md
+++ b/AppStore/README.md
@@ -83,7 +83,7 @@ Deliver every locale in the **same order** so screenshot #1 is always the same c
 | 1 | **Green shield** — friendly face, "Looking good!", glucose + carbs visible, single Continue button. |
 | 2 | **Red shield** — red face, "Heads up!", glucose high, action checks visible. |
 | 3 | **Home Screen widgets** — small + medium + large in a stack, mix of green and red. |
-| 4 | **Parent / main app view** — shielding active screen, gear icon, status. |
+| 4 | **Settings** — parent / main-app chrome: Attention Rules, Shielding On, data sources, glucose unit. |
 | 5 | **Apple Watch + complications** — watch face with glucose + carbs complications, plus the Watch app. |
 | 6 *(optional)* | **Setup checklist** — Apple Health + Nightscout + demo data choices. |
 
@@ -100,8 +100,8 @@ Captions for each scene live in the per-locale file under **Screenshot captions*
 
 ### Production checklist
 
-- [ ] Render screenshots from a real device (Screen Time UI does not work in the Simulator — see `QUIRKS.md`).
-- [ ] Use the same status bar (full battery, full signal, no notifications) — `xcrun simctl status_bar` for any non-shield screens captured in the Simulator.
+- [ ] Use `.claude/skills/appstore-screenshots/scripts/capture.sh` to render the iPhone deck (scenes 1–4, 6) from the Simulator — the in-app `ScreenshotHarness` renders marketing-equivalent shield, widget, and settings scenes without needing the live Screen Time UI. Scene 5 (Apple Watch) is still manual until the Watch path is wired.
+- [ ] Status bar is locked to 9:41, full signal, full battery by the capture script — no extra `xcrun simctl status_bar` commands needed.
 - [ ] Localize captions on the screenshot itself **and** in the App Store Connect caption field.
 - [ ] Avoid real names, school logos, or other identifying information in widget previews.
 - [ ] Keep the green/red faces consistent with the app icon variants in `iOS/App/Assets.xcassets/`.
@@ -208,7 +208,7 @@ What is **not** pushed via fastlane (still managed in App Store Connect by hand)
 
 - URLs (Support / Marketing / Privacy Policy) — they're shared across locales and rarely change. See the URLs section above.
 - Category, age rating, App Privacy answers — set once, kept in this README.
-- Screenshots and captions — produced from real devices, not yet automated.
+- Screenshots and captions — screenshots are now produced from the Simulator by `.claude/skills/appstore-screenshots`, but captions/frames aren't auto-applied yet. `skip_screenshots` stays `true` in `Deliverfile` until that's wired (tracked in issue #28).
 - The build itself — uploaded via Xcode / Transporter.
 
 ### Adding a new locale

--- a/iOS/App/App.swift
+++ b/iOS/App/App.swift
@@ -18,6 +18,14 @@ struct MainApp: App {
         // it usable as a "first launch after install" sentinel.
         Self.handleFirstLaunchAfterInstall()
 
+        #if targetEnvironment(simulator)
+        // When a fastlane snapshot run launched us with `-UITest_Scene`,
+        // seed the App Group with the scene's glucose / carb values so the
+        // widget and watch processes render the same state as the main
+        // app. No-op outside of a harness run.
+        ScreenshotHarness.seedAppGroupIfNeeded()
+        #endif
+
         // Register HealthKit observers early if the user has already granted
         // HealthKit permission in a past launch. We check by looking at
         // whether we've moved past `.notDetermined` — that's the only state
@@ -46,6 +54,19 @@ struct MainApp: App {
             ContentView()
                 .task {
                     let data = SharedDataManager.shared
+
+                    #if targetEnvironment(simulator)
+                    // Under the screenshot harness, skip HealthKit and
+                    // Nightscout entirely — the App Group was already
+                    // seeded in `init()` with deterministic values, and
+                    // re-fetching would either clobber them (HK sample
+                    // timestamp is newer) or wake the network and stall
+                    // the capture.
+                    if ScreenshotHarness.isActive {
+                        WatchSessionManager.shared.sendLatestContext()
+                        return
+                    }
+                    #endif
 
                     // HealthKit: re-request + enable background delivery
                     // if the user has been asked at least once, and try an

--- a/iOS/App/CheckInView.swift
+++ b/iOS/App/CheckInView.swift
@@ -7,12 +7,34 @@ struct CheckInView: View {
     let items: [String]
     let onDisarm: () -> Void
 
-    @State private var checkedIndices: Set<Int> = []
-    @State private var nextUnlockIndex: Int = -1
+    @State private var checkedIndices: Set<Int>
+    @State private var nextUnlockIndex: Int
     @State private var disarmReady = false
 
     private let itemDelay: TimeInterval = 1.5
     private let disarmDelay: TimeInterval = 2.0
+
+    init(items: [String], onDisarm: @escaping () -> Void) {
+        self.items = items
+        self.onDisarm = onDisarm
+
+        #if targetEnvironment(simulator)
+        // Under the App Store screenshot harness, start with N rows pre-
+        // checked so the red-shield shot reads as "user is responding"
+        // instead of a passive list. Also pre-unlocks the next row so the
+        // screenshot doesn't have to wait out the 1.5s unlock timer.
+        if let preset = ScreenshotHarness.current?.homeViewPreset,
+           preset.checkInPreCheckedCount > 0 {
+            let pre = min(preset.checkInPreCheckedCount, items.count)
+            _checkedIndices = State(initialValue: Set(0..<pre))
+            _nextUnlockIndex = State(initialValue: pre < items.count ? pre : items.count)
+            return
+        }
+        #endif
+
+        _checkedIndices = State(initialValue: [])
+        _nextUnlockIndex = State(initialValue: -1)
+    }
 
     var body: some View {
         VStack(spacing: 16) {
@@ -42,6 +64,11 @@ struct CheckInView: View {
         }
         .padding(.horizontal, 32)
         .onAppear {
+            #if targetEnvironment(simulator)
+            // Harness already seeded `nextUnlockIndex` in init; don't let
+            // the 1.5s timer stomp it back to 0.
+            if ScreenshotHarness.isActive { return }
+            #endif
             DispatchQueue.main.asyncAfter(deadline: .now() + itemDelay) {
                 withAnimation(.easeInOut(duration: 0.3)) {
                     nextUnlockIndex = 0

--- a/iOS/App/ContentView.swift
+++ b/iOS/App/ContentView.swift
@@ -2,6 +2,17 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
+        #if targetEnvironment(simulator)
+        switch ScreenshotHarness.current {
+        case .widgets:
+            WidgetShowcaseView()
+        case .settings:
+            SettingsView()
+        default:
+            HomeView()
+        }
+        #else
         HomeView()
+        #endif
     }
 }

--- a/iOS/App/HomeView.swift
+++ b/iOS/App/HomeView.swift
@@ -62,6 +62,17 @@ struct HomeView: View {
     init() {
         #if targetEnvironment(simulator)
         _isDisarmed = State(initialValue: false)
+
+        if let preset = ScreenshotHarness.current?.homeViewPreset {
+            _glucose = State(initialValue: preset.glucose)
+            _glucoseMinutesAgo = State(initialValue: preset.glucoseMinutesAgo)
+            _carbGrams = State(initialValue: preset.carbGrams)
+            _carbMinutesAgo = State(initialValue: preset.carbMinutesAgo)
+            _hasGlucoseData = State(initialValue: preset.hasGlucoseData)
+            _hasCarbData = State(initialValue: preset.hasCarbData)
+            _mockShieldingEnabled = State(initialValue: preset.shieldingEnabled)
+            _mockDisarmed = State(initialValue: preset.disarmed)
+        }
         #else
         _isDisarmed = State(initialValue: SharedDataManager.shared.isShieldDisarmed)
         #endif
@@ -119,6 +130,9 @@ struct HomeView: View {
     /// screen explains what to do instead of showing "--".
     private var showsWelcome: Bool {
         #if targetEnvironment(simulator)
+        if let preset = ScreenshotHarness.current?.homeViewPreset {
+            return preset.forceWelcome
+        }
         return false
         #else
         let data = SharedDataManager.shared
@@ -221,12 +235,14 @@ struct HomeView: View {
         }
         #if targetEnvironment(simulator)
         .overlay(alignment: .bottomTrailing) {
-            Button {
-                showMockControls = true
-            } label: {
-                Image(systemName: "ladybug")
-                    .font(.title2)
-                    .padding(12)
+            if !ScreenshotHarness.isActive {
+                Button {
+                    showMockControls = true
+                } label: {
+                    Image(systemName: "ladybug")
+                        .font(.title2)
+                        .padding(12)
+                }
             }
         }
         .sheet(isPresented: $showMockControls) {

--- a/iOS/App/ScreenshotHarness.swift
+++ b/iOS/App/ScreenshotHarness.swift
@@ -1,0 +1,205 @@
+#if targetEnvironment(simulator)
+import Foundation
+import SharedKit
+
+/// Deterministic state overrides for App Store screenshot captures.
+///
+/// Wired into `HomeView`'s simulator mock state and `MainApp.init()` so a
+/// fastlane `snapshot` UI test can launch the app, pass `-UITest_Scene
+/// <name>`, and get a pinned, reproducible render without waiting for real
+/// glucose data to swing green/red.
+///
+/// Only compiled for simulator builds, matching the existing ladybug mock-
+/// data convention in `HomeView` (see `AGENTS.md` → "Do NOT add debug menus"
+/// — the simulator-only gate is what keeps this out of TestFlight and App
+/// Store builds). Without `-UITest_Scene`, `current` is `nil` and the app
+/// behaves identically to a normal simulator run.
+///
+/// See GitHub issues #28 (tracking) and #29 (this harness).
+enum ScreenshotHarness {
+    /// Scene identifiers correspond 1:1 with the App Store screenshot
+    /// matrix documented in `AppStore/README.md` → Screenshots.
+    enum Scene: String {
+        /// All-clear state: friendly face, "Looking good!", glucose + carbs visible.
+        case greenShield
+        /// Needs-attention state: red face, check-in items visible.
+        case redShield
+        /// Home Screen widgets stack. `ContentView` swaps `HomeView` out for
+        /// `WidgetShowcaseView` when this is active.
+        case widgets
+        /// Top-level Settings list — rendered via `ContentView` as the root
+        /// `SettingsView` for the "The parent view: status, settings, peace
+        /// of mind" caption (scene 4 in `AppStore/README.md`).
+        case settings
+        /// Apple Watch scene (driven via App Group seed + the watch simulator).
+        case watch
+        /// Setup checklist front and centre, no data yet.
+        case setupChecklist
+    }
+
+    /// Scene selected via `-UITest_Scene <rawValue>` on launch, or `nil` for
+    /// normal runs. Read once at first access and cached.
+    static let current: Scene? = {
+        let args = ProcessInfo.processInfo.arguments
+        guard let idx = args.firstIndex(of: "-UITest_Scene"), idx + 1 < args.count else {
+            return nil
+        }
+        return Scene(rawValue: args[idx + 1])
+    }()
+
+    /// `true` when the harness is driving the app. Used to short-circuit
+    /// network / HealthKit work that would introduce nondeterminism into
+    /// captures.
+    static var isActive: Bool { current != nil }
+
+    /// Display unit to pin for the active capture, derived from `-AppleLocale`.
+    /// English locales use mg/dL (US/UK/Canada convention); everything else
+    /// defaults to mmol/L (the rest of the world + our app default). Stored
+    /// values on `ShieldContent` are always mmol/L, so this only flips the
+    /// display formatting — no preset rewrite needed.
+    static let glucoseUnit: GlucoseUnit = {
+        let args = ProcessInfo.processInfo.arguments
+        guard let idx = args.firstIndex(of: "-AppleLocale"), idx + 1 < args.count else {
+            return .mmolL
+        }
+        return args[idx + 1].lowercased().hasPrefix("en") ? .mgdL : .mmolL
+    }()
+}
+
+// MARK: - HomeView presets
+
+extension ScreenshotHarness.Scene {
+    /// Initial values for `HomeView`'s simulator-only `@State` properties.
+    /// Injected from `HomeView.init()` when a scene is active.
+    struct HomeViewPreset {
+        var glucose: Double
+        var glucoseMinutesAgo: Double
+        var carbGrams: Double
+        var carbMinutesAgo: Double
+        var hasGlucoseData: Bool
+        var hasCarbData: Bool
+        var shieldingEnabled: Bool
+        var disarmed: Bool
+        /// When non-nil, force `HomeView`'s welcome/empty state instead of
+        /// the status panel. Used by `setupChecklist` to clear the top of
+        /// the screen so the checklist card reads as the subject.
+        var forceWelcome: Bool
+        /// Number of check-in rows to render as already-checked in
+        /// `CheckInView`. `0` leaves the view in its "nothing tapped yet"
+        /// state; `1` shows the first row ticked and the second row
+        /// active/tappable, which reads as "user is responding" in
+        /// marketing copy. Only meaningful for scenes that reach the
+        /// check-in flow (i.e. `redShield`).
+        var checkInPreCheckedCount: Int
+    }
+
+    /// Whether `SetupChecklistCard` should be suppressed for this scene.
+    /// True for every "showcase" scene where the checklist would just
+    /// crowd out the actual subject; false only for `setupChecklist`,
+    /// which exists specifically to feature the card.
+    var hidesSetupChecklist: Bool {
+        switch self {
+        case .greenShield, .redShield, .settings, .widgets, .watch: return true
+        case .setupChecklist: return false
+        }
+    }
+
+    var homeViewPreset: HomeViewPreset {
+        switch self {
+        case .greenShield, .settings, .widgets, .watch:
+            return HomeViewPreset(
+                glucose: 6.4,
+                glucoseMinutesAgo: 3,
+                carbGrams: 25,
+                carbMinutesAgo: 90,
+                hasGlucoseData: true,
+                hasCarbData: true,
+                shieldingEnabled: true,
+                disarmed: false,
+                forceWelcome: false,
+                checkInPreCheckedCount: 0
+            )
+        case .redShield:
+            return HomeViewPreset(
+                glucose: 14.8,
+                glucoseMinutesAgo: 2,
+                carbGrams: 30,
+                carbMinutesAgo: 15,
+                hasGlucoseData: true,
+                hasCarbData: true,
+                shieldingEnabled: true,
+                disarmed: false,
+                forceWelcome: false,
+                checkInPreCheckedCount: 1
+            )
+        case .setupChecklist:
+            return HomeViewPreset(
+                glucose: 0,
+                glucoseMinutesAgo: 0,
+                carbGrams: 0,
+                carbMinutesAgo: 0,
+                hasGlucoseData: false,
+                hasCarbData: false,
+                shieldingEnabled: false,
+                disarmed: false,
+                forceWelcome: true,
+                checkInPreCheckedCount: 0
+            )
+        }
+    }
+}
+
+// MARK: - App Group seeding (widgets / watch)
+
+extension ScreenshotHarness {
+    /// Write the active scene's glucose + carb values into the shared App
+    /// Group so widget and watch processes pick up the same numbers. Called
+    /// from `MainApp.init()` before any scene is rendered.
+    ///
+    /// No-op when the harness is inactive. The seeded values are overwritten
+    /// on the next real HealthKit / Nightscout fetch, so a normal app launch
+    /// after a screenshot run doesn't keep the stale sample.
+    static func seedAppGroupIfNeeded() {
+        guard let scene = current else { return }
+        let preset = scene.homeViewPreset
+
+        guard let defaults = UserDefaults(suiteName: Constants.appGroupID) else { return }
+
+        if preset.hasGlucoseData {
+            let glucoseDate = Date().addingTimeInterval(-preset.glucoseMinutesAgo * 60)
+            defaults.set(preset.glucose, forKey: "currentGlucose")
+            defaults.set(glucoseDate.ISO8601Format(), forKey: "glucoseFetchedAt")
+        } else {
+            defaults.removeObject(forKey: "currentGlucose")
+            defaults.removeObject(forKey: "glucoseFetchedAt")
+        }
+
+        if preset.hasCarbData {
+            let carbDate = Date().addingTimeInterval(-preset.carbMinutesAgo * 60)
+            defaults.set(preset.carbGrams, forKey: "lastCarbGrams")
+            defaults.set(carbDate.ISO8601Format(), forKey: "lastCarbEntryAt")
+        } else {
+            defaults.removeObject(forKey: "lastCarbGrams")
+            defaults.removeObject(forKey: "lastCarbEntryAt")
+        }
+
+        // Reset "data source / shielding configured" flags on every run
+        // and re-apply them only where a scene actually wants them. Without
+        // this reset, running `--scene settings` then `--scene setupChecklist`
+        // carries the mock/shielding flags over and the checklist scene
+        // shows a half-configured state instead of the welcome layout.
+        //
+        // `SettingsView` renders radically differently depending on whether
+        // a data source is configured — greyed rows with "connect a source
+        // first" subtitles don't sell the app, so for the settings scene
+        // we stamp everything as "active, configured".
+        let configured = (scene == .settings)
+        defaults.set(configured, forKey: "mockModeEnabled")
+        defaults.set(configured, forKey: "shieldingEnabled")
+        defaults.set(configured, forKey: "healthKitEverDelivered")
+
+        // Pin the display unit per locale so en-US reads as mg/dL.
+        defaults.set(glucoseUnit.rawValue, forKey: "glucoseUnit")
+    }
+}
+#endif

--- a/iOS/App/SetupChecklistCard.swift
+++ b/iOS/App/SetupChecklistCard.swift
@@ -57,26 +57,38 @@ struct SetupChecklistCard: View {
     }
 
     var body: some View {
-        if shouldRender {
-            card
-                .onAppear { refresh() }
-                .onChange(of: refreshToken) { _, _ in refresh() }
-                .sheet(item: $presentedSheet, onDismiss: { refresh() }) { sheet in
-                    sheetContent(for: sheet)
-                }
-                .confirmationDialog(
-                    String(localized: "setup.checklist.hideConfirmTitle"),
-                    isPresented: $showHideConfirmation,
-                    titleVisibility: .visible
-                ) {
-                    Button(String(localized: "setup.checklist.hideConfirmAction"), role: .destructive) {
-                        withAnimation { hideTips() }
-                    }
-                    Button(String(localized: "settings.cancel"), role: .cancel) {}
-                } message: {
-                    Text("setup.checklist.hideConfirmMessage", tableName: "Localizable")
-                }
+        #if targetEnvironment(simulator)
+        if let scene = ScreenshotHarness.current, scene.hidesSetupChecklist {
+            EmptyView()
+        } else if shouldRender {
+            renderedCard
         }
+        #else
+        if shouldRender {
+            renderedCard
+        }
+        #endif
+    }
+
+    private var renderedCard: some View {
+        card
+            .onAppear { refresh() }
+            .onChange(of: refreshToken) { _, _ in refresh() }
+            .sheet(item: $presentedSheet, onDismiss: { refresh() }) { sheet in
+                sheetContent(for: sheet)
+            }
+            .confirmationDialog(
+                String(localized: "setup.checklist.hideConfirmTitle"),
+                isPresented: $showHideConfirmation,
+                titleVisibility: .visible
+            ) {
+                Button(String(localized: "setup.checklist.hideConfirmAction"), role: .destructive) {
+                    withAnimation { hideTips() }
+                }
+                Button(String(localized: "settings.cancel"), role: .cancel) {}
+            } message: {
+                Text("setup.checklist.hideConfirmMessage", tableName: "Localizable")
+            }
     }
 
     // MARK: - Visibility

--- a/iOS/App/WidgetShowcaseView.swift
+++ b/iOS/App/WidgetShowcaseView.swift
@@ -1,0 +1,125 @@
+#if targetEnvironment(simulator)
+import SharedKit
+import SwiftUI
+
+/// Mock "Home Screen widgets" scene used only for the App Store screenshot
+/// flow (`-UITest_Scene widgets`). Renders the real `SmallWidgetTile`,
+/// `MediumWidgetTile`, and `LargeWidgetTile` from SharedKit, so the shot
+/// can never drift from the live widget visuals.
+///
+/// Not a drop-in Home Screen simulator (no wallpaper, dock, or page dots) —
+/// just three tiles stacked on a soft background with a small header, which
+/// is what the App Store screenshot guide asks for: "small + medium + large
+/// in a stack, mix of green and red".
+struct WidgetShowcaseView: View {
+    // Widget geometry for a 6.9" iPhone. Hard-coded because we only capture
+    // on one device class right now; revisit when we add iPad or 6.7".
+    private let smallSide: CGFloat = 170
+    private let mediumSize = CGSize(width: 364, height: 170)
+    private let largeSize = CGSize(width: 364, height: 382)
+    private let cornerRadius: CGFloat = 22
+    /// Extra inset applied outside the tile body, inside the colored background.
+    /// WidgetKit's container adds ~12–16pt of default `contentMargin` that we
+    /// don't get when rendering the tile directly; without this, the numbers
+    /// sit closer to the tile edge than on a real Home Screen. Measured off
+    /// a side-by-side with the shipping widget on an iPhone 16 Pro Max.
+    private let widgetContentMargin: CGFloat = 12
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Spacer(minLength: 12)
+
+            HStack(spacing: 16) {
+                smallTile(calmContent)
+                smallTile(attentionContent)
+            }
+
+            mediumTile(calmContent)
+                .frame(width: mediumSize.width, height: mediumSize.height)
+
+            largeTile(calmContent)
+                .frame(width: largeSize.width, height: largeSize.height)
+
+            Spacer(minLength: 12)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(.systemGray6))
+    }
+
+    // MARK: - Tiles
+
+    private func smallTile(_ content: WidgetTileContent) -> some View {
+        SmallWidgetTile(content: content)
+            .padding(widgetContentMargin)
+            .frame(width: smallSide, height: smallSide)
+            .background(content.shieldContent.needsAttention ? Color.red : Color.green)
+            .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+    }
+
+    private func mediumTile(_ content: WidgetTileContent) -> some View {
+        MediumWidgetTile(content: content)
+            .padding(widgetContentMargin)
+            .background(content.shieldContent.needsAttention ? Color.red : Color.green)
+            .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+    }
+
+    private func largeTile(_ content: WidgetTileContent) -> some View {
+        LargeWidgetTile(content: content)
+            .padding(widgetContentMargin)
+            .background(content.shieldContent.needsAttention ? Color.red : Color.green)
+            .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+    }
+
+    // MARK: - Mock content
+
+    /// Green, calm state — same numbers as `ScreenshotHarness.greenShield`.
+    private var calmContent: WidgetTileContent {
+        makeContent(
+            glucose: 6.4,
+            glucoseMinutesAgo: 3,
+            carbGrams: 25,
+            carbMinutesAgo: 90
+        )
+    }
+
+    /// Red, needs-attention state — mirror of `ScreenshotHarness.redShield`.
+    /// Glucose 14.8 mmol/L is above the high threshold so `ShieldContent`
+    /// flips `needsAttention` true on its own.
+    private var attentionContent: WidgetTileContent {
+        makeContent(
+            glucose: 14.8,
+            glucoseMinutesAgo: 2,
+            carbGrams: 30,
+            carbMinutesAgo: 15
+        )
+    }
+
+    private func makeContent(
+        glucose: Double,
+        glucoseMinutesAgo: Double,
+        carbGrams: Double,
+        carbMinutesAgo: Double
+    ) -> WidgetTileContent {
+        let glucoseDate = Date().addingTimeInterval(-glucoseMinutesAgo * 60)
+        let carbDate = Date().addingTimeInterval(-carbMinutesAgo * 60)
+        let shield = ShieldContent(
+            glucose: glucose,
+            glucoseFetchedAt: glucoseDate,
+            lastCarbGrams: carbGrams,
+            lastCarbEntryAt: carbDate,
+            highGlucoseThreshold: SettingsDefaults.highGlucose,
+            lowGlucoseThreshold: SettingsDefaults.lowGlucose,
+            glucoseStaleMinutes: SettingsDefaults.staleMinutes,
+            carbGraceHour: SettingsDefaults.carbGraceHour,
+            carbGraceMinute: SettingsDefaults.carbGraceMinute,
+            glucoseUnit: SharedDataManager.shared.glucoseUnit,
+            strings: ShieldContent.Strings.fromPackage()
+        )
+        return WidgetTileContent(
+            shieldContent: shield,
+            glucoseDate: glucoseDate,
+            carbDate: carbDate
+        )
+    }
+}
+#endif

--- a/iOS/SharedKit/Sources/SharedKit/Resources/en.lproj/Localizable.strings
+++ b/iOS/SharedKit/Sources/SharedKit/Resources/en.lproj/Localizable.strings
@@ -40,3 +40,8 @@
 "shield.checks.noGlucoseData.0" = "Check sensor";
 "shield.checks.noGlucoseData.1" = "Check data source";
 "shield.checks.noCarbData.0" = "Check data source";
+
+/* Widget tiles (shared between StatusWidget extension and App screenshot showcase) */
+"widget.glucose" = "Glucose";
+"widget.carbs" = "Carbs";
+"widget.noData" = "No data";

--- a/iOS/SharedKit/Sources/SharedKit/Resources/nl.lproj/Localizable.strings
+++ b/iOS/SharedKit/Sources/SharedKit/Resources/nl.lproj/Localizable.strings
@@ -40,3 +40,8 @@
 "shield.checks.noGlucoseData.0" = "Check sensor";
 "shield.checks.noGlucoseData.1" = "Controleer gegevensbron";
 "shield.checks.noCarbData.0" = "Controleer gegevensbron";
+
+/* Widget tiles (shared between StatusWidget extension and App screenshot showcase) */
+"widget.glucose" = "Glucose";
+"widget.carbs" = "Koolhydraten";
+"widget.noData" = "Geen data";

--- a/iOS/SharedKit/Sources/SharedKit/WidgetTileViews.swift
+++ b/iOS/SharedKit/Sources/SharedKit/WidgetTileViews.swift
@@ -1,0 +1,187 @@
+import SwiftUI
+
+/// Visual-only tile bodies shared between the `StatusWidget` extension and
+/// the App's screenshot showcase (`WidgetShowcaseView`). The widget extension
+/// wraps each tile in `containerBackground(for: .widget)` to satisfy WidgetKit;
+/// other callers apply a plain `.background` + `.clipShape`.
+///
+/// Keeping the visuals here — rather than duplicating into an App-only mock —
+/// means the App Store screenshot can never drift from the real widget.
+
+public struct WidgetTileContent {
+    public let shieldContent: ShieldContent
+    public let glucoseDate: Date?
+    public let carbDate: Date?
+
+    public init(shieldContent: ShieldContent, glucoseDate: Date?, carbDate: Date?) {
+        self.shieldContent = shieldContent
+        self.glucoseDate = glucoseDate
+        self.carbDate = carbDate
+    }
+}
+
+// MARK: - Shared helpers
+
+private func widgetRelativeAgoText(from date: Date?, hasData: Bool) -> Text {
+    guard hasData, let date else {
+        return Text(String(localized: "widget.noData", bundle: .module))
+    }
+    return Text(date, style: .relative)
+}
+
+private func widgetGlucoseValue(_ c: ShieldContent) -> String {
+    c.glucoseValue > 0 ? c.formattedGlucose : "--"
+}
+
+private func widgetGlucoseLabel(_ c: ShieldContent) -> String {
+    "\(widgetGlucoseValue(c)) \(c.glucoseUnitLabel)"
+}
+
+private func widgetCarbsValue(_ c: ShieldContent) -> String {
+    c.carbGrams.map { "\($0)" } ?? "--"
+}
+
+private func widgetCarbsLabel(_ c: ShieldContent) -> String {
+    "\(widgetCarbsValue(c)) g"
+}
+
+// MARK: - Small tile
+
+public struct SmallWidgetTile: View {
+    public let content: WidgetTileContent
+
+    public init(content: WidgetTileContent) {
+        self.content = content
+    }
+
+    public var body: some View {
+        let c = content.shieldContent
+        VStack(alignment: .leading, spacing: 6) {
+            Text(widgetGlucoseLabel(c))
+                .font(.system(.title, design: .rounded).bold())
+                .minimumScaleFactor(0.5)
+                .lineLimit(1)
+            widgetRelativeAgoText(from: content.glucoseDate, hasData: c.glucoseValue > 0)
+                .font(.caption)
+                .opacity(0.7)
+
+            Spacer(minLength: 2)
+
+            Text(widgetCarbsLabel(c))
+                .font(.system(.title, design: .rounded).bold())
+                .minimumScaleFactor(0.5)
+                .lineLimit(1)
+            widgetRelativeAgoText(from: content.carbDate, hasData: c.carbGrams != nil)
+                .font(.caption)
+                .opacity(0.7)
+        }
+        .foregroundStyle(.white)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+    }
+}
+
+// MARK: - Medium tile
+
+public struct MediumWidgetTile: View {
+    public let content: WidgetTileContent
+
+    public init(content: WidgetTileContent) {
+        self.content = content
+    }
+
+    public var body: some View {
+        let c = content.shieldContent
+        HStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(String(localized: "widget.glucose", bundle: .module))
+                    .font(.caption.bold())
+                    .opacity(0.7)
+                HStack(alignment: .firstTextBaseline, spacing: 4) {
+                    Text(widgetGlucoseValue(c))
+                        .font(.system(size: 44, weight: .bold, design: .rounded))
+                        .minimumScaleFactor(0.5)
+                        .lineLimit(1)
+                    Text(c.glucoseUnit.shortLabel)
+                        .font(.system(size: 18, weight: .semibold, design: .rounded))
+                        .opacity(0.7)
+                }
+                widgetRelativeAgoText(from: content.glucoseDate, hasData: c.glucoseValue > 0)
+                    .font(.subheadline)
+                    .opacity(0.7)
+                    .lineLimit(1)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(String(localized: "widget.carbs", bundle: .module))
+                    .font(.caption.bold())
+                    .opacity(0.7)
+                HStack(alignment: .firstTextBaseline, spacing: 4) {
+                    Text(widgetCarbsValue(c))
+                        .font(.system(size: 44, weight: .bold, design: .rounded))
+                        .minimumScaleFactor(0.5)
+                        .lineLimit(1)
+                    Text("g")
+                        .font(.system(size: 18, weight: .semibold, design: .rounded))
+                        .opacity(0.7)
+                }
+                widgetRelativeAgoText(from: content.carbDate, hasData: c.carbGrams != nil)
+                    .font(.subheadline)
+                    .opacity(0.7)
+                    .lineLimit(1)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .foregroundStyle(.white)
+        .frame(maxHeight: .infinity)
+        .padding()
+    }
+}
+
+// MARK: - Large tile
+
+public struct LargeWidgetTile: View {
+    public let content: WidgetTileContent
+
+    public init(content: WidgetTileContent) {
+        self.content = content
+    }
+
+    public var body: some View {
+        let c = content.shieldContent
+        VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(String(localized: "widget.glucose", bundle: .module))
+                    .font(.subheadline.bold())
+                    .opacity(0.7)
+                Text(widgetGlucoseLabel(c))
+                    .font(.system(size: 64, weight: .bold, design: .rounded))
+                    .minimumScaleFactor(0.5)
+                    .lineLimit(1)
+                widgetRelativeAgoText(from: content.glucoseDate, hasData: c.glucoseValue > 0)
+                    .font(.subheadline)
+                    .opacity(0.7)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Spacer(minLength: 8)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(String(localized: "widget.carbs", bundle: .module))
+                    .font(.subheadline.bold())
+                    .opacity(0.7)
+                Text(widgetCarbsLabel(c))
+                    .font(.system(size: 52, weight: .bold, design: .rounded))
+                    .minimumScaleFactor(0.5)
+                    .lineLimit(1)
+                widgetRelativeAgoText(from: content.carbDate, hasData: c.carbGrams != nil)
+                    .font(.subheadline)
+                    .opacity(0.7)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .foregroundStyle(.white)
+        .padding()
+    }
+}

--- a/iOS/StatusWidget/StatusWidgetViews.swift
+++ b/iOS/StatusWidget/StatusWidgetViews.swift
@@ -120,141 +120,54 @@ struct AccessoryInlineView: View {
 }
 
 // MARK: - Home Screen widgets
+//
+// The visual body of each tile lives in `SharedKit/WidgetTileViews.swift` so
+// the App's screenshot showcase can render an identical picture without
+// duplicating layout code. This file keeps only the WidgetKit-specific
+// wrapping: `containerBackground(for: .widget)` which WidgetKit uses to
+// colour the tile chrome beyond the padded body.
 
 struct SmallWidgetView: View {
     let entry: StatusEntry
-    private var c: ShieldContent { entry.content }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            // Glucose
-            Text(glucoseLabel(c))
-                .font(.system(.title, design: .rounded).bold())
-                .minimumScaleFactor(0.5)
-                .lineLimit(1)
-            relativeAgoText(from: entry.glucoseDate, hasData: c.glucoseValue > 0)
-                .font(.caption)
-                .opacity(0.7)
-
-            Spacer(minLength: 2)
-
-            // Carbs
-            Text(carbsLabel(c))
-                .font(.system(.title, design: .rounded).bold())
-                .minimumScaleFactor(0.5)
-                .lineLimit(1)
-            relativeAgoText(from: entry.carbDate, hasData: c.carbGrams != nil)
-                .font(.caption)
-                .opacity(0.7)
-        }
-        .foregroundStyle(.white)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding()
+        SmallWidgetTile(content: WidgetTileContent(
+            shieldContent: entry.content,
+            glucoseDate: entry.glucoseDate,
+            carbDate: entry.carbDate
+        ))
         .containerBackground(for: .widget) {
-            c.needsAttention ? Color.red : Color.green
+            entry.content.needsAttention ? Color.red : Color.green
         }
     }
 }
 
 struct MediumWidgetView: View {
     let entry: StatusEntry
-    private var c: ShieldContent { entry.content }
 
     var body: some View {
-        HStack(spacing: 0) {
-            // Glucose column
-            VStack(alignment: .leading, spacing: 2) {
-                Text(String(localized: "widget.glucose"))
-                    .font(.caption.bold())
-                    .opacity(0.7)
-                HStack(alignment: .firstTextBaseline, spacing: 4) {
-                    Text(glucoseValue(c))
-                        .font(.system(size: 44, weight: .bold, design: .rounded))
-                        .minimumScaleFactor(0.5)
-                        .lineLimit(1)
-                    Text(c.glucoseUnit.shortLabel)
-                        .font(.system(size: 18, weight: .semibold, design: .rounded))
-                        .opacity(0.7)
-                }
-                relativeAgoText(from: entry.glucoseDate, hasData: c.glucoseValue > 0)
-                    .font(.subheadline)
-                    .opacity(0.7)
-                    .lineLimit(1)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-
-            // Carbs column
-            VStack(alignment: .leading, spacing: 2) {
-                Text(String(localized: "widget.carbs"))
-                    .font(.caption.bold())
-                    .opacity(0.7)
-                HStack(alignment: .firstTextBaseline, spacing: 4) {
-                    Text(carbsValue(c))
-                        .font(.system(size: 44, weight: .bold, design: .rounded))
-                        .minimumScaleFactor(0.5)
-                        .lineLimit(1)
-                    Text("g")
-                        .font(.system(size: 18, weight: .semibold, design: .rounded))
-                        .opacity(0.7)
-                }
-                relativeAgoText(from: entry.carbDate, hasData: c.carbGrams != nil)
-                    .font(.subheadline)
-                    .opacity(0.7)
-                    .lineLimit(1)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-        }
-        .foregroundStyle(.white)
-        .frame(maxHeight: .infinity)
-        .padding()
+        MediumWidgetTile(content: WidgetTileContent(
+            shieldContent: entry.content,
+            glucoseDate: entry.glucoseDate,
+            carbDate: entry.carbDate
+        ))
         .containerBackground(for: .widget) {
-            c.needsAttention ? Color.red : Color.green
+            entry.content.needsAttention ? Color.red : Color.green
         }
     }
 }
 
 struct LargeWidgetView: View {
     let entry: StatusEntry
-    private var c: ShieldContent { entry.content }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            // Glucose section
-            VStack(alignment: .leading, spacing: 2) {
-                Text(String(localized: "widget.glucose"))
-                    .font(.subheadline.bold())
-                    .opacity(0.7)
-                Text(glucoseLabel(c))
-                    .font(.system(size: 64, weight: .bold, design: .rounded))
-                    .minimumScaleFactor(0.5)
-                    .lineLimit(1)
-                relativeAgoText(from: entry.glucoseDate, hasData: c.glucoseValue > 0)
-                    .font(.subheadline)
-                    .opacity(0.7)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-
-            Spacer(minLength: 8)
-
-            // Carbs section
-            VStack(alignment: .leading, spacing: 2) {
-                Text(String(localized: "widget.carbs"))
-                    .font(.subheadline.bold())
-                    .opacity(0.7)
-                Text(carbsLabel(c))
-                    .font(.system(size: 52, weight: .bold, design: .rounded))
-                    .minimumScaleFactor(0.5)
-                    .lineLimit(1)
-                relativeAgoText(from: entry.carbDate, hasData: c.carbGrams != nil)
-                    .font(.subheadline)
-                    .opacity(0.7)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-        }
-        .foregroundStyle(.white)
-        .padding()
+        LargeWidgetTile(content: WidgetTileContent(
+            shieldContent: entry.content,
+            glucoseDate: entry.glucoseDate,
+            carbDate: entry.carbDate
+        ))
         .containerBackground(for: .widget) {
-            c.needsAttention ? Color.red : Color.green
+            entry.content.needsAttention ? Color.red : Color.green
         }
     }
 }


### PR DESCRIPTION
Automates the App Store screenshot flow so the deck regenerates in ~30 seconds from the command line, instead of being hand-crafted on a real device. Closes #29, moves #28 forward.

## What's inside

Three commits on this branch, each self-contained:

1. **`refactor(widgets): extract tile views into SharedKit`** — pure refactor. `SmallWidgetView` / `MediumWidgetView` / `LargeWidgetView` moved into `SharedKit` as `SmallWidgetTile` / `MediumWidgetTile` / `LargeWidgetTile` (with a new `WidgetTileContent` value type). The widget extension now only supplies the WidgetKit-specific `containerBackground` wrap. Widget visuals are pixel-identical in production.

2. **`feat(ios): screenshot harness for deterministic captures`** — adds `ScreenshotHarness`, a simulator-only state injector driven by launch arguments. Reads `-UITest_Scene <name>` and pins `HomeView` state, `CheckInView` pre-checked rows, `SetupChecklistCard` visibility, and App Group shared defaults (glucose/carbs samples, shielding/mock/HealthKit flags, glucose unit). Adds `WidgetShowcaseView` (renders the real SharedKit tiles for scene 3) and routes scene 4 to `SettingsView` via a new `ContentView` shim. All gated behind `#if targetEnvironment(simulator)`.

3. **`feat(appstore): appstore-screenshots skill and capture script`** — `.claude/skills/appstore-screenshots/` ships a `capture.sh` that builds once, boots the iPhone 17 Pro Max simulator, locks the status bar, and sweeps every `AppStore/<locale>.md` × scene combination, writing PNGs into the `iOS/fastlane/screenshots/` layout `deliver` expects. Updates `AppStore/README.md` to point at the skill instead of the old "real device required" instruction.

## Scenes covered

| # | Scene | Captured? |
|---|---|---|
| 01 | `greenShield` | Yes |
| 02 | `redShield` (first check-in row pre-ticked) | Yes |
| 03 | `widgets` (small × 2 + medium + large, mixed green/red) | Yes |
| 04 | `settings` | Yes |
| 05 | `watch` | No — needs the Watch simulator path, follow-up |
| 06 | `setupChecklist` | Yes |

**Locales:** English (mg/dL) and Dutch (mmol/L), auto-discovered from `AppStore/<locale>.md`.

## How to use

\`\`\`bash
bash .claude/skills/appstore-screenshots/scripts/capture.sh
\`\`\`

Output: 10 PNGs under \`iOS/fastlane/screenshots/<locale>/iPhone-6.9/\`. Review them before pushing; `skip_screenshots` stays `true` in \`Deliverfile\` until captions + device frames are automated (tracked in #28).

## Side effects on the simulator

Capturing `--scene settings` writes `mockModeEnabled`, `shieldingEnabled`, `healthKitEverDelivered`, and `glucoseUnit` to the shared App Group so the Settings rows render as configured. The harness resets those on every non-settings launch, so running the full deck leaves the sim clean — but running only `--scene settings` or `--scene widgets` (English) leaves flags on until the next run or an uninstall.

## Validated

- [x] Full deck regenerates cleanly (10 PNGs, 5 scenes × 2 locales)
- [x] No scene bleed between runs
- [x] Each scene visually distinct
- [x] Widget tile padding matches a real-device side-by-side on iPhone 16 Pro Max
- [x] App + Watch + StatusWidget + ShieldConfig all build green
- [x] Normal simulator launch (no `-UITest_Scene`) behaves identically to before

## Not in this PR (follow-ups)

- Apple Watch scene 5 — needs the Watch simulator path
- Caption rendering / device frames — `fastlane frameit` wiring
- Flipping `Deliverfile` to `skip_screenshots false` + auto-upload — depends on both of the above (see #28)

Made with [Cursor](https://cursor.com)