### PR TITLE
build(docs): add docs-publish-check for production-mirror local serve

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ venv-clean:
 
 # --- App Store listing (fastlane deliver) ---
 
-.PHONY: appstore-bootstrap appstore-sync appstore-push appstore-pull appstore-screenshots appstore-beta docs-sync-screenshots docs-bootstrap docs-serve
+.PHONY: appstore-bootstrap appstore-sync appstore-push appstore-pull appstore-screenshots appstore-beta docs-sync-screenshots docs-bootstrap docs-serve docs-clean docs-build docs-publish-check
 
 ## One-time: install fastlane into iOS/vendor/bundle (uses iOS/Gemfile)
 appstore-bootstrap:
@@ -110,6 +110,29 @@ docs-bootstrap:
 docs-serve:
 	@cd docs && PATH="$(DOCS_PATH)" ruby -e 'exit RUBY_VERSION.start_with?("3.3.") ? 0 : 1' || { echo "ERROR: docs/ requires Ruby 3.3.x (see docs/.tool-versions). Run 'make docs-bootstrap' first." >&2; exit 1; }
 	cd docs && PATH="$(DOCS_PATH)" bundle exec jekyll serve --livereload
+
+## Wipe Jekyll's build output and caches under docs/. Safe to run anytime;
+## the next `docs-build` / `docs-serve` will regenerate everything.
+docs-clean:
+	rm -rf docs/_site docs/.jekyll-cache docs/.sass-cache
+
+## Build the marketing site exactly as GitHub Pages will, into docs/_site/.
+## Sets JEKYLL_ENV=production so jekyll-seo-tag emits canonical URLs and
+## any production-only conditionals fire. Always starts from a clean tree
+## so cached or stale output can't mask a real publish-time failure.
+docs-build: docs-clean
+	@cd docs && PATH="$(DOCS_PATH)" ruby -e 'exit RUBY_VERSION.start_with?("3.3.") ? 0 : 1' || { echo "ERROR: docs/ requires Ruby 3.3.x (see docs/.tool-versions). Run 'make docs-bootstrap' first." >&2; exit 1; }
+	cd docs && PATH="$(DOCS_PATH)" JEKYLL_ENV=production bundle exec jekyll build
+
+## Final pre-merge sanity check: clean production build, then serve the
+## static docs/_site/ from a vanilla HTTP server on http://127.0.0.1:4001/.
+## `docs-serve` runs Jekyll's dev server with live-reload, which can mask
+## issues (missing assets, wrong relative_url, Liquid-only-in-includes
+## breakage) that only surface in the static output GitHub Pages publishes.
+## Uses port 4001 so it can run alongside `docs-serve` (which owns 4000).
+docs-publish-check: docs-build
+	@echo "Serving production build of docs/_site/ at http://127.0.0.1:4001/ — Ctrl-C to stop."
+	cd docs/_site && python3 -m http.server 4001 --bind 127.0.0.1
 
 ## Build a Release archive and upload it to TestFlight.
 ## Auto-bumps the build number from the latest TestFlight build and uses

--- a/docs/README.md
+++ b/docs/README.md
@@ -92,6 +92,26 @@ your own `PATH` or run them through `asdf exec` from inside `docs/`.
 
 [asdf]: https://asdf-vm.com/
 
+### Pre-merge production check
+
+Before merging anything that's likely to affect what GitHub Pages
+serves (layout includes, plugin config, `_config.yml`, asset paths),
+run a clean production build and serve the static output exactly the
+way Pages will:
+
+```sh
+make docs-publish-check
+```
+
+That target runs `JEKYLL_ENV=production bundle exec jekyll build` into
+`docs/_site/`, then serves the result with a vanilla
+`python3 -m http.server` on <http://127.0.0.1:4001/> (different port
+from `docs-serve` so both can run side-by-side). It catches issues
+that `docs-serve`'s live-reload mode hides — wrong `relative_url`s,
+broken Liquid in includes that only fires under the production env,
+missing assets that 404 once Jekyll's dev middleware isn't proxying
+them.
+
 ## Editing copy
 
 All user-visible English strings live in `_data/en.yml`. All Dutch strings


### PR DESCRIPTION
## Why

`make docs-serve` runs Jekyll's dev server with live-reload — great
for iterating on copy and CSS, bad as a publish-time sanity check.
A few classes of bug only show up in the static output GitHub Pages
publishes:

- Wrong `relative_url` resolution under a non-root `baseurl`.
- Missing assets that Jekyll's dev middleware silently proxies.
- Liquid in includes that only fires under `JEKYLL_ENV=production`
  (jekyll-seo-tag canonical URLs are the obvious one).
- Stale `_site/` output masking a regression because incremental
  build skipped a file.

This PR adds a target that builds the site exactly the way Pages
will, then serves the static output from a vanilla HTTP server, so
the final pre-merge check sees what real users will see.

## What

Three new Make targets:

- **`docs-clean`** — wipes `docs/_site/` and the Jekyll caches.
- **`docs-build`** — clean production build into `docs/_site/`.
  Always runs `docs-clean` first so cached output can't hide a
  publish-time failure. Same Ruby-version guard as `docs-serve`.
- **`docs-publish-check`** — depends on `docs-build`, then serves
  `docs/_site/` via `python3 -m http.server` on
  <http://127.0.0.1:4001/>. Different port from `docs-serve` (4000)
  so both can run side-by-side.

`docs/README.md` gets a "Pre-merge production check" subsection
under Local development pointing at the new target.

Smoke-tested locally:

\`\`\`
$ make docs-build
…
                    done in 0.809 seconds.
$ ls docs/_site
404.html  CNAME  assets  index.html  nl  privacy  robots.txt  sitemap.xml  support
$ cat docs/_site/CNAME
gluwink.app
\`\`\`

`CNAME` is copied through (Pages will pick it up), `sitemap.xml` is
emitted by `jekyll-sitemap`, and `permalink: pretty` produces
`/privacy/` and `/support/` directories.

## Test plan

- [ ] `make docs-build` exits 0 and writes a populated `docs/_site/`.
- [ ] `make docs-publish-check` serves <http://127.0.0.1:4001/>;
      both EN and NL homes render and the carousel auto-rotates.
- [ ] `docs-clean` is idempotent (safe to re-run).
- [ ] `docs-serve` (4000) still works alongside `docs-publish-check`
      (4001) — they don't fight for ports.

## Out of scope

- The actual GitHub Pages launch (DNS, custom domain, HTTPS) — that
  runbook is captured in #48.
- Copy review of the live site — #47.

Refs #17, #48.

Made with [Cursor](https://cursor.com)