### PR TITLE
docs: add GitHub Pull Request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Summary
+<!-- 1-3 sentences: what changed and why. -->
+
+## Linked issues
+<!-- Use "Closes #N" to auto-close on merge, or "Refs #N" to link without closing. -->
+Closes #
+
+## Screenshots / recordings
+<!-- Required for any user-visible change. Include light + dark mode if relevant. Delete this section if the change has no UI surface. -->
+
+## Testing
+- [ ] Built and run on a physical iPhone (Screen Time APIs don't work in the Simulator)
+- [ ] `make deploy` succeeds
+- [ ] Tested both EN and NL if any user-facing strings changed
+- [ ] If shared App Group state or `ShieldContent` changed: verified widget, watch, and shield extensions still render correctly
+
+## Checklist
+- [ ] No hardcoded "GluWink" in Swift code (use `Constants.displayName`; use `%@` in `.strings`)
+- [ ] New user-facing strings added to both `en.lproj` and `nl.lproj` (and the matching `InfoPlist.strings` if applicable)
+- [ ] No new settings or actions bypass the passphrase gate
+- [ ] Read the `QUIRKS.md` / `AGENTS.md` sections relevant to this change
+- [ ] If visible UI changed: regenerated App Store screenshots with `make appstore-screenshots` (writes to `iOS/fastlane/screenshots/` and syncs `docs/assets/screenshots/`; CI's `screenshots-sync-check` will fail otherwise)
+- [ ] No secrets or `private/` contents committed
+
+## Notes for reviewers
+<!-- Anything non-obvious: known limitations, follow-ups, deferred work, things you'd like a closer look at. -->


### PR DESCRIPTION
## Summary
Adds `.github/pull_request_template.md` so every PR opened on github.com pre-populates with a consistent structure that mirrors what `CONTRIBUTING.md`, `AGENTS.md`, and `QUIRKS.md` already require — physical-device testing, EN+NL localization, no hardcoded app name, passphrase gate, shared-state sync across widget/watch/shield, and regenerating the App Store screenshot deck when visible UI changes.

This PR is also the first one to use the new template (eating our own dog food).

## Linked issues
Closes #40

## Screenshots / recordings
N/a — docs-only, no UI surface.

## Testing
- [x] Built and run on a physical iPhone (Screen Time APIs don't work in the Simulator) — N/a, docs-only
- [x] `make deploy` succeeds — N/a, docs-only
- [x] Tested both EN and NL if any user-facing strings changed — N/a, no app strings changed
- [x] If shared App Group state or `ShieldContent` changed: verified widget, watch, and shield extensions still render correctly — N/a, no shared state changed

## Checklist
- [x] No hardcoded "GluWink" in Swift code (use `Constants.displayName`; use `%@` in `.strings`) — N/a, no Swift changed
- [x] New user-facing strings added to both `en.lproj` and `nl.lproj` (and the matching `InfoPlist.strings` if applicable) — N/a, no strings added
- [x] No new settings or actions bypass the passphrase gate — N/a, no settings touched
- [x] Read the `QUIRKS.md` / `AGENTS.md` sections relevant to this change
- [x] If visible UI changed: regenerated App Store screenshots with `make appstore-screenshots` — N/a, no UI changed
- [x] No secrets or `private/` contents committed

## Notes for reviewers

Drafted from the template proposed in #40, then cross-referenced against the actual repo to fix discrepancies before committing:

- **Verified canonical Make targets**: `make deploy` (✓ exists in `Makefile` as `deploy: build install`) and `make appstore-screenshots` (✓ exists; the issue's draft only pointed at the path `iOS/fastlane/screenshots/**` and didn't mention the command, which leaves a gap because `.github/workflows/screenshots-sync-check.yml` will fail PRs where `iOS/fastlane/screenshots/` and `docs/assets/screenshots/` drift — `make appstore-screenshots` is what keeps them in sync).
- **Verified screenshot path**: `iOS/fastlane/screenshots/<locale>/iPhone-6.9/` exists with `en-US/` and `nl-NL/` subfolders.
- **Added Apple Watch** to the widget/shield sync checkbox — `WatchApp` and `WatchWidget` are real targets that share App Group state (per `AGENTS.md` → "Architecture") and the issue's draft only mentioned widget/watch/shield in passing.
- **Trimmed the issue's draft** per the "keep it tight" guidance — single template, no `PULL_REQUEST_TEMPLATE/` directory variants (the issue marks that as optional), `<!-- comment -->` hints inline so they disappear once filled in.
- **Localization wording**: cited `en.lproj` / `nl.lproj` explicitly to match the repo's actual folder names (per `CONTRIBUTING.md` → "Project Structure").

`CONTRIBUTING.md` items cross-referenced: Prerequisites (physical iPhone), Coding Conventions → App name, Coding Conventions → Localization, Security model → passphrase gate, Testing → No Simulator for Screen Time, Useful Make commands → `make deploy`. From `AGENTS.md`: Coding Conventions (`Constants.displayName`), shared App Group container (widget/watch/shield consumers). From `QUIRKS.md`: no PR-time gotchas surfaced beyond what's already in the checklist.

Made with [Cursor](https://cursor.com)