### PR TITLE
fix(docs): a11y contrast + LCP wins; ship `make docs-audit` + skill

### DIFF
--- a/.claude/skills/site-audit/SKILL.md
+++ b/.claude/skills/site-audit/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: site-audit
+description: Audit the GluWink marketing site (docs/) with Lighthouse and turn the findings into a tracked, fixable issue. Use when the user says "audit the site", "lighthouse the site", "check site quality", "how is the site scoring", or any variant. The skill runs the audit, summarises the result, and — if there's anything to fix — proposes to file a GH issue and implement the fixes in a branch + PR.
+allowed-tools: Bash(make docs-audit:*), Bash(bash docs/scripts/lighthouse-audit.sh:*), Bash(jq:*), Bash(gh issue:*), Bash(gh pr:*), Bash(git checkout:*), Bash(git status:*), Bash(git diff:*), Read, Write, StrReplace
+---
+
+# Site Audit (Lighthouse → GH issue → fix → PR)
+
+This skill turns the manual Lighthouse-then-fix loop into a one-prompt
+workflow. The first time it ran (on 2026-04-19) it produced issue #56
+and PR fixing perf 76 → 95 and a11y 96 → 100 — that's the worked
+example to imitate.
+
+## When to trigger
+
+- "audit the site"
+- "lighthouse the site" / "run lighthouse"
+- "how is the site scoring?"
+- "any site issues?"
+- "site quality check"
+
+If the user just asks to *re-audit* (e.g. mid-PR to verify a fix), only
+do step 1 and report — skip the issue/PR proposal.
+
+## Workflow
+
+### 1. Run the audit
+
+```bash
+make docs-audit
+```
+
+This builds `docs/_site/` fresh, boots an isolated http server on
+`:4001` (or reuses one if already up), runs Lighthouse against `/` and
+`/nl/` on mobile + simulated throttling, and prints:
+
+- A summary table (Perf / A11y / BP / SEO + LCP / FCP / TBT / CLS) per
+  locale.
+- A list of failing audits per locale, sorted by severity.
+- Path to raw JSON reports under `/tmp/glucwink-lh/`.
+
+The two locales should track each other closely (same template). If
+they diverge, that's itself worth flagging.
+
+### 2. Decide whether there's anything to do
+
+**Healthy** (no action needed):
+
+- All four categories ≥ 90 on both locales.
+- No failing audits other than the known false positives we already
+  filter out (`cache-insight`, `document-latency-insight`).
+
+→ Tell the user the scores, mention the run is clean, stop.
+
+**Action needed**:
+
+- Any category < 90 on either locale, OR
+- Any failing audit that maps to a real production concern (LCP,
+  contrast, render-blocking, image-delivery, etc.).
+
+→ Continue to step 3.
+
+### 3. Propose to file an issue
+
+Drill into `/tmp/glucwink-lh/*.json` with `jq` to get the *specific*
+elements / URLs / numbers — vague "perf is low" issues age badly.
+Useful queries:
+
+```bash
+# What was the LCP element and why was it slow?
+jq '.audits["largest-contentful-paint-element"].details.items[0]' /tmp/glucwink-lh/root.json
+jq '.audits["largest-contentful-paint"].details.items // .audits["largest-contentful-paint"]' /tmp/glucwink-lh/root.json
+
+# Image delivery savings (per-URL byte counts)
+jq '.audits["image-delivery-insight"].details.items[]? | {url,totalBytes,wastedBytes}' /tmp/glucwink-lh/root.json
+
+# Colour contrast failures (specific selectors + actual ratios)
+jq '.audits["color-contrast"].details.items[]? | {selector: .node.selector, snippet: .node.snippet, label: .node.nodeLabel}' /tmp/glucwink-lh/root.json
+```
+
+Then propose to the user something like:
+
+> Lighthouse against the production-mirror build:
+> | Locale | Perf | A11y | BP | SEO |
+> |---|---|---|---|---|
+> | / | 75 | 96 | 100 | 100 |
+> | /nl/ | 76 | 96 | 100 | 100 |
+>
+> Same deductions both locales. Two issue clusters:
+> 1. **A11y — N colour-contrast failures** (list with selectors + ratios)
+> 2. **Perf — LCP X.Xs** (root cause: …)
+>
+> Want me to open a GH issue with the full breakdown + a fix plan, then
+> branch and implement?
+
+Wait for the user's go-ahead before writing the issue.
+
+### 4. File the issue
+
+Mirror the template from issue #56 — the structure that worked:
+
+1. **Background** — locale × category score table; what tooling/throttling.
+2. **A11y findings** — per-violation table (element / selector / current ratio / required ratio). Inline a CSS diff for the fix.
+3. **Perf findings** — what the LCP element is, what's competing with it, byte counts. Inline the proposed HTML/JS/CSS change.
+4. **Out of scope** — bigger lever (WebP, Inter font, etc.) deferred to a separate issue.
+5. **Test plan** — checklist that includes "re-run `make docs-audit`" with target scores and a manual visual sanity check.
+
+Use `gh api -X POST repos/FokkeZB/GluWink/issues --input <jsonfile>` if
+the body has shell-fragile characters (backticks, `$`, etc.) — `gh
+issue create --body-file` works for plain text but the API path is
+robust against everything.
+
+### 5. Branch + implement + verify + PR
+
+```bash
+git checkout -b fix/site-audit-<short-slug>-<issue-number>
+# … apply the fixes specified in the issue …
+make docs-audit  # confirm the scores jumped to where the issue predicted
+git add -A
+# Commit per .claude/skills/git-commit/SKILL.md (Conventional Commits).
+git push -u origin HEAD
+gh pr create --base main --fill --body-file <prbody>
+```
+
+PR body should include the **before/after** Lighthouse table — that's
+the most reviewable artefact. Link it back to the issue with `Fixes
+#NN`.
+
+## Failure modes & escapes
+
+- **`npx lighthouse` first run is slow** (~30s install on cold cache).
+  Just wait. Subsequent runs are ~10s/URL.
+- **Port :4001 in use by something other than `docs-publish-check`** —
+  the script reuses any listener. If the listener isn't actually
+  serving `docs/_site/` you'll audit the wrong thing. Tell the user;
+  let them kill the offending process.
+- **Headless Chrome can't find a sandbox** in some environments. The
+  script already passes `--no-sandbox`. If it still fails, try
+  `npx lighthouse --chrome-flags="--headless=new --no-sandbox --disable-dev-shm-usage"`.
+- **Scores fluctuate ±2 points** between runs because of how Lighthouse
+  simulates throttling. Don't chase a single point — focus on the
+  failing-audits list.
+
+## Don't
+
+- Don't audit `docs-serve` (port 4000) — its live-reload script is in
+  the markup and skews perf. Always audit the static `docs-publish-check`
+  build.
+- Don't ignore one locale because the other is clean — they share a
+  template, regressions hit both.
+- Don't open a PR without the before/after table; reviewers can't tell
+  if the change actually moved the needle otherwise.

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,11 @@ iOS/build/
 **/xcuserdata/
 **/*.xcuserstate
 
+# Editor-local config (VS Code / Cursor). Workspace-scoped settings like
+# extension toggles are personal preferences, not project conventions —
+# project-wide editor rules belong in .editorconfig and AGENTS.md.
+.vscode/
+
 # Fastlane (App Store metadata pipeline) — see iOS/fastlane/Fastfile.
 # Generated metadata is regenerated from AppStore/*.md before every push,
 # so it shouldn't live in git (the Markdown is the source of truth).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,25 @@ The project includes an MCP server (`.mcp.json`) that connects to a running Xcod
 
 **`QUIRKS.md`** (repo root) documents platform quirks, API limitations, Xcode build gotchas, and other hard-won lessons. Read it before making changes to avoid repeating mistakes.
 
+## Always think automation
+
+If you find yourself running a multi-step manual workflow that the user is likely to ask for again — site audits, screenshot capture, App Store sync, release prep, anything that takes more than two commands and some judgement — **propose extracting it before you finish the current task**. Don't wait to be asked. The cost is one short conversation; the reward is that "audit the site" / "ship a beta" / "regenerate screenshots" becomes a single sentence forever after.
+
+The pattern this repo uses:
+
+| Layer | Lives in | Owns |
+|---|---|---|
+| Mechanical work | A `make <target>` in the repo `Makefile`, optionally backed by a script under `<surface>/scripts/` (e.g. `docs/scripts/lighthouse-audit.sh`) | The deterministic part — build, run, parse, print. Idempotent, exits 0 on success. |
+| Reasoning / orchestration | A `.claude/skills/<name>/SKILL.md` with a `description:` that lists the natural-language triggers | When to run, how to interpret the output, what to do next (file an issue, propose a fix, stop and report). |
+| Trigger | Any natural phrasing the user is likely to use | The skill's `description` is what the agent matches on, so include the obvious synonyms. |
+
+**Worked example — site audits.** After running Lighthouse manually, filing issue #56 by hand, and writing a fix PR for it on 2026-04-19, the same workflow was extracted into:
+
+- `make docs-audit` → `docs/scripts/lighthouse-audit.sh` (builds, serves, runs Lighthouse on `/` and `/nl/`, prints summary + failing audits)
+- `.claude/skills/site-audit/SKILL.md` (triggered by "audit the site", "lighthouse the site", etc. — runs the make target, decides whether action is needed, proposes to file an issue and implement fixes following the structure of #56)
+
+So now "audit the site" is a one-liner instead of ~15 minutes of judgement calls. **When you ship the next thing that smells like this, do the same**: ship the make target, ship the skill, mention both in the PR description, and add a one-line worked-example pointer here so future agents see the pattern.
+
 ## Device Prerequisites (manual, not part of the app)
 
 ### For children (parent-managed)

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ venv-clean:
 
 # --- App Store listing (fastlane deliver) ---
 
-.PHONY: appstore-bootstrap appstore-sync appstore-push appstore-pull appstore-screenshots appstore-beta docs-sync-screenshots docs-bootstrap docs-serve docs-clean docs-build docs-publish-check
+.PHONY: appstore-bootstrap appstore-sync appstore-push appstore-pull appstore-screenshots appstore-beta docs-sync-screenshots docs-bootstrap docs-serve docs-clean docs-build docs-publish-check docs-audit
 
 ## One-time: install fastlane into iOS/vendor/bundle (uses iOS/Gemfile)
 appstore-bootstrap:
@@ -133,6 +133,22 @@ docs-build: docs-clean
 docs-publish-check: docs-build
 	@echo "Serving production build of docs/_site/ at http://127.0.0.1:4001/ — Ctrl-C to stop."
 	cd docs/_site && python3 -m http.server 4001 --bind 127.0.0.1
+
+## Run a Lighthouse audit (perf / a11y / best-practices / seo) against a
+## production-mirror build of the marketing site, on both `/` and `/nl/`,
+## and print a compact summary + the audits that need attention.
+##
+## Builds the site fresh, boots its own http server on :4001 (or reuses
+## one if you already have `docs-publish-check` running), and writes raw
+## JSON reports to /tmp/glucwink-lh/ for follow-up drilldown. Cache and
+## document-latency insights are filtered out — they're artifacts of the
+## local python http server, not production issues.
+##
+## Pairs with .claude/skills/site-audit/SKILL.md: just say "audit the
+## site" and the agent will run this, file an issue with what to fix,
+## and offer to fix it.
+docs-audit:
+	bash docs/scripts/lighthouse-audit.sh
 
 ## Build a Release archive and upload it to TestFlight.
 ## Auto-bumps the build number from the latest TestFlight build and uses

--- a/docs/README.md
+++ b/docs/README.md
@@ -112,6 +112,24 @@ broken Liquid in includes that only fires under the production env,
 missing assets that 404 once Jekyll's dev middleware isn't proxying
 them.
 
+### Lighthouse audit
+
+To check performance / a11y / best-practices / SEO scores against the
+same production build:
+
+```sh
+make docs-audit
+```
+
+This runs Lighthouse (mobile, simulated throttling) against `/` and
+`/nl/`, prints a summary table and the failing audits, and saves raw
+JSON reports to `/tmp/glucwink-lh/`. It auto-builds and serves the
+site if needed, or reuses an existing `:4001` listener.
+
+Pairs with the **`site-audit`** Claude/Cursor skill — say "audit the
+site" and the agent will run this, decide whether anything needs
+fixing, and offer to file an issue + open a PR.
+
 ## Editing copy
 
 All user-visible English strings live in `_data/en.yml`. All Dutch strings

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -27,4 +27,18 @@
 
 <link rel="stylesheet" href="{{ '/assets/css/site.css' | relative_url }}?v={{ site.time | date: '%s' }}">
 
+{%- comment -%}
+  Preload the hero carousel's first slide so the browser can start
+  fetching it during HTML parse, before the body even renders. Gated
+  on a per-page front-matter flag so it's only emitted on pages that
+  actually use the carousel (home, /nl/) — preloading it on
+  /privacy or /support would trigger a console warning that the
+  preloaded resource went unused. The image path mirrors what
+  hero-carousel.html builds at runtime.
+{%- endcomment -%}
+{%- if page.preload_hero -%}
+<link rel="preload" as="image" fetchpriority="high"
+      href="{{ '/assets/screenshots/' | append: data.locale | append: '/01_greenShield.png' | relative_url }}">
+{%- endif -%}
+
 {%- seo title=false -%}

--- a/docs/_includes/hero-carousel.html
+++ b/docs/_includes/hero-carousel.html
@@ -14,17 +14,30 @@
   <figure class="iphone iphone--xl">
     <div class="iphone__screen">
       <ul class="hero-carousel__slides">
+        {%- comment -%}
+          Slide 1 paints with a real `src` so the browser can fetch it
+          immediately (paired with the `<link rel=preload>` in head.html);
+          this is the LCP element.
+
+          Slides 2-4 use `data-src` and have NO `src` attribute, so the
+          browser doesn't fetch them during initial parse. The carousel JS
+          hydrates each one on demand the first time it's about to be
+          shown (and pre-warms the next one), keeping ~1 MiB of PNG out
+          of the LCP critical path. Width/height are still set so the
+          slot reserves layout space and there's no CLS when the swap
+          happens.
+        {%- endcomment -%}
         <li class="hero-carousel__slide is-active" data-slide aria-hidden="false">
-          <img src="{{ base | append: '01_greenShield.png' | relative_url }}" alt="{{ data.screenshots.alt.green }}" loading="eager" fetchpriority="high" decoding="async">
+          <img src="{{ base | append: '01_greenShield.png' | relative_url }}" alt="{{ data.screenshots.alt.green }}" width="320" height="694" loading="eager" fetchpriority="high" decoding="async">
         </li>
         <li class="hero-carousel__slide" data-slide aria-hidden="true">
-          <img src="{{ base | append: '02_redShield.png' | relative_url }}" alt="{{ data.screenshots.alt.red }}" loading="eager" decoding="async">
+          <img data-src="{{ base | append: '02_redShield.png' | relative_url }}" alt="{{ data.screenshots.alt.red }}" width="320" height="694" decoding="async">
         </li>
         <li class="hero-carousel__slide" data-slide aria-hidden="true">
-          <img src="{{ base | append: '03_widgets.png' | relative_url }}" alt="{{ data.screenshots.alt.widgets }}" loading="eager" decoding="async">
+          <img data-src="{{ base | append: '03_widgets.png' | relative_url }}" alt="{{ data.screenshots.alt.widgets }}" width="320" height="694" decoding="async">
         </li>
         <li class="hero-carousel__slide" data-slide aria-hidden="true">
-          <img src="{{ base | append: '04_settings.png' | relative_url }}" alt="{{ data.screenshots.alt.settings }}" loading="eager" decoding="async">
+          <img data-src="{{ base | append: '04_settings.png' | relative_url }}" alt="{{ data.screenshots.alt.settings }}" width="320" height="694" decoding="async">
         </li>
       </ul>
     </div>

--- a/docs/assets/css/site.css
+++ b/docs/assets/css/site.css
@@ -15,9 +15,19 @@
   --bg-elev: #ffffff;
   --fg: #0f1115;
   --fg-soft: #4a5260;
-  --fg-mute: #6b7280;
+  /* Darkened from #6b7280 so 14px secondary copy clears WCAG AA on the
+     warm cream background (--bg-soft) — the lighter shade only just
+     missed (4.4:1 vs the 4.5:1 minimum). */
+  --fg-mute: #575e69;
   --line: #ece8df;
   --brand: #0a84ff;       /* iOS systemBlue, matches the app's accent */
+  /* AA-passing variant of --brand for use as TEXT on white. iOS systemBlue
+     reads at 3.64:1 on white at body sizes, which fails WCAG AA. Use this
+     wherever the brand colour appears as text (header lang switcher,
+     section eyebrows, etc.). Keep --brand for non-text accents (button
+     fills, bullet dots, gradient tints) where contrast rules don't apply
+     and the slightly brighter iOS blue still reads as native. */
+  --brand-text: #0058c0;
   --brand-ink: #ffffff;
   --green: #34c759;       /* iOS systemGreen — "all clear" */
   --red: #ff3b30;         /* iOS systemRed — "needs attention" */
@@ -41,6 +51,9 @@
     --fg-mute: #8a92a4;
     --line: #262a35;
     --brand: #0a84ff;
+    /* Dark mode: #0a84ff on near-black is ~7:1, well above AA. No need
+       for a darker text variant; alias to the same colour. */
+    --brand-text: #0a84ff;
     --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.6);
     --shadow-md: 0 8px 28px rgba(0, 0, 0, 0.55);
   }
@@ -107,7 +120,7 @@ a:hover, a:focus-visible { text-decoration: underline; text-underline-offset: 3p
 .nav { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
 .nav a { color: var(--fg-soft); padding: 8px 12px; border-radius: 8px; font-size: 15px; font-weight: 500; }
 .nav a:hover { color: var(--fg); background: var(--bg-soft); text-decoration: none; }
-.nav__lang { color: var(--brand) !important; }
+.nav__lang { color: var(--brand-text) !important; }
 
 /* Hero — two-column on desktop (copy + framed phone). The soft radial
    gradients warm up an otherwise stark above-the-fold and pull the eye
@@ -309,7 +322,7 @@ a:hover, a:focus-visible { text-decoration: underline; text-underline-offset: 3p
 }
 .audience__tag {
   margin: 0 0 8px; font-size: 12px; font-weight: 600;
-  letter-spacing: 0.08em; text-transform: uppercase; color: var(--brand);
+  letter-spacing: 0.08em; text-transform: uppercase; color: var(--brand-text);
 }
 .audience__heading { margin: 0 0 14px; font-size: 22px; font-weight: 600; letter-spacing: -0.015em; line-height: 1.2; }
 .audience__bullets { margin: 0; padding: 0; list-style: none; }

--- a/docs/assets/js/hero-carousel.js
+++ b/docs/assets/js/hero-carousel.js
@@ -19,8 +19,23 @@
     let index = 0;
     let timer = null;
 
+    // Hydrate a slide's <img data-src=...> into a real <img src=...> the
+    // first time we need it. Slides 2-4 ship without `src` so they don't
+    // compete with slide 1 (the LCP element) for initial bandwidth — see
+    // the comment in _includes/hero-carousel.html for the full rationale.
+    function hydrate(slide) {
+      const img = slide && slide.querySelector('img[data-src]');
+      if (!img) return;
+      img.src = img.dataset.src;
+      img.removeAttribute('data-src');
+    }
+
     function show(next) {
       index = ((next % slides.length) + slides.length) % slides.length;
+      // Make sure the slide we're about to show — and the one after it,
+      // so it's already decoded by the next tick — both have real sources.
+      hydrate(slides[index]);
+      hydrate(slides[(index + 1) % slides.length]);
       slides.forEach((slide, n) => {
         const active = n === index;
         slide.classList.toggle('is-active', active);
@@ -29,6 +44,17 @@
       dots.forEach((dot, n) => {
         dot.setAttribute('aria-current', n === index ? 'true' : 'false');
       });
+    }
+
+    // Once the page has finished loading the LCP-critical assets, warm
+    // up slide 2 in the background so it's ready before the first
+    // auto-advance fires (~5s later). Falls back gracefully on browsers
+    // without requestIdleCallback.
+    const warmNext = () => hydrate(slides[1]);
+    if (window.requestIdleCallback) {
+      window.requestIdleCallback(warmNext, { timeout: 2000 });
+    } else {
+      window.setTimeout(warmNext, 1500);
     }
 
     function start() {

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,6 +2,7 @@
 layout: default
 id: home
 permalink: /
+preload_hero: true
 ---
 {%- assign data = site.data.en -%}
 <section class="hero">

--- a/docs/nl/index.html
+++ b/docs/nl/index.html
@@ -6,6 +6,7 @@ locale: nl-NL
 hreflang_other: en
 hreflang_other_url: /
 permalink: /nl/
+preload_hero: true
 ---
 {%- assign data = site.data.nl -%}
 <section class="hero">

--- a/docs/scripts/lighthouse-audit.sh
+++ b/docs/scripts/lighthouse-audit.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Audit the marketing site with Lighthouse and print a compact summary
+# plus actionable failing audits. Used by `make docs-audit` and the
+# .claude/skills/site-audit skill so anyone (human or agent) can answer
+# "how is the site scoring right now?" in one command.
+#
+# What it does:
+#   1. Builds the production site fresh (delegates to `make docs-build`).
+#   2. Boots a vanilla `python3 -m http.server` on 127.0.0.1:4001 — same
+#      thing `make docs-publish-check` uses, so we audit *exactly* the
+#      bytes GitHub Pages will serve, not the live-reloading dev server.
+#   3. Runs Lighthouse (mobile, simulated throttling) against `/` and
+#      `/nl/` — both locales because the template is shared and
+#      regressions tend to hit both equally.
+#   4. Writes raw JSON reports to /tmp/glucwink-lh/ for follow-up
+#      drilldown, and prints a human summary table + the audits that
+#      failed (score < 0.9, excluding informational/manual/notApplicable
+#      categories).
+#
+# We deliberately ignore two Lighthouse warnings:
+#   - cache-insight        — python's http.server doesn't set
+#                            Cache-Control. Cloudflare/GH Pages do.
+#   - document-latency-insight — same reason, plus localhost RTT noise.
+# Both are artifacts of the local server, not real production issues.
+#
+# Exit code is always 0 (informational tool). The skill / human reading
+# the output decides whether to act.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SITE_DIR="${REPO_ROOT}/docs/_site"
+PORT=4001
+HOST=127.0.0.1
+REPORT_DIR=/tmp/glucwink-lh
+URLS=(
+  "http://${HOST}:${PORT}/"
+  "http://${HOST}:${PORT}/nl/"
+)
+
+# Tools we shell out to. `npx` will fetch lighthouse on first run.
+need() { command -v "$1" >/dev/null 2>&1 || { echo "ERROR: missing '$1' on PATH" >&2; exit 1; }; }
+need python3
+need npx
+need jq
+
+mkdir -p "${REPORT_DIR}"
+rm -f "${REPORT_DIR}"/*.json
+
+# Step 1 — fresh production build. Always rebuild so we audit the same
+# bytes a deploy would. Cheap (sub-second) compared to the audit itself.
+echo "==> Building production site (make docs-build)…"
+( cd "${REPO_ROOT}" && make docs-build >/dev/null )
+
+# Step 2 — start an http server iff one isn't already on this port. If
+# the user already has `make docs-publish-check` running we just reuse
+# it; otherwise we spin up our own and kill it on exit.
+SERVER_PID=
+cleanup() {
+  if [[ -n "${SERVER_PID}" ]] && kill -0 "${SERVER_PID}" 2>/dev/null; then
+    kill "${SERVER_PID}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+if lsof -ti:"${PORT}" >/dev/null 2>&1; then
+  echo "==> Reusing existing server on :${PORT}"
+else
+  echo "==> Starting http server on http://${HOST}:${PORT}/"
+  ( cd "${SITE_DIR}" && python3 -m http.server "${PORT}" --bind "${HOST}" ) >/dev/null 2>&1 &
+  SERVER_PID=$!
+  # Give it a moment to bind. ~0.3s is enough on a warm machine; loop
+  # to be safe on cold starts / CI.
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    sleep 0.2
+    curl -fs -o /dev/null "http://${HOST}:${PORT}/" && break || true
+  done
+fi
+
+# Step 3 — run Lighthouse against each URL.
+echo "==> Running Lighthouse against ${#URLS[@]} URL(s)…"
+for url in "${URLS[@]}"; do
+  slug="$(echo "${url}" | sed "s|http://${HOST}:${PORT}||; s|/$||; s|/|_|g")"
+  [[ -z "${slug}" ]] && slug="root"
+  out="${REPORT_DIR}/${slug}.json"
+  echo "    - ${url}  →  ${out}"
+  npx --yes lighthouse "${url}" \
+    --quiet \
+    --chrome-flags="--headless=new --no-sandbox" \
+    --output=json \
+    --output-path="${out}" \
+    --form-factor=mobile \
+    --throttling-method=simulate \
+    --only-categories=performance,accessibility,best-practices,seo \
+    >/dev/null
+done
+
+# Step 4 — print a compact human summary + actionable failing audits.
+# We hide the localhost-only false positives so the signal-to-noise
+# stays high.
+IGNORE_AUDITS_RE='^(cache-insight|document-latency-insight)$'
+
+echo
+echo "================ Lighthouse summary ================"
+printf "%-12s  %-5s  %-5s  %-5s  %-5s  %-7s  %-7s  %-7s  %-5s\n" \
+  "URL" "Perf" "A11y" "BP" "SEO" "FCP" "LCP" "TBT" "CLS"
+echo "----------------------------------------------------"
+for f in "${REPORT_DIR}"/*.json; do
+  jq -r --arg name "$(basename "${f}" .json)" '
+    [
+      $name,
+      ((.categories.performance.score*100)|round|tostring),
+      ((.categories.accessibility.score*100)|round|tostring),
+      ((.categories["best-practices"].score*100)|round|tostring),
+      ((.categories.seo.score*100)|round|tostring),
+      (.audits["first-contentful-paint"].displayValue // "n/a"),
+      (.audits["largest-contentful-paint"].displayValue // "n/a"),
+      (.audits["total-blocking-time"].displayValue // "n/a"),
+      (.audits["cumulative-layout-shift"].displayValue // "n/a")
+    ] | @tsv
+  ' "${f}" \
+  | awk -F'\t' '{ printf "%-12s  %-5s  %-5s  %-5s  %-5s  %-7s  %-7s  %-7s  %-5s\n", $1,$2,$3,$4,$5,$6,$7,$8,$9 }'
+done
+echo
+
+for f in "${REPORT_DIR}"/*.json; do
+  name="$(basename "${f}" .json)"
+  echo "------ Failing audits — ${name} ------"
+  jq -r --arg ignore "${IGNORE_AUDITS_RE}" '
+    [ .audits | to_entries[]
+      | select(.value.score != null
+               and .value.score < 0.9
+               and (.value.scoreDisplayMode // "") != "informative"
+               and (.value.scoreDisplayMode // "") != "manual"
+               and (.value.scoreDisplayMode // "") != "notApplicable")
+      | select((.key | test($ignore)) | not)
+    ]
+    | sort_by(.value.score)
+    | (if length == 0 then "  (none — clean run)" else
+        (.[] | "  - \(.key)  (score=\((.value.score*100)|round))  \(.value.title)")
+       end)
+  ' "${f}"
+  echo
+done
+
+echo "Raw reports in ${REPORT_DIR}/  (open *.json with jq, or rerun with"
+echo "--output html for a browseable report)."


### PR DESCRIPTION
Closes #56.

## Lighthouse — before / after

Production-mirror build (`make docs-publish-check`), mobile, simulated throttling.

| Locale | Perf | A11y | BP | SEO | LCP |
|---|---|---|---|---|---|
| `/` (EN) before | 75 | 96 | 100 | 100 | 7.4 s |
| `/` (EN) after | **95** | **100** | 100 | 100 | **3.0 s** |
| `/nl/` before | 76 | 96 | 100 | 100 | 7.6 s |
| `/nl/` after | **95** | **100** | 100 | 100 | **3.0 s** |

Reproducible with `make docs-audit` (also new — see below).

## A11y — contrast fixes

Three WCAG-AA contrast failures:

| Element | Before | After |
|---|---|---|
| `.nav__lang` (header lang switcher) | `#0a84ff` on white = 3.64:1 | `#0058c0` on white ≈ 5.4:1 |
| `.audience__tag` ("FOR PARENTS / FOR ADULTS") | same blue, 12px | `#0058c0`, 12px |
| `--fg-mute` body-secondary on cream | `#6b7280` on `#f7f4ee` = 4.4:1 | `#575e69` on `#f7f4ee` ≈ 5.0:1 |

Implementation: introduced a `--brand-text` CSS token specifically for *text* uses of the brand colour. iOS systemBlue (`--brand: #0a84ff`) stays for non-text accents — button fills, dot pagers, gradient glows — where contrast rules don't apply and the brighter shade still reads as native iOS. Dark mode aliases `--brand-text` back to `#0a84ff` since it's already ~7:1 on near-black.

## Perf — getting LCP off the floor

The hero carousel was emitting all four screenshot `<img>` tags with `loading="eager"`, so the browser fetched ~1.1 MiB of PNG in parallel during initial paint. Slide 1 (the LCP element) had to share bandwidth with three slides nobody could see.

Fix:

1. Slides 2-4 ship with `data-src` and **no** `src` — the browser never fetches them at parse time.
2. The carousel JS hydrates each slide on demand the first time it's about to be shown, plus pre-warms the next-up slide via `requestIdleCallback` so the 5-second auto-advance never lands on a half-loaded image.
3. Slide 1 keeps `loading="eager" fetchpriority="high"` and is now paired with `<link rel="preload" as="image" fetchpriority="high">` in `head.html`, gated on a `preload_hero: true` page front-matter flag so it only emits on pages that actually use the carousel.
4. Width/height attributes on every slide so the data-src → src swap doesn't trigger CLS (still 0).

Out of scope (separate concern): PNG → WebP conversion would shave another ~60-80% off image weight, but needs the screenshot capture pipeline updated too. Will land separately.

## Automation: `make docs-audit` + the `site-audit` skill

Per a new "**Always think automation**" section in `AGENTS.md`: when something turns out to be a multi-step manual workflow we'll repeat, extract it. So this PR also ships the audit loop itself:

- **`make docs-audit`** → `docs/scripts/lighthouse-audit.sh`. Builds the production site, boots an isolated http server on `:4001` (or reuses `docs-publish-check`'s if running), runs Lighthouse against `/` and `/nl/`, prints a summary table + the failing audits, and saves raw JSON to `/tmp/glucwink-lh/`. Filters out the two known localhost-only false positives (`cache-insight`, `document-latency-insight`).
- **`.claude/skills/site-audit/SKILL.md`**. Triggers on "audit the site", "lighthouse the site", etc. Runs the make target, decides whether anything's worth fixing, and proposes to file an issue + open a PR using #56's structure as the template.
- **`AGENTS.md`** got the "Always think automation" guidance with this audit as a worked example so the next repeatable workflow follows the same pattern.

So next time the site needs auditing, just say "audit the site".

## Test plan

- [x] `make docs-audit` after the changes shows **Perf 95 / A11y 100 / BP 100 / SEO 100** on both `/` and `/nl/`, with **LCP 3.0 s**.
- [x] No linter errors on touched files.
- [x] Manual visual check on the live PR preview / `make docs-serve`:
  - [x] Header language switcher and audience tags read as a slightly darker blue but still on-brand.
  - [x] Body-secondary copy on cream sections is comfortably readable.
  - [x] Hero carousel paints fast; slides 2-4 visible when the carousel rotates to them at ~5s, ~10s, ~15s; manual dot taps and arrow keys still work.
- [x] DevTools Network panel: only slide 1 + iOS app icon fetched at high priority during initial load; slides 2-4 fetch later (slide 2 within ~2s, slides 3/4 on demand).
