### PR TITLE
fix(settings): re-evaluate shields + badge when attention rules change

### DIFF
--- a/iOS/App/SettingsView.swift
+++ b/iOS/App/SettingsView.swift
@@ -323,16 +323,25 @@ struct AttentionRulesSettingsView: View {
     }
 
     private func saveAttentionRules() {
-        SharedDataManager.shared.saveSettings(
+        let data = SharedDataManager.shared
+        data.saveSettings(
             highGlucoseThreshold: unit.toMmol(highThreshold),
             lowGlucoseThreshold: unit.toMmol(lowThreshold),
             glucoseStaleMinutes: Int(staleMinutes),
             carbGraceHour: carbGraceHour,
             carbGraceMinute: carbGraceMinute,
-            attentionIntervalMinutes: SharedDataManager.shared.attentionIntervalMinutes ?? ActivityScheduler.defaultAttentionInterval,
-            noAttentionIntervalMinutes: SharedDataManager.shared.noAttentionIntervalMinutes ?? ActivityScheduler.defaultNoAttentionInterval,
-            cooldownSeconds: SharedDataManager.shared.cooldownSeconds ?? 60
+            attentionIntervalMinutes: data.attentionIntervalMinutes ?? ActivityScheduler.defaultAttentionInterval,
+            noAttentionIntervalMinutes: data.noAttentionIntervalMinutes ?? ActivityScheduler.defaultNoAttentionInterval,
+            cooldownSeconds: data.cooldownSeconds ?? 60
         )
+        // A threshold/grace tweak is an explicit user action — re-arm or
+        // disarm shields immediately rather than waiting for the next
+        // DeviceActivityMonitor interval. Mirrors `saveShielding()` and
+        // keeps the badge in sync with the new rules.
+        if data.shieldingEnabled {
+            ShieldManager.shared.reevaluateShields()
+        }
+        data.refreshAttentionBadge()
         WidgetCenter.shared.reloadAllTimelines()
     }
 }


### PR DESCRIPTION
## Summary

Tweaks to the Attention Rules — high/low glucose thresholds, stale-minutes, carb grace window — only reloaded widget timelines. Shields kept whatever state they had until the next `DeviceActivityMonitor` interval fired, so dropping the high cutoff below the current reading didn't re-arm shields, and raising it above the current reading didn't disarm them. The settings UI felt broken.

This mirrors what `saveShielding()` already does for the shielding toggle / "only when attention" / app picker:

- `ShieldManager.shared.reevaluateShields()` from `saveAttentionRules()`, gated on `shieldingEnabled` (no-op when shielding is off).
- `SharedDataManager.shared.refreshAttentionBadge()` so the icon badge tracks the new rules without waiting.

The check-in *interval* is intentionally untouched — a settings change is an explicit user action, so bypassing it is the desired behavior (per the issue).

I audited the `.onChange` handlers in `SettingsView.swift` for `highThreshold`, `lowThreshold`, `staleMinutes`, `carbGraceHour`, `carbGraceMinute` — all five route through `saveAttentionRules()`, so the single fix covers all the inputs called out in #11. No other settings outside the Attention Rules screen feed attention evaluation.

## Files

- `iOS/App/SettingsView.swift` — `AttentionRulesSettingsView.saveAttentionRules()` now re-evaluates shields and refreshes the badge.

## Verification

- `xcodebuild -project iOS/App.xcodeproj -scheme App -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build` → **BUILD SUCCEEDED**.
- Behavioral verification (lower high-threshold below current reading → shields re-arm, etc.) requires a physical device because Screen Time APIs don't fire on the simulator. Owner to confirm on device.

Closes #11

Made with [Cursor](https://cursor.com)