### PR TITLE
fix(home): warn when HealthKit access is denied and no other source is configured

### DIFF
--- a/iOS/App/HomeView.swift
+++ b/iOS/App/HomeView.swift
@@ -1,6 +1,8 @@
 import Combine
+import HealthKit
 import SharedKit
 import SwiftUI
+import UIKit
 
 /// The app's main screen. Shown unconditionally — no more "setup vs active"
 /// branching. Renders:
@@ -12,7 +14,15 @@ import SwiftUI
 /// - The `SetupChecklistCard` below everything, surfacing optional
 ///   next-step setup until the user configures or dismisses each item.
 struct HomeView: View {
+    @Environment(\.scenePhase) private var scenePhase
     @State private var showSettings = false
+    /// Cached "has the user been asked for HealthKit read access?" — refreshed
+    /// on appear and on `scenePhase == .active` so toggling Health-app
+    /// permissions while we're backgrounded is reflected the moment the user
+    /// returns. iOS doesn't tell us if read access is currently granted (see
+    /// `SharedDataManager.healthKitEverDelivered`), so this is just the
+    /// "moved past .notDetermined" signal.
+    @State private var healthKitAsked: Bool = false
 
     #if targetEnvironment(simulator)
     @State private var glucose: Double = 6.4
@@ -147,6 +157,24 @@ struct HomeView: View {
         #endif
     }
 
+    /// True when the user was asked for HealthKit read access AND no data
+    /// has ever been delivered AND no other data source is configured. iOS
+    /// privacy-masks read-auth status so we can't tell "denied" from
+    /// "granted but no data yet" directly — see
+    /// `SharedDataManager.healthKitEverDelivered`. We approximate denial
+    /// by the lack of any sample after we've prompted, gated on no other
+    /// source being live so we don't pester users who deliberately
+    /// chose Nightscout or Demo instead.
+    private var showsHealthKitDeniedWarning: Bool {
+        #if targetEnvironment(simulator)
+        return false
+        #else
+        guard healthKitAsked else { return false }
+        let data = SharedDataManager.shared
+        return !data.healthKitEverDelivered && !data.hasAnyDataSource
+        #endif
+    }
+
     var body: some View {
         let _ = checklistRefreshToken
         let currentContent = content
@@ -182,6 +210,10 @@ struct HomeView: View {
                             shieldingEnabled: effectiveShieldingEnabled,
                             shieldsArmed: shieldsArmed
                         )
+                    }
+
+                    if showsHealthKitDeniedWarning {
+                        healthKitDeniedWarning
                     }
 
                     SetupChecklistCard(refreshToken: $checklistRefreshToken)
@@ -255,6 +287,7 @@ struct HomeView: View {
         .onAppear {
             pinTitleIfNeeded()
             refreshDisarmedState()
+            refreshHealthKitAskedState()
             SharedDataManager.shared.refreshAttentionBadge()
             checklistRefreshToken &+= 1
         }
@@ -262,6 +295,12 @@ struct HomeView: View {
             pinnedTitle = nil
             pinTitleIfNeeded()
             SharedDataManager.shared.refreshAttentionBadge()
+        }
+        .onChange(of: scenePhase) {
+            if scenePhase == .active {
+                refreshHealthKitAskedState()
+                checklistRefreshToken &+= 1
+            }
         }
         .onReceive(timer) {
             tick = $0
@@ -311,6 +350,67 @@ struct HomeView: View {
                 .padding(.horizontal, 32)
                 .fixedSize(horizontal: false, vertical: true)
         }
+    }
+
+    // MARK: - HealthKit Denied Warning
+
+    /// Surfaced when we asked Apple Health for read access but no sample
+    /// has ever arrived (i.e. the user almost certainly denied) and no
+    /// other source is filling the gap. Without this the welcome panel
+    /// silently sits with no glucose/carb data and the user has no
+    /// signal that they need to grant access.
+    private var healthKitDeniedWarning: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                    .font(.title3)
+                Text("home.healthKitDenied.title", tableName: "Localizable")
+                    .font(.headline)
+            }
+
+            Text("home.healthKitDenied.body \(Constants.displayName)", tableName: "Localizable")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Button {
+                openHealthApp()
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "arrow.up.right.square")
+                    Text("home.healthKitDenied.openHealth", tableName: "Localizable")
+                }
+                .font(.subheadline.weight(.semibold))
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.orange)
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(.secondarySystemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .padding(.horizontal, 16)
+    }
+
+    /// `x-apple-health://` lands inside the Health app — there's no
+    /// public deep-link to the per-app permissions page, but it's
+    /// where the user manages read access. Mirrors
+    /// `HealthKitSettingsView.openHealthApp()`.
+    private func openHealthApp() {
+        if let url = URL(string: "x-apple-health://"), UIApplication.shared.canOpenURL(url) {
+            UIApplication.shared.open(url)
+        }
+    }
+
+    private func refreshHealthKitAskedState() {
+        #if !targetEnvironment(simulator)
+        let status = HKHealthStore().authorizationStatus(for: HKQuantityType(.bloodGlucose))
+        let asked = status != .notDetermined
+        if asked != healthKitAsked {
+            healthKitAsked = asked
+        }
+        #endif
     }
 
     // MARK: - Status Panel

--- a/iOS/App/en.lproj/Localizable.strings
+++ b/iOS/App/en.lproj/Localizable.strings
@@ -7,6 +7,11 @@
 "home.welcome.title %@" = "Welcome to %@";
 "home.welcome.tagline %@" = "Turn your iPhone and Apple Watch from your biggest distraction into your best tool. Glucose and carbs everywhere. Apps blocked when something needs your attention.";
 
+/* Home - HealthKit denied warning */
+"home.healthKitDenied.title" = "Apple Health isn't sharing data";
+"home.healthKitDenied.body %@" = "%@ asked Apple Health for glucose and carb data, but nothing is coming through. Open the Health app to grant access, or pick another data source below.";
+"home.healthKitDenied.openHealth" = "Open Health app";
+
 /* Setup Checklist */
 "setup.checklist.title" = "Set up";
 "setup.checklist.hide" = "Hide";

--- a/iOS/App/nl.lproj/Localizable.strings
+++ b/iOS/App/nl.lproj/Localizable.strings
@@ -7,6 +7,11 @@
 "home.welcome.title %@" = "Welkom bij %@";
 "home.welcome.tagline %@" = "Verander je iPhone en Apple Watch van je grootste afleider in je beste hulpmiddel. Glucose en koolhydraten overal zichtbaar. Apps blokkeren als iets je aandacht vraagt.";
 
+/* Home - Apple Gezondheid geweigerd */
+"home.healthKitDenied.title" = "Apple Gezondheid deelt geen gegevens";
+"home.healthKitDenied.body %@" = "%@ heeft Apple Gezondheid om glucose- en koolhydraatgegevens gevraagd, maar er komt niets binnen. Open de Gezondheid-app om toegang te geven, of kies hieronder een andere gegevensbron.";
+"home.healthKitDenied.openHealth" = "Open Gezondheid-app";
+
 /* Set-up Checklist */
 "setup.checklist.title" = "Instellen";
 "setup.checklist.hide" = "Verberg";


### PR DESCRIPTION
## Summary

If the user denied HealthKit during setup and didn't configure Nightscout or Demo, the home screen silently sat in the welcome state with no glucose / carb data and no signal that anything was wrong — the entire attention engine quietly broke (issue #2).

This PR surfaces a clear warning card on `HomeView` when that state is detected, with an "Open Health app" CTA so the user can grant access.

## Detection rule

iOS privacy-masks HealthKit read-auth status (`HKHealthStore.authorizationStatus(for:)` returns `.sharingDenied` regardless of grant for read-only requests), so denial can't be detected directly. Instead the warning fires when **all three** are true:

1. HealthKit was prompted: `authorizationStatus(for: .bloodGlucose) != .notDetermined`
2. No HK sample has ever arrived: `SharedDataManager.healthKitEverDelivered == false`
3. No other source is configured: `!SharedDataManager.hasAnyDataSource` (mirrors HK + Nightscout + Demo)

State refreshes on `onAppear` and `scenePhase == .active`, so toggling Health-app permissions while we're backgrounded reflects the moment the user returns.

## What the warning looks like

A card above the `SetupChecklistCard`, styled like the rest of the home cards (`Color(.secondarySystemBackground)`, `RoundedRectangle(cornerRadius: 12)`):

- `exclamationmark.triangle.fill` icon (orange) + headline: **"Apple Health isn't sharing data"**
- Body: **"GluWink asked Apple Health for glucose and carb data, but nothing is coming through. Open the Health app to grant access, or pick another data source below."**
- Borderless-prominent button (orange tint): **"Open Health app"** → `x-apple-health://`

`x-apple-health://` lands in the Health app where read permissions are managed — Apple doesn't expose a direct deep-link to the per-app permissions page. This mirrors the existing `HealthKitSettingsView.openHealthApp()` pattern. The standard `UIApplication.openSettingsURLString` would land in **Settings → GluWink**, which doesn't show HealthKit permissions at all (those live in the Health app for read-only access).

Localized in English and Dutch using the existing `home.*` / `setup.checklist.*` convention.

## Doesn't break the `.notDetermined` flow

The warning is gated on `healthKitAsked`, so users who haven't been prompted still see the existing `SetupChecklistCard` "Connect Apple Health" row unchanged.

## Touched files

- `iOS/App/HomeView.swift` — detection logic + warning card view + `scenePhase` refresh hook
- `iOS/App/en.lproj/Localizable.strings` — three new keys under `home.healthKitDenied.*`
- `iOS/App/nl.lproj/Localizable.strings` — Dutch counterparts

## Verification

- `xcodebuild -project iOS/App.xcodeproj -scheme App -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -configuration Debug build CODE_SIGNING_ALLOWED=NO` → `** BUILD SUCCEEDED **`.
- Detection logic guarded with `#if !targetEnvironment(simulator)` so the warning never appears in screenshot harness or simulator builds — keeps existing snapshot fixtures untouched.

Closes #2

Made with [Cursor](https://cursor.com)