### PR TITLE
chore(appstore): add make appstore-screenshots alias

### DIFF
--- a/.claude/skills/appstore-screenshots/SKILL.md
+++ b/.claude/skills/appstore-screenshots/SKILL.md
@@ -27,15 +27,17 @@ Locales come from `AppStore/<locale>.md`. Today: `en-US`, `nl-NL`. Adding a new 
 
 ```bash
 # Capture every scene × every locale (one build, ~30s end-to-end)
-bash .claude/skills/appstore-screenshots/scripts/capture.sh
+make appstore-screenshots
 
-# Iterate on one scene without rebuilding
+# Iterate on one scene without rebuilding — drop down to the script directly
 bash .claude/skills/appstore-screenshots/scripts/capture.sh \
     --scene redShield --locale en-US --no-build
 
 # Different simulator (default is "iPhone 17 Pro Max", the 6.9" device)
 bash .claude/skills/appstore-screenshots/scripts/capture.sh --device "iPhone 16 Pro Max"
 ```
+
+`make appstore-screenshots` is the short alias for the full-deck capture. Use the raw `capture.sh` path for the `--scene` / `--locale` / `--device` / `--no-build` flags.
 
 The script writes to `iOS/fastlane/screenshots/<locale>/iPhone-6.9/<NN>_<scene>.png` and locks the simulator status bar to 9:41, full battery, full bars before each shot.
 

--- a/AppStore/README.md
+++ b/AppStore/README.md
@@ -100,7 +100,7 @@ Captions for each scene live in the per-locale file under **Screenshot captions*
 
 ### Production checklist
 
-- [ ] Use `.claude/skills/appstore-screenshots/scripts/capture.sh` to render the iPhone deck (scenes 1–4, 6) from the Simulator — the in-app `ScreenshotHarness` renders marketing-equivalent shield, widget, and settings scenes without needing the live Screen Time UI. Scene 5 (Apple Watch) is still manual until the Watch path is wired.
+- [ ] Run `make appstore-screenshots` to render the iPhone deck (scenes 1–4, 6) from the Simulator — the in-app `ScreenshotHarness` renders marketing-equivalent shield, widget, and settings scenes without needing the live Screen Time UI. Scene 5 (Apple Watch) is still manual until the Watch path is wired. See `.claude/skills/appstore-screenshots/SKILL.md` for scene-level flags and locale filters.
 - [ ] Status bar is locked to 9:41, full signal, full battery by the capture script — no extra `xcrun simctl status_bar` commands needed.
 - [ ] Localize captions on the screenshot itself **and** in the App Store Connect caption field.
 - [ ] Avoid real names, school logos, or other identifying information in widget previews.

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ venv-clean:
 
 # --- App Store listing (fastlane deliver) ---
 
-.PHONY: appstore-bootstrap appstore-sync appstore-push appstore-pull
+.PHONY: appstore-bootstrap appstore-sync appstore-push appstore-pull appstore-screenshots
 
 ## One-time: install fastlane into iOS/vendor/bundle (uses iOS/Gemfile)
 appstore-bootstrap:
@@ -74,3 +74,9 @@ appstore-push:
 ## Download current App Store metadata into iOS/fastlane/metadata/ (snapshot only)
 appstore-pull:
 	cd iOS && bundle exec fastlane pull_metadata
+
+## Regenerate the App Store screenshot deck (every scene × every locale).
+## Writes PNGs into iOS/fastlane/screenshots/<locale>/iPhone-6.9/.
+## See .claude/skills/appstore-screenshots/SKILL.md for what's covered.
+appstore-screenshots:
+	bash .claude/skills/appstore-screenshots/scripts/capture.sh


### PR DESCRIPTION
Wraps `.claude/skills/appstore-screenshots/scripts/capture.sh` in a Makefile target so the screenshot deck regenerates with the same verb shape as the rest of the App Store plumbing (`appstore-sync`, `appstore-push`, `appstore-pull`).

Closes #30 — see commit body for why the remaining Snapfile / UI test / \`fastlane snapshot\` items from that issue are intentionally skipped. Tl;dr: the in-app \`ScreenshotHarness\` (#29) already lets \`capture.sh\` drive every scene directly via \`xcrun simctl launch --args\`, so the UI-test detour adds complexity for no practical gain.

## Changes

- \`Makefile\`: new \`appstore-screenshots\` target.
- \`.claude/skills/appstore-screenshots/SKILL.md\`: Quick Start now leads with \`make appstore-screenshots\`; raw \`capture.sh\` stays documented for \`--scene\` / \`--locale\` / \`--no-build\` iteration.
- \`AppStore/README.md\`: production checklist points at the make target.

## Test plan

- [x] \`make -n appstore-screenshots\` prints the script invocation.
- [x] \`make appstore-screenshots\` runs capture.sh end-to-end (already validated in #39).

Made with [Cursor](https://cursor.com)