### PR TITLE
feat(appstore): add make appstore-beta for one-command TestFlight uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,10 @@ iOS/fastlane/metadata/
 iOS/fastlane/screenshots/
 iOS/fastlane/report.xml
 iOS/fastlane/README.md
+# `make appstore-beta` leftovers: gym (build_app) generates a preview HTML
+# and a temp working dir alongside the Fastfile. The .ipa + .xcarchive land
+# in iOS/build/ (already ignored above).
+iOS/fastlane/Preview.html
+iOS/fastlane/tmp/
 iOS/vendor/bundle/
 iOS/.bundle/

--- a/AppStore/README.md
+++ b/AppStore/README.md
@@ -189,6 +189,7 @@ The Markdown files in this folder are the source of truth. They get converted to
 | `make appstore-sync` | Regenerate `iOS/fastlane/metadata/` from `AppStore/*.md`. Validates length limits locally, no network. |
 | `make appstore-push` | Sync, then push to App Store Connect. Updates the **editable** version (most recent draft / "Prepare for Submission"). Does **not** submit for review. |
 | `make appstore-pull` | Download Apple's current copy into `iOS/fastlane/metadata/` — handy for diffing or bootstrapping a new locale. Read-only; never overwrite the Markdown from this. |
+| `make appstore-beta` | Archive a Release build and upload to TestFlight. Auto-bumps the build number from ASC. See "Releasing a TestFlight build" below. |
 
 What gets pushed (per locale, from each `<locale>.md`):
 
@@ -207,7 +208,7 @@ What is **not** pushed via fastlane (still managed in App Store Connect by hand)
 
 - URLs (Support / Marketing / Privacy Policy) — they're shared across locales and rarely change. See the URLs section above.
 - Category, age rating, App Privacy answers — set once, kept in this README.
-- The build itself — uploaded via Xcode / Transporter.
+- The build itself — `make appstore-beta` uploads it to TestFlight (see the "Releasing a TestFlight build" section below). `make appstore-push` stays text-only via `skip_binary_upload true` in `Deliverfile`, so it's safe to re-run without touching the binary.
 
 Screenshots _are_ pushed by `make appstore-push` now (captions baked in, `skip_screenshots false` in `Deliverfile`). Regenerate with `make appstore-screenshots` first so ASC gets the latest deck.
 
@@ -217,6 +218,51 @@ Screenshots _are_ pushed by `make appstore-push` now (captions baked in, `skip_s
 2. Run `make appstore-sync` to confirm it parses without errors.
 3. In App Store Connect, add the locale to the app version (English UK doesn't auto-create itself).
 4. Run `make appstore-push`.
+
+---
+
+## Releasing a TestFlight build
+
+`make appstore-beta` takes the current `main` checkout to a pending TestFlight build — archive, sign, upload — in one command.
+
+### What it does
+
+1. Calls App Store Connect to find the latest build number across all versions and picks the next integer. Never collides with an existing build, never prompts for a manual bump.
+2. Runs `xcodebuild archive` with `-allowProvisioningUpdates`, so Xcode-managed signing can create or renew the App Store distribution profile on its own.
+3. Exports the archive as an `app-store` `.ipa` into `iOS/build/` (gitignored).
+4. Uploads the `.ipa` to TestFlight via the same App Store Connect API key used for metadata pushes. `skip_waiting_for_build_processing` is on, so the lane returns as soon as Apple acknowledges the upload — the build appears under **TestFlight → Builds** within a few minutes.
+
+The marketing version (`MARKETING_VERSION` in the xcodeproj, shown to users as "1.0") is **not** touched. Bumping that is a deliberate release step tracked under #33. Build numbers, on the other hand, are bookkeeping and move every upload.
+
+### Prerequisites
+
+On top of the metadata setup above:
+
+- Signed into Xcode at least once with an Apple ID on team `Y39937U7XN` (the one in `DEVELOPMENT_TEAM`). `-allowProvisioningUpdates` talks to that session to fetch the App Store profile.
+- The App target still has `CODE_SIGN_STYLE = Automatic`. If you ever flip it to manual, this lane needs an `export_options.provisioningProfiles` override and re-signing notes.
+- `private/asc-api-key.json` is the one with role **App Manager** or higher — "Developer" can read but not upload.
+
+### Running it
+
+```sh
+make appstore-beta
+```
+
+First run takes 3–5 minutes (clean archive + upload); subsequent runs are similar because we `clean: true` every time to avoid "phantom fixed" builds from cached derived data.
+
+Running it again picks a new build number automatically — the lane is safe to re-run as often as needed.
+
+### Checking it worked
+
+- The lane's last log line should be `Successfully uploaded the new binary to App Store Connect`.
+- Within ~5 minutes, the build shows up under **App Store Connect → TestFlight → Builds** in "Processing" state.
+- Once it flips to "Ready to Test", internal testers see it automatically; external distribution is a separate click in ASC.
+
+### When it fails
+
+- **"Cannot find a matching profile"** — sign into Xcode with an account on the `DEVELOPMENT_TEAM` and retry. `-allowProvisioningUpdates` can create profiles but not conjure accounts.
+- **"The bundle version must be higher than the previously uploaded version"** — you're uploading faster than ASC indexes. Wait 30s and rerun; `latest_testflight_build_number` will see the new build and bump past it.
+- **"Invalid API key"** — the key lost its upload role, or expired. Recreate at App Store Connect → Users and Access → Integrations → Keys, save over `private/asc-api-key.json`.
 
 ---
 
@@ -232,6 +278,6 @@ Before tapping **Submit for Review**:
 - [ ] Age rating questionnaire completed (4+, mild medical info).
 - [ ] Sign-in info / demo account section: explicitly say "no account required" and point the reviewer at Demo mode.
 - [ ] Reviewer notes: mention that Screen Time + Family Controls require a real device and that the reviewer can use Demo mode in Settings → Data Sources to populate glucose without a CGM.
-- [ ] Build uploaded and selected for the version.
+- [ ] Build uploaded (run `make appstore-beta`) and selected for the version.
 - [ ] Pricing set to Free.
 - [ ] Availability set to all territories where the listing is localized (at minimum: US, NL, BE).

--- a/AppStore/README.md
+++ b/AppStore/README.md
@@ -238,6 +238,7 @@ The marketing version (`MARKETING_VERSION` in the xcodeproj, shown to users as "
 
 On top of the metadata setup above:
 
+- **Family Controls Distribution** approved by Apple for team `Y39937U7XN` — request at https://developer.apple.com/contact/request/family-controls-distribution/. Without this, archive succeeds but `xcodebuild -exportArchive` fails because the auto-generated **Store** profile cannot include `com.apple.developer.family-controls`. Apple grants the **Development** variant of the capability automatically; the **Distribution** variant is a manual review (typically days to a few weeks). See `QUIRKS.md` → "Family Controls Distribution requires manual Apple approval" for the full story.
 - Signed into Xcode at least once with an Apple ID on team `Y39937U7XN` (the one in `DEVELOPMENT_TEAM`). `-allowProvisioningUpdates` talks to that session to fetch the App Store profile.
 - The App target still has `CODE_SIGN_STYLE = Automatic`. If you ever flip it to manual, this lane needs an `export_options.provisioningProfiles` override and re-signing notes.
 - `private/asc-api-key.json` is the one with role **App Manager** or higher — "Developer" can read but not upload.
@@ -260,6 +261,7 @@ Running it again picks a new build number automatically — the lane is safe to 
 
 ### When it fails
 
+- **`Provisioning profile "iOS Team Store Provisioning Profile: nl.fokkezb.GluWink…" doesn't include the Family Controls (Development) capability` / `…doesn't include the com.apple.developer.family-controls entitlement`** — repeated for the App, ShieldConfig, ShieldAction, and DeviceActivityMonitor targets, with `** EXPORT FAILED **` and `Exit status: 70` at the end. The archive built fine; the Distribution profile is missing the entitlement because Apple hasn't approved Family Controls for distribution on this team yet. Submit the request linked in the Prerequisites above and re-run the lane after approval lands. There is no code workaround — stripping the entitlement breaks the app, and ad-hoc / development export can't go to TestFlight. The misleading "(Development)" wording in the error means the profile only carries the auto-granted Development variant, not the Distribution variant the binary needs.
 - **"Cannot find a matching profile"** — sign into Xcode with an account on the `DEVELOPMENT_TEAM` and retry. `-allowProvisioningUpdates` can create profiles but not conjure accounts.
 - **"The bundle version must be higher than the previously uploaded version"** — you're uploading faster than ASC indexes. Wait 30s and rerun; `latest_testflight_build_number` will see the new build and bump past it.
 - **"Invalid API key"** — the key lost its upload role, or expired. Recreate at App Store Connect → Users and Access → Integrations → Keys, save over `private/asc-api-key.json`.

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ venv-clean:
 
 # --- App Store listing (fastlane deliver) ---
 
-.PHONY: appstore-bootstrap appstore-sync appstore-push appstore-pull appstore-screenshots
+.PHONY: appstore-bootstrap appstore-sync appstore-push appstore-pull appstore-screenshots appstore-beta
 
 ## One-time: install fastlane into iOS/vendor/bundle (uses iOS/Gemfile)
 appstore-bootstrap:
@@ -80,3 +80,11 @@ appstore-pull:
 ## See .claude/skills/appstore-screenshots/SKILL.md for what's covered.
 appstore-screenshots:
 	bash .claude/skills/appstore-screenshots/scripts/capture.sh
+
+## Build a Release archive and upload it to TestFlight.
+## Auto-bumps the build number from the latest TestFlight build and uses
+## Xcode-managed signing. Requires private/asc-api-key.json and being
+## signed into Xcode with the development team.
+## See AppStore/README.md → "Releasing a TestFlight build".
+appstore-beta:
+	cd iOS && bundle exec fastlane beta

--- a/QUIRKS.md
+++ b/QUIRKS.md
@@ -39,6 +39,18 @@ Tested 2026-04-13: `requestAuthorization(for: .individual)` succeeds on a non-ch
 ### .child authorization fails silently without Family Sharing
 On a device that isn't a child member of a Family Sharing group, `.child` authorization throws an error. The app catches this and falls back to `.individual`. The error message is not user-friendly (Apple internal domain), which is why we don't surface it.
 
+### Family Controls Distribution requires manual Apple approval
+The `com.apple.developer.family-controls` entitlement is one of Apple's "restricted capabilities". Apple grants the **Development** variant automatically to any team, so dev builds and Run-on-device work out of the box. The **Distribution** variant — needed for any App Store / TestFlight build — has to be requested per team at https://developer.apple.com/contact/request/family-controls-distribution/ and is reviewed manually (typically days to a few weeks).
+
+Symptom when the request hasn't been approved yet: `xcodebuild archive` succeeds, then `xcodebuild -exportArchive` fails with one error per Family-Controls-using target:
+
+```
+error: exportArchive Provisioning profile "iOS Team Store Provisioning Profile: nl.fokkezb.GluWink.ShieldConfig" doesn't include the Family Controls (Development) capability.
+error: exportArchive Provisioning profile "iOS Team Store Provisioning Profile: nl.fokkezb.GluWink.ShieldConfig" doesn't include the com.apple.developer.family-controls entitlement.
+```
+
+The "(Development)" wording is misleading — it means the auto-generated Store profile is *limited to* the Development variant of the entitlement (which is all Apple lets it carry without approval), not that the binary asked for a Development entitlement. There is no code workaround: removing the entitlement gates out the entire shielding feature, and ad-hoc / enterprise export can't reach TestFlight. The only path is the Apple form, then re-running `make appstore-beta` once the approval email arrives. Targets affected: `App`, `ShieldConfig`, `ShieldAction`, `DeviceActivityMonitor`.
+
 ### Passphrase stored in Keychain, not App Group
 The settings passphrase is stored in the device Keychain (SHA-256 hash + random salt, 48 bytes total). It is NOT in App Group UserDefaults — extensions don't need it, and Keychain is encrypted at rest. `kSecAttrAccessibleAfterFirstUnlock` ensures it survives backgrounding and reboots but requires the device to have been unlocked at least once.
 

--- a/iOS/fastlane/Fastfile
+++ b/iOS/fastlane/Fastfile
@@ -143,6 +143,60 @@ platform :ios do
     end
   end
 
+  desc "Build a Release archive and upload it to TestFlight."
+  desc "Uses Xcode-managed signing (-allowProvisioningUpdates) and auto-bumps"
+  desc "CURRENT_PROJECT_VERSION from the latest TestFlight build so successive"
+  desc "runs never collide. Requires private/asc-api-key.json and being signed"
+  desc "into Xcode with an Apple ID on team Y39937U7XN."
+  lane :beta do
+    api_key_path = require_api_key!
+
+    # Next build number = (latest on TestFlight) + 1. No `version:` filter so
+    # we pick up the overall max across marketing versions — safer than
+    # per-version, because it can't collide with a leftover build left under
+    # a prior version during a release transition. initial_build_number: 0
+    # covers the first-ever upload where ASC returns nothing.
+    next_build_number = latest_testflight_build_number(
+      api_key_path: api_key_path,
+      initial_build_number: 0,
+    ) + 1
+    UI.message("Next TestFlight build number: #{next_build_number}")
+
+    # Thread the build number through xcargs instead of mutating the
+    # xcodeproj with `increment_build_number` — keeps git clean between runs
+    # and matches the "TestFlight is the source of truth for build numbers"
+    # model above. -allowProvisioningUpdates lets Xcode-managed signing
+    # fetch / renew the App Store profile on its own during archive.
+    build_app(
+      project: "App.xcodeproj",
+      scheme: "App",
+      configuration: "Release",
+      export_method: "app-store",
+      output_directory: "build",
+      output_name: "App.ipa",
+      clean: true,
+      xcargs: "CURRENT_PROJECT_VERSION=#{next_build_number} -allowProvisioningUpdates",
+    )
+
+    # dSYM upload to a third-party crash reporter goes here once we wire
+    # one up (Sentry, Crashlytics, etc.). pilot already uploads dSYMs to
+    # App Store Connect as part of the .ipa, so Apple-side symbolication
+    # is covered without any extra step.
+    # upload_symbols_to_sentry(dsym_path: lane_context[SharedValues::DSYM_OUTPUT_PATH])
+
+    upload_to_testflight(
+      api_key_path: api_key_path,
+      # Don't block the lane on ASC's post-upload processing. The build
+      # shows up under TestFlight → Builds within a few minutes on its own.
+      # Flip this to false once we start passing a `changelog:` — the
+      # release notes can only be applied after processing completes.
+      skip_waiting_for_build_processing: true,
+      # No auto-distribute: internal testers see the build once ASC finishes
+      # processing; external distribution is a conscious click in ASC until
+      # we decide on a tester-group strategy.
+    )
+  end
+
   desc "Download current App Store metadata into fastlane/metadata/ (read-only)."
   desc "Useful to inspect what Apple has, or to bootstrap a new locale."
   lane :pull_metadata do


### PR DESCRIPTION
Closes #32.

## Summary

One command (`make appstore-beta`) takes a clean checkout to a pending TestFlight build — archive, sign, upload — no Organizer clicking and no manual `CURRENT_PROJECT_VERSION` bump.

- New `beta` lane in `iOS/fastlane/Fastfile` using the existing App Store Connect API key.
- Auto-bumps the build number from the latest TestFlight build (queried via the API key, no cert) and threads it through `xcargs` — the xcodeproj stays untouched between runs.
- Uses Xcode-managed signing (`-allowProvisioningUpdates`) rather than `fastlane match`. Decision rationale: solo-dev project, one Mac, Xcode signing already working, `CODE_SIGN_STYLE = Automatic` across targets. `match` was the issue's recommendation but adds a separate private certs repo and ~1h of setup for no current payoff. Easy to switch later if cross-machine signing or a second contributor shows up.
- dSYM upload left as a commented-out `upload_symbols_to_sentry(...)` stub — pilot already covers Apple-side symbolication; third-party crash reporter isn't wired yet.
- `Makefile` target matches the existing `appstore-*` convention (`-bootstrap` / `-sync` / `-push` / `-pull` / `-screenshots` / `-beta`).
- README gets a new "Releasing a TestFlight build" section covering the prerequisites, what the lane does, and the failure modes likely to hit first.

## Files

- `iOS/fastlane/Fastfile` — `beta` lane.
- `Makefile` — `appstore-beta` target.
- `.gitignore` — ignore `iOS/fastlane/Preview.html` and `iOS/fastlane/tmp/` (gym leftovers); `iOS/build/` where the .ipa + .xcarchive land was already ignored.
- `AppStore/README.md` — new TestFlight section, day-to-day table row, submission checklist update, and cleanup of the stale "binary is not pushed via fastlane" bullet.

## Out of scope

- Full App Store release lane (submission, phased release, marketing-version bump) — that's #33, and this PR intentionally doesn't touch `Deliverfile`'s `skip_binary_upload true` so `make appstore-push` stays safe to re-run.
- Moving this to CI — the issue explicitly defers that. Lane runs locally first; GitHub Actions is a follow-up once the flow is stable. Tracks alongside #41.
- `fastlane match` — see rationale above; revisit if we ever need cross-machine signing.

## Test plan

- [ ] `make appstore-beta` on a clean checkout produces a new build in App Store Connect → TestFlight → Builds within ~5 minutes.
- [ ] Running it twice in a row picks a new build number each time without manual edits.
- [ ] `make appstore-push` still works after a `beta` run and does not touch the binary (it should pass `skip_binary_upload` and upload metadata only).
- [ ] `git status` is clean after the lane finishes (build output in `iOS/build/`, gym leftovers under `iOS/fastlane/` both gitignored).

Made with [Cursor](https://cursor.com)