### PR TITLE
fix(ios): reset home to welcome state when every source is off

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -610,6 +610,41 @@ The Watch target follows the same convention in `iOS/WatchApp/Assets.xcassets/`.
 4. **In the ShieldConfig extension** (and any other extension that needs the variants): the App's asset catalog is **not** in the extension's bundle. Each extension that needs the artwork must ship its own copies. ShieldConfig keeps `iOS/ShieldConfig/AppIcon-Red.png` and `iOS/ShieldConfig/AppIcon-Green.png` as raw bundle resources and loads them with `UIImage(contentsOfFile: Bundle.main.path(forResource: "AppIcon-Red", ofType: "png"))`. There is intentionally no blue PNG in the extension. When adding the variants to a new extension, copy the PNGs into that target's folder; this project uses file-system synchronized groups so Xcode will pick them up automatically.
 5. **Keep the artworks in sync.** When the icon is redesigned, update: `AppIcon.appiconset`, `AppIcon-Blue.imageset`, `AppIcon-Red.imageset`, `AppIcon-Green.imageset` (in both the App and Watch catalogs where they exist), and the raw PNG copies inside any extension folder. The `icons/` folder at the repo root holds the master SVGs (`iOS.svg`, `iOS-green.svg`, `iOS-red.svg`, and their `watchOS.svg` counterparts; the blue `.imageset`s reuse `iOS.png` / `watchOS.png`).
 
+## Data Source State
+
+The app supports three data sources for glucose / carbs: **Apple Health**, **Nightscout**, and **Demo**. Most UI (`HomeView` welcome panel, `SetupChecklistCard`, shielding gate) needs to answer "is *anything* live right now?" — and we get that wrong the moment we treat history as configuration.
+
+**Rule:** "Has a data source" must reflect **current** state, never sticky history. Use `SharedDataManager.hasAnyDataSource` (and never re-implement the disjunction inline).
+
+### Definitions
+
+- **Nightscout / Demo:** straightforward — `nightscoutEnabled` / `isMockModeEnabled` are user-controlled toggles. Reading the flag is the truth.
+- **Apple Health:** iOS privacy-masks read-auth status (`HKHealthStore.authorizationStatus(for:)` returns `.sharingDenied` for both "user denied" and "we never asked", and `!= .notDetermined` once we've prompted — even after the user later revokes access). So we infer "active" from sample freshness via `SharedDataManager.healthKitDeliveringRecently`: HK has delivered at least once *and* the latest stored glucose timestamp is fresher than `glucoseStaleMinutes`.
+  - `healthKitEverDelivered` is kept as a stored flag, but only as the historical "we got data once" signal. Never use it as the gate for UI or shielding.
+
+### Disable handlers MUST clean up
+
+When the user toggles off Nightscout or Demo from Settings, the handler MUST call `SharedDataManager.handleInAppSourceDisabled()` after flipping the flag. That helper wipes the cached glucose / carb values **only** when no in-app source remains, so:
+
+- Disabling Demo while Nightscout is still on → values stay (Nightscout will keep them fresh on the next poll).
+- Disabling the last in-app source → values are cleared. If HK is still authorized + delivering, its next observer fire repopulates them within seconds; if not, the cleared state is honest and `HomeView` returns to the welcome panel.
+
+Disable paths should also kick remaining live sources (`NightscoutManager.fetchAll()`, `HealthKitManager.refreshIfAuthorized()`) so the UI reflects the new picture immediately instead of waiting for the next poll.
+
+The shield gate (`ShieldManager.disableIfNoDataSource()`) reads `hasAnyDataSource` too — when sources go quiet for longer than `glucoseStaleMinutes`, shielding auto-disables on the next launch / re-evaluation. That's deliberate: shielding without fresh data would treat every wake as `needsAttention` and never let the user back in.
+
+### Welcome state UI rules
+
+When `!hasAnyDataSource` the home screen is in *welcome* mode and must follow these rules — they keep the screen honest and focused:
+
+- **Icon:** blue (`AppIcon-Blue`). Never red/green: with no live source there's no signal to colour against.
+- **Status panel:** hidden entirely. No glucose number, no carb number, no attention checks. `HomeView.showsWelcome` returning `true` swaps the whole panel for `welcomePanel`.
+- **Cached values:** wiped by `handleInAppSourceDisabled()` whenever the last in-app source is turned off. We don't ship migrations for pre-release state — disable handlers are the only thing keeping the cache honest, so they must run on every disable path.
+- **Setup checklist:** *only* the data-source picker (Apple Health / Nightscout / Demo). The recommended group (shielding, passphrase, notifications) is suppressed in welcome state regardless of `setupTipsHidden`. Picking a source is the one decision that unblocks everything else; burying it under other rows dilutes the CTA.
+- **`setupTipsHidden` is overridden for the data-source picker.** Even if the user previously hid the checklist, the picker reappears the moment every source goes away. They have no other path back to a working app.
+
+Toggling a source on/off must always re-fetch (or wipe). Enable paths trigger the source's own fetch (`NightscoutManager.configurationDidChange()`, `HealthKitManager.requestAuthorization() → fetchLatest…`, `MockDataSettingsView.saveMockData()` writes directly). Disable paths run `handleInAppSourceDisabled()` + kick remaining live sources via `refreshIfAuthorized()` / `fetchAll()`. Never leave a stale value visible across a toggle.
+
 ## Coding Conventions
 
 - Swift 5.9+, SwiftUI for all UI

--- a/iOS/App/HealthKitManager.swift
+++ b/iOS/App/HealthKitManager.swift
@@ -94,6 +94,16 @@ final class HealthKitManager {
 
     // MARK: - Fetch Latest Values
 
+    /// Convenience: refresh both glucose and carbs *only* if the user has
+    /// ever been prompted for HealthKit. Safe to call from anywhere — does
+    /// nothing when authorization was never requested, so it won't trigger
+    /// a permission prompt as a side-effect.
+    func refreshIfAuthorized() async {
+        guard healthStore.authorizationStatus(for: glucoseType) != .notDetermined else { return }
+        await fetchLatestGlucose()
+        await fetchLatestCarbs()
+    }
+
     func fetchLatestGlucose() async {
         guard !SharedDataManager.shared.isMockModeEnabled else {
             logger.info("Mock mode active — skipping HealthKit glucose fetch")

--- a/iOS/App/HomeView.swift
+++ b/iOS/App/HomeView.swift
@@ -1,5 +1,4 @@
 import Combine
-import HealthKit
 import SharedKit
 import SwiftUI
 
@@ -125,9 +124,18 @@ struct HomeView: View {
         #endif
     }
 
-    /// True when the user hasn't hooked up any data source yet and has no
-    /// glucose history. Drives the welcome/empty state so the first-launch
-    /// screen explains what to do instead of showing "--".
+    /// True when no data source is currently active. Drives the
+    /// welcome/empty state so the first-launch (and post-disable-
+    /// everything) screen explains what to do instead of showing a
+    /// stale "--" or, worse, lying with green-on-old-data.
+    ///
+    /// Intentionally does NOT also check for cached glucose values:
+    /// without an active source those values are stale by definition
+    /// (see `SharedDataManager.hasAnyDataSource`'s recency window) and
+    /// surfacing them next to "no source configured" is confusing. The
+    /// launch-time migration in `MainApp` clears the cache in that
+    /// case, but if a user is mid-toggle and we momentarily race, the
+    /// welcome panel is still the correct UI to show.
     private var showsWelcome: Bool {
         #if targetEnvironment(simulator)
         if let preset = ScreenshotHarness.current?.homeViewPreset {
@@ -135,12 +143,7 @@ struct HomeView: View {
         }
         return false
         #else
-        let data = SharedDataManager.shared
-        let healthKitAsked = HKHealthStore()
-            .authorizationStatus(for: HKQuantityType(.bloodGlucose)) != .notDetermined
-        let hasDataSource = data.nightscoutEnabled || healthKitAsked || data.isMockModeEnabled
-        let hasAnyGlucose = data.currentGlucose != nil
-        return !hasDataSource && !hasAnyGlucose
+        return !SharedDataManager.shared.hasAnyDataSource
         #endif
     }
 

--- a/iOS/App/SettingsView.swift
+++ b/iOS/App/SettingsView.swift
@@ -34,7 +34,7 @@ struct SettingsView: View {
         _demoEnabled = State(initialValue: data.isMockModeEnabled)
         _glucoseUnit = State(initialValue: data.glucoseUnit)
         _nightscoutEnabled = State(initialValue: data.nightscoutEnabled)
-        _healthKitDelivering = State(initialValue: data.healthKitEverDelivered)
+        _healthKitDelivering = State(initialValue: data.healthKitDeliveringRecently)
     }
 
     var body: some View {
@@ -115,9 +115,12 @@ struct SettingsView: View {
                             // Apple Health can't tell us whether read
                             // access is currently granted (iOS privacy-
                             // masks that for read-only requests), so we
-                            // show "On" only once HealthKit has actually
-                            // delivered a sample — matching how the rest
-                            // of the app classifies it as a real source.
+                            // show "On" only when HK has delivered a
+                            // recent sample — matching how the rest of
+                            // the app classifies it as a real source
+                            // (see `SharedDataManager.healthKitDeliveringRecently`).
+                            // A revoked-in-Health-app source naturally
+                            // flips back to "Off" once samples go stale.
                             Text(healthKitDelivering
                                 ? String(localized: "settings.statusOn")
                                 : String(localized: "settings.statusOff"))
@@ -170,7 +173,7 @@ struct SettingsView: View {
                 shieldingEnabled = data.shieldingEnabled
                 demoEnabled = data.isMockModeEnabled
                 nightscoutEnabled = data.nightscoutEnabled
-                healthKitDelivering = data.healthKitEverDelivered
+                healthKitDelivering = data.healthKitDeliveringRecently
             }
             .navigationTitle(String(localized: "settings.title"))
             .navigationBarTitleDisplayMode(.inline)
@@ -669,10 +672,24 @@ struct MockDataSettingsView: View {
                 data.clearCarbData()
             }
         } else if data.isMockModeEnabled {
+            // `clearMockData` only wipes the cached values when no other
+            // in-app source is enabled (Nightscout/Demo share the same
+            // App Group keys as live sources). In that case, kick HK
+            // too — if it's still authorized and delivering, the UI
+            // repopulates within seconds; otherwise the cleared state
+            // is honest and HomeView returns to the welcome panel.
             data.clearMockData()
-            // Demo was the only source — turn shielding off too so the user
-            // doesn't end up with shielding enabled and nothing to evaluate.
+            // Disable shielding too if Demo was the last live source —
+            // there's nothing left to base attention decisions on.
             ShieldManager.shared.disableIfNoDataSource()
+            // Kick remaining live sources so the user sees their data
+            // immediately instead of waiting for the next poll cycle.
+            Task {
+                if data.nightscoutEnabled {
+                    await NightscoutManager.shared.fetchAll()
+                }
+                await HealthKitManager.shared.refreshIfAuthorized()
+            }
         }
         WatchSessionManager.shared.sendLatestContext()
         WidgetCenter.shared.reloadAllTimelines()
@@ -920,13 +937,23 @@ struct NightscoutSettingsView: View {
 
     private func disable() {
         enabled = false
-        SharedDataManager.shared.nightscoutEnabled = false
-        SharedDataManager.shared.flush()
+        let data = SharedDataManager.shared
+        data.nightscoutEnabled = false
+        data.flush()
         NightscoutManager.shared.configurationDidChange()
+        // Wipe Nightscout's last cached values when no other in-app
+        // source remains — otherwise the home screen keeps showing the
+        // disabled source's stale data with a green status. Live HK
+        // (if any) will repopulate via the kick below.
+        data.handleInAppSourceDisabled()
         // Disabling the last data source must also disable shielding —
         // there's nothing left to base attention decisions on.
         ShieldManager.shared.disableIfNoDataSource()
+        // Kick HK so users running HK-as-fallback see their data
+        // immediately instead of waiting for the next observer fire.
+        Task { await HealthKitManager.shared.refreshIfAuthorized() }
         WatchSessionManager.shared.sendLatestContext()
+        WidgetCenter.shared.reloadAllTimelines()
     }
 }
 

--- a/iOS/App/SetupChecklistCard.swift
+++ b/iOS/App/SetupChecklistCard.swift
@@ -38,9 +38,12 @@ struct SetupChecklistCard: View {
     /// Mirror of `SharedDataManager.isMockModeEnabled` for the same reason
     /// as `nightscoutEnabled`.
     @State private var isMockModeEnabled: Bool
-    /// Mirror of `SharedDataManager.healthKitEverDelivered` for the same
-    /// reason as `nightscoutEnabled`.
-    @State private var healthKitEverDelivered: Bool
+    /// Mirror of `SharedDataManager.healthKitDeliveringRecently` for the
+    /// same reason as `nightscoutEnabled`. Recency-based rather than the
+    /// sticky `healthKitEverDelivered` so the card re-shows the
+    /// data-source rows when HK access is revoked or the sensor goes
+    /// offline (see issue #36 — no force-quit needed).
+    @State private var healthKitDeliveringRecently: Bool
     @State private var showHideConfirmation = false
 
     init(refreshToken: Binding<Int>) {
@@ -53,27 +56,39 @@ struct SetupChecklistCard: View {
         _shieldingEnabled = State(initialValue: data.shieldingEnabled)
         _nightscoutEnabled = State(initialValue: data.nightscoutEnabled)
         _isMockModeEnabled = State(initialValue: data.isMockModeEnabled)
-        _healthKitEverDelivered = State(initialValue: data.healthKitEverDelivered)
+        _healthKitDeliveringRecently = State(initialValue: data.healthKitDeliveringRecently)
     }
 
     var body: some View {
-        #if targetEnvironment(simulator)
-        if let scene = ScreenshotHarness.current, scene.hidesSetupChecklist {
-            EmptyView()
-        } else if shouldRender {
-            renderedCard
+        // Lifecycle modifiers MUST live on the outer container, not on
+        // `renderedCard` — when `shouldRender` is false the card is
+        // absent from the view tree, taking `.onChange(of: refreshToken)`
+        // with it. That stranded the @State mirrors when the user
+        // disabled the last data source from Settings: HomeView bumped
+        // the token on dismiss, but no `refresh()` ran, so
+        // `nightscoutEnabled` etc. stayed true, `shouldRender` stayed
+        // false, and the data-source tiles only reappeared after a
+        // force-quit. Keeping them up here means we always hear the
+        // ping, regardless of whether we're currently rendering.
+        Group {
+            #if targetEnvironment(simulator)
+            if let scene = ScreenshotHarness.current, scene.hidesSetupChecklist {
+                EmptyView()
+            } else if shouldRender {
+                renderedCard
+            }
+            #else
+            if shouldRender {
+                renderedCard
+            }
+            #endif
         }
-        #else
-        if shouldRender {
-            renderedCard
-        }
-        #endif
+        .onAppear { refresh() }
+        .onChange(of: refreshToken) { _, _ in refresh() }
     }
 
     private var renderedCard: some View {
         card
-            .onAppear { refresh() }
-            .onChange(of: refreshToken) { _, _ in refresh() }
             .sheet(item: $presentedSheet, onDismiss: { refresh() }) { sheet in
                 sheetContent(for: sheet)
             }
@@ -93,15 +108,18 @@ struct SetupChecklistCard: View {
 
     // MARK: - Visibility
 
-    /// The card always renders while no data source is configured — that's
-    /// the most important next step, so we don't let the user hide it. Once
-    /// at least one source is set up, the card respects `setupTipsHidden`
-    /// and disappears on demand. Disabling all data sources later brings
-    /// the card back automatically without any extra reset step.
+    /// In the welcome state (no data source configured) the data-source
+    /// picker is the *only* group that shows — and it shows
+    /// unconditionally, even if the user previously hid setup tips.
+    /// Picking a source is the one decision that unblocks every other
+    /// feature, so we never let it stay hidden.
+    ///
+    /// Once a source is connected, the card respects `setupTipsHidden`:
+    /// the recommended group (shielding, passphrase, notifications)
+    /// hides on demand. Disabling every source later brings the
+    /// data-source picker back automatically.
     private var shouldRender: Bool {
-        guard !visibleGroups.isEmpty else { return false }
-        if !hasAnyDataSource { return true }
-        return !SharedDataManager.shared.setupTipsHidden
+        !visibleGroups.isEmpty
     }
 
     /// True once the user has connected at least one data source. The whole
@@ -110,16 +128,11 @@ struct SetupChecklistCard: View {
     ///
     /// Mirrors `SharedDataManager.hasAnyDataSource` but reads from local
     /// @State so SwiftUI re-renders when any of the underlying flags
-    /// (`nightscoutEnabled`, `isMockModeEnabled`, `healthKitEverDelivered`)
+    /// (`nightscoutEnabled`, `isMockModeEnabled`, `healthKitDeliveringRecently`)
     /// changes. Reading the manager directly here would skip re-render
     /// because the body wouldn't observe those flags.
     private var hasAnyDataSource: Bool {
-        nightscoutEnabled || isMockModeEnabled || healthKitEverDelivered
-    }
-
-    private var dataSourceRows: [ChecklistRow] {
-        guard !hasAnyDataSource else { return [] }
-        return [.healthKit, .nightscout, .demo]
+        nightscoutEnabled || isMockModeEnabled || healthKitDeliveringRecently
     }
 
     /// The shielding row stays visible until shielding is actually enabled —
@@ -146,26 +159,32 @@ struct SetupChecklistCard: View {
     }
 
     private var visibleGroups: [ChecklistGroup] {
-        var groups: [ChecklistGroup] = []
-        let dataSources = dataSourceRows
-        if !dataSources.isEmpty {
-            groups.append(ChecklistGroup(
+        // Welcome state: nothing matters except picking a source. The
+        // recommended group is intentionally suppressed here — shielding
+        // can't enable, and burying the data-source picker under
+        // passphrase / notifications dilutes the one CTA the user
+        // actually needs.
+        if !hasAnyDataSource {
+            return [ChecklistGroup(
                 kind: .dataSources,
                 titleKey: "setup.checklist.dataSources",
                 footerKey: "setup.checklist.dataSourcesFooter",
-                rows: dataSources
-            ))
+                rows: [.healthKit, .nightscout, .demo]
+            )]
         }
+
+        // Configured state: show the recommended group unless the user
+        // explicitly dismissed it. The data-source group is always
+        // empty here (we just confirmed `hasAnyDataSource`).
+        guard !SharedDataManager.shared.setupTipsHidden else { return [] }
         let recommended = recommendedRows
-        if !recommended.isEmpty {
-            groups.append(ChecklistGroup(
-                kind: .recommended,
-                titleKey: "setup.checklist.recommended",
-                footerKey: nil,
-                rows: recommended
-            ))
-        }
-        return groups
+        guard !recommended.isEmpty else { return [] }
+        return [ChecklistGroup(
+            kind: .recommended,
+            titleKey: "setup.checklist.recommended",
+            footerKey: nil,
+            rows: recommended
+        )]
     }
 
     // MARK: - Card
@@ -307,7 +326,7 @@ struct SetupChecklistCard: View {
         shieldingEnabled = data.shieldingEnabled
         nightscoutEnabled = data.nightscoutEnabled
         isMockModeEnabled = data.isMockModeEnabled
-        healthKitEverDelivered = data.healthKitEverDelivered
+        healthKitDeliveringRecently = data.healthKitDeliveringRecently
         Task {
             let settings = await UNUserNotificationCenter.current().notificationSettings()
             await MainActor.run { notificationStatus = settings.authorizationStatus }

--- a/iOS/App/SharedDataManager.swift
+++ b/iOS/App/SharedDataManager.swift
@@ -152,27 +152,36 @@ final class SharedDataManager {
         defaults?.removeObject(forKey: "lastCarbEntryAt")
     }
 
+    /// Disable mock mode. The cached glucose / carb values share storage
+    /// with HealthKit and Nightscout (see `saveGlucose` doc), so we can't
+    /// safely wipe them unconditionally — Nightscout-or-HK-sourced
+    /// values would disappear too. `handleInAppSourceDisabled` only
+    /// clears when no in-app source remains, leaving live sources to
+    /// re-publish on their own poll/observer cycle.
     func clearMockData() {
         isMockModeEnabled = false
-        clearGlucoseData()
-        clearCarbData()
-        logger.info("Mock mode disabled, data cleared")
+        handleInAppSourceDisabled()
+        logger.info("Mock mode disabled")
     }
 
     // MARK: - Data Sources
 
     /// Set to true the first time Apple Health actually delivers a sample
-    /// (glucose or carb). Stays true afterwards — we have no reliable way to
-    /// detect that the user later revoked read access in the Health app, so
-    /// "has ever delivered" is the best "source is real" signal we have.
+    /// (glucose or carb). Stays true afterwards — we have no reliable way
+    /// to detect that the user later revoked read access in the Health
+    /// app, so "has ever delivered" is the most honest "we successfully
+    /// got data from HK at some point" signal.
     ///
     /// Why not just use `HKHealthStore.authorizationStatus`? For read-only
     /// requests iOS privacy-masks that status: it returns `.sharingDenied`
-    /// both when the user denied *and* when we haven't asked — and for a
-    /// user who denied we'd still see `!= .notDetermined`, making "was
-    /// prompted" useless as a "source is active" signal. A user who denied
-    /// HealthKit looks identical to a user who accepted it until a sample
-    /// arrives, so we wait for the sample.
+    /// both when the user denied *and* when we haven't asked. A user who
+    /// denied HealthKit looks identical to a user who accepted it until a
+    /// sample arrives, so we wait for the sample.
+    ///
+    /// Treat this as historical only — for the "is HK currently a source
+    /// I should trust?" question, use `healthKitDeliveringRecently`. The
+    /// `hasAnyDataSource` gate combines that with the user-controlled
+    /// Nightscout / Demo toggles.
     var healthKitEverDelivered: Bool {
         get { defaults?.bool(forKey: "healthKitEverDelivered") ?? false }
         set { defaults?.set(newValue, forKey: "healthKitEverDelivered") }
@@ -183,22 +192,66 @@ final class SharedDataManager {
         if healthKitEverDelivered { return }
         healthKitEverDelivered = true
         flush()
-        logger.info("HealthKit marked as delivering — shielding now allowed")
+        logger.info("HealthKit marked as delivering")
     }
 
-    /// True when at least one data source is actually usable:
+    /// True when Apple Health both has delivered at least one sample AND
+    /// the latest stored glucose timestamp is fresher than `glucoseStaleMinutes`.
+    /// Used as the "HK is currently active" proxy because iOS doesn't let
+    /// us read the actual read-auth status (see `healthKitEverDelivered`).
     ///
-    /// - Nightscout: user has toggled it on (credentials verified)
-    /// - Demo: user has toggled it on
-    /// - Apple Health: has delivered at least one sample (see
-    ///   `healthKitEverDelivered`)
+    /// `glucoseFetchedAt` is shared across HK and Nightscout — that's
+    /// fine: if anyone wrote a fresh sample recently, *something* is
+    /// alive. When the user disables Nightscout/Demo the disable handler
+    /// clears the cached values (see `handleInAppSourceDisabled`), so a
+    /// stale-but-non-nil timestamp left over from a since-disabled source
+    /// can't masquerade as HK delivery.
     ///
-    /// Shielding requires this: the feature can't make a red/green decision
-    /// without glucose or carb input, so enabling it before any source is
-    /// live is meaningless. Disabling the last source automatically
-    /// disables shielding (see `ShieldManager.disableIfNoDataSource()`).
+    /// Falls back to a 30-minute window when no user override is set so
+    /// we don't have to read `Info.plist` from extension bundles where
+    /// the key may not be present.
+    var healthKitDeliveringRecently: Bool {
+        guard healthKitEverDelivered, let last = glucoseFetchedAt else { return false }
+        let minutes = glucoseStaleMinutes ?? 30
+        return Date().timeIntervalSince(last) < TimeInterval(minutes * 60)
+    }
+
+    /// True when at least one data source can credibly be supplying data
+    /// **right now**:
+    ///
+    /// - Nightscout / Demo: user has toggled them on.
+    /// - Apple Health: has delivered a sample within `glucoseStaleMinutes`
+    ///   (see `healthKitDeliveringRecently`).
+    ///
+    /// Drives both UI surfaces (welcome panel, setup checklist) and the
+    /// shielding gate. Shielding can't make red/green decisions without
+    /// fresh input, so disabling the last live source also disables
+    /// shielding (see `ShieldManager.disableIfNoDataSource()`).
     var hasAnyDataSource: Bool {
-        nightscoutEnabled || isMockModeEnabled || healthKitEverDelivered
+        if nightscoutEnabled || isMockModeEnabled { return true }
+        return healthKitDeliveringRecently
+    }
+
+    /// Call after the user disables an in-app data-source toggle
+    /// (Nightscout, Demo). When no in-app source remains enabled, wipes
+    /// the cached glucose + carb values so the home screen returns to the
+    /// welcome state and the setup checklist re-shows the data-source
+    /// rows immediately, rather than the user staring at a stale "green
+    /// with data" panel and an empty checklist.
+    ///
+    /// HK is intentionally not in the "anything left" check here — we
+    /// can't programmatically tell whether HK read auth is still granted.
+    /// Two outcomes both end up correct:
+    /// - HK is still authorized and delivering → its next observer fire
+    ///   re-populates the cleared values within seconds.
+    /// - HK was revoked / never set up → the values stay cleared and the
+    ///   welcome / setup state is honest.
+    func handleInAppSourceDisabled() {
+        guard !nightscoutEnabled, !isMockModeEnabled else { return }
+        clearGlucoseData()
+        clearCarbData()
+        flush()
+        logger.info("All in-app data sources disabled — cleared cached glucose/carb values")
     }
 
     // MARK: - Glucose Unit


### PR DESCRIPTION
## Summary
Disabling every data source (Nightscout / Demo / HealthKit) used to leave HomeView frozen on the last fetched values — green icon, stale glucose, no setup checklist — and a force-quit was the only way back to the welcome screen. This fix makes the home screen react in real time to source toggles, wipes cached values when the last in-app source is removed, and reduces the welcome-state checklist to *only* the data-source picker so the one CTA that unblocks everything else can't get buried.

Two root causes were addressed together:

1. **`hasAnyDataSource` was sticky.** Once HK delivered once, `healthKitEverDelivered` stayed true forever — so the gate kept reporting "we have a source" even after access was revoked or the sensor went quiet. Replaced with `healthKitDeliveringRecently` (HK delivered once *and* the stored sample is fresher than `glucoseStaleMinutes`), which is the most honest signal Apple's privacy-masked auth API permits.
2. **Disable handlers didn't clean up.** Toggling Nightscout / Demo off cleared their flags but left cached glucose / carb values in App Group `UserDefaults`. Added `SharedDataManager.handleInAppSourceDisabled()` (clears the cache only when no in-app source remains, so disabling Demo while Nightscout is still on keeps Nightscout's values) plus a `HealthKitManager.refreshIfAuthorized()` helper the disable paths use to immediately repopulate from any still-live source.

Also hoisted `SetupChecklistCard`'s `.onAppear` / `.onChange(of: refreshToken)` modifiers to the outer body. They previously unmounted with the card when `shouldRender` was false, so HomeView's post-Settings token bump never reached `refresh()`, the `@State` mirrors stayed stale, and the picker tiles only reappeared after a force-quit.

## Linked issues
Closes #36
Refs #37

## Screenshots / recordings
Verified on device — see attached screenshot in the PR comments below. Welcome state after disabling the last source: blue icon, no stale numbers, only the data-source picker.

## Testing
- [x] Built and run on a physical iPhone (Screen Time APIs don't work in the Simulator)
- [x] \`make deploy\` succeeds
- [x] Verified live: enable Nightscout → disable Nightscout → home immediately returns to blue welcome with picker tiles, no force-quit
- [x] Verified live: same with Demo
- [x] Verified \`handleInAppSourceDisabled()\` keeps Nightscout's values when Demo is the one being turned off
- [x] EN + NL — no user-facing string changes in this PR
- [x] Shared App Group + \`ShieldContent\` unchanged in shape; widgets, watch, shield extensions still build

## Checklist
- [x] No hardcoded "GluWink" in Swift code
- [x] No new user-facing strings
- [x] No new settings or actions bypass the passphrase gate
- [x] Re-read \`AGENTS.md\` → "App Icon Variants" + new "Data Source State" section (added in this PR)
- [x] No visible UI *layout* changed — same screens, just correct state. App Store screenshots unaffected.
- [x] No secrets or \`private/\` contents committed

## Notes for reviewers
- The contract is now documented in \`AGENTS.md\` → **Data Source State** (configured-vs-active, the welcome-state UI rules, the must-clean-up requirement on disable handlers). Future source integrations should hit \`handleInAppSourceDisabled()\` from their disable paths and read \`SharedDataManager.hasAnyDataSource\` rather than re-implementing the disjunction inline.
- Pre-release, deliberately did **not** ship a launch-time migration to clean up stale cache from older builds — \`handleInAppSourceDisabled()\` on the next disable is enough, and the no-migration policy was confirmed for unreleased state.
- The lifecycle-modifier hoist on \`SetupChecklistCard\` is the kind of SwiftUI footgun worth grepping for elsewhere — any view that conditionally returns \`EmptyView\` and attaches \`.onChange\`/\`.onAppear\` to the inner branch has the same latent bug.