### PR TITLE
feat(docs): add /.well-known/security.txt

### DIFF
--- a/docs/.well-known/security.txt
+++ b/docs/.well-known/security.txt
@@ -1,0 +1,4 @@
+Contact: https://github.com/FokkeZB/GluWink/security/advisories/new
+Expires: 2027-04-20T00:00:00.000Z
+Preferred-Languages: en, nl
+Canonical: https://gluwink.app/.well-known/security.txt

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -32,6 +32,11 @@ exclude:
   - .jekyll-cache
   - .sass-cache
 
+# Jekyll skips dotfile-prefixed paths by default. Force-include the
+# .well-known/ folder so /.well-known/security.txt (RFC 9116) is served.
+include:
+  - .well-known
+
 # Locale tagging — kept consistent with App Store locale codes.
 defaults:
   - scope: { path: "" }


### PR DESCRIPTION
## What

Adds `/.well-known/security.txt` ([RFC 9116](https://datatracker.ietf.org/doc/html/rfc9116)) so security researchers and bug-bounty / scanner auto-discovery tools have a standard, discoverable channel for reporting vulnerabilities. Until now the only path was "find the right person on GitHub and hope".

Tiny file, big trust signal.

## Where

- `docs/.well-known/security.txt` — the file itself.
- `docs/_config.yml` — added `include: [".well-known"]`. Jekyll excludes any path starting with a dot by default, so without this the source file would never make it to the published `_site/`.

GitHub Pages will serve the file at the canonical location per the spec:

```
https://gluwink.app/.well-known/security.txt
```

## Contents

```
Contact: https://github.com/FokkeZB/GluWink/security/advisories/new
Expires: 2027-04-20T00:00:00.000Z
Preferred-Languages: en, nl
Canonical: https://gluwink.app/.well-known/security.txt
```

Notes per field:

- **Contact** — the issue called for a reachable channel without standing up email yet, so this points at the GitHub Security Advisories *new advisory* form. Switch to `mailto:security@gluwink.app` in the same file once #54 lands.
- **Expires** — set to one year from today (2026-04-20) per the RFC's "future ISO-8601 timestamp" requirement and the conventional ~1y horizon. The issue body suggested `2027-04-19` but that was written one day before this PR; using today + 1y keeps the convention honest.
- **Preferred-Languages** — `en, nl` to match the rest of the bilingual site.
- **Canonical** — the published URL, so a mirror or copy can be detected as not-the-truth.

`Acknowledgments:` and `Policy:` are intentionally omitted — premature at v1.

## Test plan

Verified locally in this PR:

- [x] Production build picks up the file: `make docs-build` writes `docs/_site/.well-known/security.txt` (would have been silently dropped without the `include:` change).
- [x] Local serve mirrors GitHub Pages exactly: served `docs/_site/` via vanilla `python3 -m http.server 4001` (the same setup `make docs-publish-check` uses) and checked:
  - \`curl -sI http://127.0.0.1:4001/.well-known/security.txt\` → \`HTTP/1.0 200 OK\`, \`Content-type: text/plain\`.
  - \`curl -s http://127.0.0.1:4001/.well-known/security.txt\` → body matches the file byte-for-byte.
- [x] Manual RFC 9116 sanity check: \`Contact:\`, \`Expires:\`, \`Preferred-Languages:\`, \`Canonical:\` all present; \`Expires\` is a future ISO-8601 timestamp; no trailing whitespace weirdness.

To do after merge / deploy (can't be done from a feature branch):

- [ ] \`curl -sI https://gluwink.app/.well-known/security.txt\` → \`HTTP/2 200\`, \`content-type: text/plain\`.
- [ ] Validate against <https://securitytxt.org/> — should report no errors.
- [ ] Set a calendar reminder for ~11 months out to bump \`Expires:\` (the issue mentions a CI \`Expires\` check as a possible follow-up — out of scope for this PR).

## When to bump the Contact field

Once email is set up (#54) and \`security@gluwink.app\` is working, swap the \`Contact:\` line in this same file. No structural change.

Refs #17, follows #48.

Closes #53

Made with [Cursor](https://cursor.com)