### PR TITLE
build(ci): add docs-check workflow — production Jekyll build on every site PR

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,0 +1,55 @@
+# Build the marketing site exactly the way GitHub Pages will publish it
+# and fail the PR if Jekyll can't produce a clean static tree. Catches
+# Liquid syntax errors, missing _data references, broken includes, plugin
+# loading failures, and anything else that surfaces only in JEKYLL_ENV=
+# production but not in the live-reload dev server.
+#
+# Layer 1 of the site-check stack from #62. Future layers (htmlproofer
+# for asset/link validation, project-specific smoke greps for the
+# canonical/OG dedupe class of bug) land in the PR that fixes #51,
+# alongside the bugs they're meant to catch.
+#
+# Triggered only on PRs and main pushes that actually touch the site or
+# this workflow, so docs-only churn doesn't burn minutes on every iOS PR.
+
+name: Docs build check
+
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs-check.yml"
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs-check.yml"
+
+# Cancel superseded runs when a PR gets a new push.
+concurrency:
+  group: docs-check-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: docs
+    steps:
+      - uses: actions/checkout@v4
+
+      # Pin Ruby to the same version docs/.tool-versions and GitHub
+      # Pages itself run, so the build matches production. bundler-cache
+      # restores docs/vendor/bundle/ keyed on docs/Gemfile.lock — first
+      # run installs gems, every subsequent run is a cache hit.
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3.4"
+          bundler-cache: true
+          working-directory: docs
+
+      - name: Build site (production)
+        env:
+          JEKYLL_ENV: production
+        run: bundle exec jekyll build --strict_front_matter --trace


### PR DESCRIPTION
## Summary

Layer 1 of the site-check stack from #62: a small GitHub Actions workflow
that builds the marketing site exactly the way GitHub Pages will publish
it (`JEKYLL_ENV=production`, `--strict_front_matter`, `--trace`) and
fails any PR — or push to `main` — where the build crashes.

Today, the only CI gate on the marketing site is screenshot drift
(`screenshots-sync-check.yml`). Liquid syntax errors, missing `_data`
references, broken `_includes`, and plugin loading failures only surface
when someone runs `make docs-publish-check` locally — most contributors
won't, and the live-reload dev server masks several of these compared to
a clean production build.

This is the always-safe layer (no existing breakage on `main`). Layers 2
and 3 — `htmlproofer` for asset/link validation and project-specific
smoke greps for the canonical/OG dedupe class of bug — land in the PR
that fixes #51, alongside the bugs they're meant to catch (so the test
plan in that PR can demonstrate the value of each new check).

## What's in the PR

- New `.github/workflows/docs-check.yml`:
  - Triggered on `pull_request` and `push: main` paths-filtered to
    `docs/**` and the workflow file itself, so iOS-only PRs don't burn
    CI minutes.
  - `concurrency` group cancels superseded runs when a PR gets a new
    push.
  - `ruby/setup-ruby@v1` with `ruby-version: '3.3.4'` (matches
    `docs/.tool-versions` and GitHub Pages itself) + `bundler-cache: true`
    keyed on `docs/Gemfile.lock`. First run installs gems (~30s), every
    subsequent run is a cache hit.
  - `bundle exec jekyll build --strict_front_matter --trace` with
    `JEKYLL_ENV=production`. Strict front-matter catches malformed YAML
    on individual pages; `--trace` makes any CI-only failure debuggable
    without re-running locally.

No code, no template, no Make target touched — purely additive CI.

## Test plan

- [ ] CI run on this PR is green (the workflow runs against itself
      because the path filter includes `.github/workflows/docs-check.yml`).
- [ ] After merge, an iOS-only PR (no `docs/**` changes) does **not**
      trigger this workflow — confirms the path filter.
- [ ] After merge, deliberately break a Liquid expression in
      `docs/_includes/head.html` on a throwaway branch and confirm the
      workflow fails the PR with a useful traceback.

Refs #62, follows #48.
