### PR TITLE
chore(docs): swap domain from gluwink.app to gluwink.com

### DIFF
--- a/AppStore/README.md
+++ b/AppStore/README.md
@@ -36,11 +36,11 @@ Apple character limits are noted next to each field in the per-locale files. Any
 
 ## URLs
 
-The domain is **`gluwink.app`** (GitHub Pages, served from the repo).
+The domain is **`gluwink.com`** (GitHub Pages, served from the repo).
 
-- **Support URL:** `https://gluwink.app/support` — page that links to GitHub Issues.
-- **Marketing URL:** `https://gluwink.app`
-- **Privacy Policy URL:** `https://gluwink.app/privacy` — must exist before submission.
+- **Support URL:** `https://gluwink.com/support` — page that links to GitHub Issues.
+- **Marketing URL:** `https://gluwink.com`
+- **Privacy Policy URL:** `https://gluwink.com/privacy` — must exist before submission.
 
 These URLs are the same across every locale. The marketing site itself must have a localized variant (or a language switcher) before the corresponding App Store locale goes live.
 

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,1 @@
-gluwink.app
+gluwink.com

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 Static Jekyll site served by **GitHub Pages** from the `main` branch's
 `/docs` folder. No Actions workflow builds the site — Pages runs the
-allowlisted Jekyll plugins on its own. Lives at **`https://gluwink.app`**
+allowlisted Jekyll plugins on its own. Lives at **`https://gluwink.com`**
 (custom domain via `docs/CNAME`).
 
 The screenshots drift-check (`.github/workflows/screenshots-sync-check.yml`)
@@ -12,7 +12,7 @@ is a separate, small workflow that has nothing to do with the site build.
 
 ```
 docs/
-├── CNAME                           gluwink.app (custom-domain marker)
+├── CNAME                           gluwink.com (custom-domain marker)
 ├── _config.yml                     site config; flip `launched: true` at v1.0
 ├── Gemfile                         pinned to the github-pages gem
 ├── _data/
@@ -177,12 +177,12 @@ If you want the consistency of self-hosted Inter:
 The whole change is one CSS file + 4 woff2 files; no other code touches
 font loading.
 
-## Deploying to `gluwink.app`
+## Deploying to `gluwink.com`
 
 GitHub side (one-time):
 
 1. Settings → Pages → Source: **Deploy from a branch** → `main` / `/docs`.
-2. Settings → Pages → Custom domain: **`gluwink.app`** → tick **Enforce
+2. Settings → Pages → Custom domain: **`gluwink.com`** → tick **Enforce
    HTTPS** once the certificate provisions.
 
 DNS side (registrar):
@@ -197,16 +197,16 @@ doesn't support ALIAS / ANAME. Latest list:
 <https://docs.github.com/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-an-apex-domain>.
 
 After DNS propagates (minutes to a few hours), GitHub re-issues the cert
-automatically, the green check appears under Pages, and `https://gluwink.app`
+automatically, the green check appears under Pages, and `https://gluwink.com`
 serves this folder.
 
 ## App Store URL checklist (before submitting v1.0)
 
 App Review verifies these URLs exist and return 200 in every locale:
 
-- `https://gluwink.app/` and `https://gluwink.app/nl/` — marketing
-- `https://gluwink.app/privacy/` and `https://gluwink.app/nl/privacy/`
-- `https://gluwink.app/support/` and `https://gluwink.app/nl/support/`
+- `https://gluwink.com/` and `https://gluwink.com/nl/` — marketing
+- `https://gluwink.com/privacy/` and `https://gluwink.com/nl/privacy/`
+- `https://gluwink.com/support/` and `https://gluwink.com/nl/support/`
 
 The Medical category specifically requires Privacy + Support to be live
 before submission.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,7 +4,7 @@
 
 title: GluWink
 description: Make your iPhone and Apple Watch a tool for diabetes — not a distraction from it.
-url: "https://gluwink.app"
+url: "https://gluwink.com"
 baseurl: ""
 
 author:


### PR DESCRIPTION
## Summary

`gluwink.com` was registered instead of `gluwink.app`, so swap every reference across the marketing site and App Store metadata to the new domain.

- `docs/CNAME` → `gluwink.com` (GitHub Pages reads this to bind the custom domain)
- `docs/_config.yml` → canonical `url` set to `https://gluwink.com` (drives absolute URLs in `sitemap.xml`, `feed.xml`, OG/Twitter cards via `seo` tag)
- `docs/README.md` → updated the deploy runbook headings, file-tree comment, and App Store URL checklist
- `AppStore/README.md` → updated Support / Marketing / Privacy URLs

No other files referenced the literal `.app` host (`rg gluwink.app` returns nothing after this PR).

## Side effects worth noting

- GitHub Pages does not send a `Strict-Transport-Security` header on custom domains ([isaacs/github#1249](https://github.com/isaacs/github/issues/1249), still open as of today). On `.app` the TLD-level [HSTS preload list](https://hstspreload.org/) gave us first-visit downgrade protection for free; on `.com` we no longer have that. **Settings → Pages → Enforce HTTPS** still adds the HTTP→HTTPS 301, but there's no HSTS header, so a man-in-the-middle on a user's first request can still strip TLS until they've visited once.
- For a brochure site without auth or sessions this is an acceptable gap. If we want true HSTS later, the cheapest fix is to put Cloudflare (or any CDN that supports custom response headers) in front of Pages and add the header there.
- DNS recipe is unchanged (apex A/AAAA + `www` CNAME to `fokkezb.github.io`).
- Issue #48 (the launch runbook) is updated alongside this PR to reflect the new domain and the corrected HSTS picture.

## Test plan

- [ ] `make docs-publish-check` — verify built `_site/` references `https://gluwink.com` in `sitemap.xml`, `feed.xml`, and the canonical/OG tags on `/` and `/nl/`.
- [ ] `cat docs/_site/CNAME` → `gluwink.com`.
- [ ] After merge: GitHub Pages picks up the new `CNAME`, then point DNS per the runbook in `docs/README.md`.

Refs #17, #48
