### PR TITLE
fix(app): show red icon when source configured but no data

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -597,14 +597,14 @@ The iOS App ships **four icon variants** in `iOS/App/Assets.xcassets/`:
 
 The Watch target follows the same convention in `iOS/WatchApp/Assets.xcassets/`.
 
-**Rule:** Green and red may only be shown when we have real glucose or carb data to base the decision on (see `ShieldContent.hasNoData`). Before the first sample arrives, in-app surfaces fall back to the blue variant. The shield UI never reaches the no-data state because shielding can only be enabled once a data source is configured (see `ShieldManager.disableIfNoDataSource()`).
+**Rule:** Blue is the *welcome* variant — shown only when no data source has been configured yet (see `HomeView.showsWelcome`). Once the user has opted in to a source, in-app surfaces commit to red/green: missing or stale data with a configured source is a `needsAttention` (red) state, not a neutral one. The shield UI never reaches a no-data state because shielding can only be enabled once a data source is configured (see `ShieldManager.disableIfNoDataSource()`).
 
 ### Rules
 
 1. **Do NOT call `UIApplication.shared.setAlternateIconName(...)`.** We deliberately do not provide alternate `.appiconset`s and do not swap the home-screen icon — it's unreliable, racy with extensions, and confuses users. The home-screen signal is the badge (see `SharedDataManager.refreshAttentionBadge()`).
 2. **Use `AppIcon-Blue` / `AppIcon-Red` / `AppIcon-Green` for any surface where we control the rendering at attention-evaluation time.** Selection logic depends on the surface:
-   - **In-app surfaces** (e.g. `HomeView`): `hasNoData` → blue; else `needsAttention` → red; else green.
-   - **Shield UI** (`ShieldConfigurationExtension`): only red / green. Shielding is gated on having a data source, so `hasNoData` cannot occur; if the configured source has stopped delivering, that's a `needsAttention` case (red).
+   - **In-app surfaces** (e.g. `HomeView`): welcome state (no source configured) → blue; else `needsAttention` → red; else green. Note: `ShieldContent.hasNoData` exists as a descriptive flag but is NOT the trigger — a configured source with missing data is red, not blue.
+   - **Shield UI** (`ShieldConfigurationExtension`): only red / green. Shielding is gated on having a data source, so the no-data state cannot occur; if the configured source has stopped delivering, that's a `needsAttention` case (red).
    - Other examples that follow the in-app rule: future notification attachments / rich content, future widgets that want to show the brand mark with attention state.
 3. **In SwiftUI inside the App target:** `Image("AppIcon-Blue")` / `Image("AppIcon-Red")` / `Image("AppIcon-Green")` works because all three are `.imageset`s in the App's asset catalog.
 4. **In the ShieldConfig extension** (and any other extension that needs the variants): the App's asset catalog is **not** in the extension's bundle. Each extension that needs the artwork must ship its own copies. ShieldConfig keeps `iOS/ShieldConfig/AppIcon-Red.png` and `iOS/ShieldConfig/AppIcon-Green.png` as raw bundle resources and loads them with `UIImage(contentsOfFile: Bundle.main.path(forResource: "AppIcon-Red", ofType: "png"))`. There is intentionally no blue PNG in the extension. When adding the variants to a new extension, copy the PNGs into that target's folder; this project uses file-system synchronized groups so Xcode will pick them up automatically.

--- a/iOS/App/HomeView.swift
+++ b/iOS/App/HomeView.swift
@@ -274,7 +274,7 @@ struct HomeView: View {
     @ViewBuilder
     private func iconHeader(content: ShieldContent, shieldingEnabled: Bool, shieldsArmed: Bool) -> some View {
         ZStack(alignment: .bottom) {
-            Image(showsWelcome ? "AppIcon-Blue" : iconName(for: content))
+            Image(iconName(for: content))
                 .resizable()
                 .frame(width: 96, height: 96)
                 .clipShape(RoundedRectangle(cornerRadius: 22))
@@ -440,7 +440,7 @@ struct HomeView: View {
     }
 
     private func iconName(for content: ShieldContent) -> String {
-        if content.hasNoData { return "AppIcon-Blue" }
+        if showsWelcome { return "AppIcon-Blue" }
         return content.needsAttention ? "AppIcon-Red" : "AppIcon-Green"
     }
 

--- a/iOS/SharedKit/Sources/SharedKit/ShieldContent.swift
+++ b/iOS/SharedKit/Sources/SharedKit/ShieldContent.swift
@@ -11,11 +11,12 @@ public struct ShieldContent: Sendable {
     /// True when we have no glucose AND no carb data at all — e.g. right after
     /// initial configuration, before HealthKit has delivered anything.
     ///
-    /// In-app surfaces (`HomeView`) use this to render a neutral blue
-    /// "no data yet" variant instead of green/red. The shield UI does not
-    /// branch on this: shielding is gated on having a data source, and a
-    /// missing reading from a configured source is treated as "needs
-    /// attention" (red).
+    /// This is descriptive only. It is NOT the trigger for the in-app blue
+    /// "welcome" icon variant — that's gated by the App-layer welcome state
+    /// (no data source configured *and* no glucose history). Once a source
+    /// is configured, missing data is a `needsAttention` case (red), not a
+    /// neutral one. The shield UI similarly never reaches the no-data state
+    /// because shielding is gated on having a data source.
     public let hasNoData: Bool
     public let buttonLabel: String
     public let glucoseValue: Double


### PR DESCRIPTION
## Summary

The home screen's app-icon variant was tied to `ShieldContent.hasNoData`, which only knows whether glucose+carb data is present — it has no notion of whether the user has *configured* a source. So once a data source was hooked up but no readings had landed (CGM offline, HealthKit denied, Nightscout fetch failing, etc.), the home icon dropped back to the friendly blue "welcome" face while the shield padlock was simultaneously red and armed. The icon was lying about the state — exactly the symptom in the screenshot evidence on #37 (glucose `--`, carbs `--`, padlock red, but a happy blue character looking back at you).

This PR moves the blue branch in `HomeView.iconName(for:)` from `content.hasNoData` to `showsWelcome`. `showsWelcome` already encodes "no data source configured *and* no glucose history" (see `HomeView.swift` ~131-144), which is the only state that legitimately reads as "neutral / first-launch / nothing-to-say". With a configured source, missing readings flow through `needsAttention` and the icon goes red — matching the padlock and the rest of the shield UI.

## States after the fix

| State | Icon |
|---|---|
| First launch, no source configured | **Blue** (welcome — unchanged) |
| Source configured, no data yet / stale / lost | **Red** (was incorrectly blue) |
| Fresh data in range | **Green** (unchanged) |
| Fresh data out of range / stale | **Red** (unchanged) |

The shield UI itself is unchanged — `ShieldConfigurationExtension` already only renders red/green and never branches on `hasNoData`, because shielding is gated on a configured source (see `ShieldManager.disableIfNoDataSource()`).

## Watch path

The acceptance criteria ask whether the same rule needs applying on the Watch status screen. **It doesn't:** `WatchContentView` already paints its background directly off `current.needsAttention` with no blue/welcome variant in the mix. Confirmed by `rg 'AppIcon-Blue|hasNoData' iOS/WatchApp/` returning no matches.

## What changed

- `iOS/App/HomeView.swift` — `iconName(for:)` now branches on `showsWelcome` instead of `content.hasNoData`. The redundant welcome check at the call site is removed (the function owns the full icon-state decision now).
- `iOS/SharedKit/Sources/SharedKit/ShieldContent.swift` — `hasNoData` doc comment updated to clarify it's a descriptive flag, NOT the icon trigger. The property itself is unchanged (kept per #38's explicit guidance — "don't introduce a new property; just stop using this as the icon trigger").
- `AGENTS.md` → "App Icon Variants" — the rule and the in-app surfaces bullet now describe blue as the welcome variant gated at the App layer, not as the no-data variant gated on `hasNoData`.

## Testing

Built locally with `make build` (xcodebuild on the `App` scheme, generic iOS destination) → `BUILD SUCCEEDED`.

This needs **eyeball verification on a physical device** for the no-data state — the Screen Time / FamilyControls APIs don't run in the Simulator, so we can't reliably reproduce the "configured source, missing readings" scenario in isolation there (per AGENTS.md → "Things that WILL NOT work"). Suggested manual check on device:

1. Fresh install (no source) → blue welcome icon. ✅
2. Authorize HealthKit (or enable Nightscout) but with no glucose data flowing → icon should now be **red**, padlock red. ✅ (was blue before this PR)
3. CGM starts delivering → icon goes green when in range, red when out of range or stale. ✅

The Simulator mock controls (`#if targetEnvironment(simulator)` debug sheet) can be used to exercise the rendering paths — toggle "Has glucose data" off with `forceWelcome` off and the icon should now go red instead of blue.

Closes #38

Made with [Cursor](https://cursor.com)