### PR TITLE
fix(thresholds): read user overrides from App Group across all surfaces

### DIFF
--- a/iOS/App/HomeView.swift
+++ b/iOS/App/HomeView.swift
@@ -52,11 +52,9 @@ struct HomeView: View {
     /// area as the user scrolls.
     private static let bottomFadeHeight: CGFloat = 48
 
-    private static let highGlucoseThreshold = Double(Bundle.main.object(forInfoDictionaryKey: "HighGlucoseThreshold") as! String)!
-    private static let lowGlucoseThreshold = Double(Bundle.main.object(forInfoDictionaryKey: "LowGlucoseThreshold") as! String)!
-    private static let glucoseStaleMinutes = Int(Bundle.main.object(forInfoDictionaryKey: "GlucoseStaleMinutes") as! String)!
-    private static let carbGraceHour = Int(Bundle.main.object(forInfoDictionaryKey: "CarbGraceHour") as! String)!
-    private static let carbGraceMinute = Int(Bundle.main.object(forInfoDictionaryKey: "CarbGraceMinute") as! String)!
+    /// Read per-render via `SharedDataManager.effective*` so user overrides
+    /// from Settings take effect immediately. We deliberately don't cache
+    /// these in `static let`s — that's the bug fixed by #77.
 
     init() {
         #if targetEnvironment(simulator)
@@ -80,6 +78,12 @@ struct HomeView: View {
     private var content: ShieldContent {
         let _ = tick
         let strings = ShieldContent.Strings.fromPackage()
+        let data = SharedDataManager.shared
+        let highThreshold = data.effectiveHighGlucoseThreshold
+        let lowThreshold = data.effectiveLowGlucoseThreshold
+        let staleMinutes = data.effectiveGlucoseStaleMinutes
+        let graceHour = data.effectiveCarbGraceHour
+        let graceMinute = data.effectiveCarbGraceMinute
 
         #if targetEnvironment(simulator)
         let now = overrideTime
@@ -96,27 +100,26 @@ struct HomeView: View {
             glucoseFetchedAt: glucoseDate,
             lastCarbGrams: hasCarbData ? carbGrams : nil,
             lastCarbEntryAt: carbDate,
-            highGlucoseThreshold: Self.highGlucoseThreshold,
-            lowGlucoseThreshold: Self.lowGlucoseThreshold,
-            glucoseStaleMinutes: Self.glucoseStaleMinutes,
-            carbGraceHour: Self.carbGraceHour,
-            carbGraceMinute: Self.carbGraceMinute,
-            glucoseUnit: SharedDataManager.shared.glucoseUnit,
+            highGlucoseThreshold: highThreshold,
+            lowGlucoseThreshold: lowThreshold,
+            glucoseStaleMinutes: staleMinutes,
+            carbGraceHour: graceHour,
+            carbGraceMinute: graceMinute,
+            glucoseUnit: data.glucoseUnit,
             strings: strings,
             now: now
         )
         #else
-        let data = SharedDataManager.shared
         return ShieldContent(
             glucose: data.currentGlucose ?? 0,
             glucoseFetchedAt: data.glucoseFetchedAt,
             lastCarbGrams: data.lastCarbGrams,
             lastCarbEntryAt: data.lastCarbEntryAt,
-            highGlucoseThreshold: Self.highGlucoseThreshold,
-            lowGlucoseThreshold: Self.lowGlucoseThreshold,
-            glucoseStaleMinutes: Self.glucoseStaleMinutes,
-            carbGraceHour: Self.carbGraceHour,
-            carbGraceMinute: Self.carbGraceMinute,
+            highGlucoseThreshold: highThreshold,
+            lowGlucoseThreshold: lowThreshold,
+            glucoseStaleMinutes: staleMinutes,
+            carbGraceHour: graceHour,
+            carbGraceMinute: graceMinute,
             glucoseUnit: data.glucoseUnit,
             customChecks: data.allCustomChecks(),
             strings: strings

--- a/iOS/App/SharedDataManager.swift
+++ b/iOS/App/SharedDataManager.swift
@@ -82,11 +82,11 @@ final class SharedDataManager {
         let carbDate = defaults?.string(forKey: "lastCarbEntryAt")
             .flatMap { ISO8601DateFormatter().date(from: $0) }
 
-        let highThreshold = Double(Bundle.main.object(forInfoDictionaryKey: "HighGlucoseThreshold") as! String)!
-        let lowThreshold = Double(Bundle.main.object(forInfoDictionaryKey: "LowGlucoseThreshold") as! String)!
-        let staleMinutes = Int(Bundle.main.object(forInfoDictionaryKey: "GlucoseStaleMinutes") as! String)!
-        let carbGraceHour = Int(Bundle.main.object(forInfoDictionaryKey: "CarbGraceHour") as! String)!
-        let carbGraceMinute = Int(Bundle.main.object(forInfoDictionaryKey: "CarbGraceMinute") as! String)!
+        let highThreshold = effectiveHighGlucoseThreshold
+        let lowThreshold = effectiveLowGlucoseThreshold
+        let staleMinutes = effectiveGlucoseStaleMinutes
+        let carbGraceHour = effectiveCarbGraceHour
+        let carbGraceMinute = effectiveCarbGraceMinute
 
         let now = Date()
         let cal = Calendar.current
@@ -292,6 +292,32 @@ final class SharedDataManager {
 
     var carbGraceMinute: Int? {
         get { defaults?.object(forKey: "carbGraceMinute") as? Int }
+    }
+
+    // MARK: - Effective thresholds (override → xcconfig fallback)
+
+    /// Resolved `highGlucoseThreshold`: user override if set, otherwise the
+    /// xcconfig default from `SettingsDefaults`. Use these from every App
+    /// surface that evaluates attention so the override contract documented
+    /// in `AGENTS.md` → "Settings override precedence" can't drift.
+    var effectiveHighGlucoseThreshold: Double {
+        ThresholdResolver.highGlucose(defaults: defaults, fallback: SettingsDefaults.highGlucose)
+    }
+
+    var effectiveLowGlucoseThreshold: Double {
+        ThresholdResolver.lowGlucose(defaults: defaults, fallback: SettingsDefaults.lowGlucose)
+    }
+
+    var effectiveGlucoseStaleMinutes: Int {
+        ThresholdResolver.staleMinutes(defaults: defaults, fallback: SettingsDefaults.staleMinutes)
+    }
+
+    var effectiveCarbGraceHour: Int {
+        ThresholdResolver.carbGraceHour(defaults: defaults, fallback: SettingsDefaults.carbGraceHour)
+    }
+
+    var effectiveCarbGraceMinute: Int {
+        ThresholdResolver.carbGraceMinute(defaults: defaults, fallback: SettingsDefaults.carbGraceMinute)
     }
 
     var attentionIntervalMinutes: Int? {

--- a/iOS/App/ShieldManager.swift
+++ b/iOS/App/ShieldManager.swift
@@ -64,11 +64,11 @@ final class ShieldManager {
         let data = SharedDataManager.shared
         let now = Date()
 
-        let highThreshold = data.highGlucoseThreshold ?? SettingsDefaults.highGlucose
-        let lowThreshold = data.lowGlucoseThreshold ?? SettingsDefaults.lowGlucose
-        let staleMinutes = data.glucoseStaleMinutes ?? SettingsDefaults.staleMinutes
-        let graceHour = data.carbGraceHour ?? SettingsDefaults.carbGraceHour
-        let graceMinute = data.carbGraceMinute ?? SettingsDefaults.carbGraceMinute
+        let highThreshold = data.effectiveHighGlucoseThreshold
+        let lowThreshold = data.effectiveLowGlucoseThreshold
+        let staleMinutes = data.effectiveGlucoseStaleMinutes
+        let graceHour = data.effectiveCarbGraceHour
+        let graceMinute = data.effectiveCarbGraceMinute
 
         let glucose = data.currentGlucose ?? 0
         if glucose > 0, let fetchedAt = data.glucoseFetchedAt {

--- a/iOS/DeviceActivityMonitor/DeviceActivityMonitorExtension.swift
+++ b/iOS/DeviceActivityMonitor/DeviceActivityMonitorExtension.swift
@@ -4,14 +4,42 @@ import Foundation
 import ManagedSettings
 import os
 
+/// Duplicate of `SharedKit.ThresholdResolver` — this extension does not link
+/// SharedKit (kept lean per the extension memory cap), so the contract is
+/// re-stated locally. Keep in sync with SharedKit/ThresholdResolver.swift.
+private enum ThresholdResolver {
+    static func highGlucose(defaults: UserDefaults?, fallback: Double) -> Double {
+        (defaults?.object(forKey: "highGlucoseThreshold") as? Double) ?? fallback
+    }
+
+    static func lowGlucose(defaults: UserDefaults?, fallback: Double) -> Double {
+        (defaults?.object(forKey: "lowGlucoseThreshold") as? Double) ?? fallback
+    }
+
+    static func staleMinutes(defaults: UserDefaults?, fallback: Int) -> Int {
+        (defaults?.object(forKey: "glucoseStaleMinutes") as? Int) ?? fallback
+    }
+
+    static func carbGraceHour(defaults: UserDefaults?, fallback: Int) -> Int {
+        (defaults?.object(forKey: "carbGraceHour") as? Int) ?? fallback
+    }
+
+    static func carbGraceMinute(defaults: UserDefaults?, fallback: Int) -> Int {
+        (defaults?.object(forKey: "carbGraceMinute") as? Int) ?? fallback
+    }
+}
+
 class DeviceActivityMonitorExtension: DeviceActivityMonitor {
     private static let bundlePrefix = Bundle.main.object(forInfoDictionaryKey: "BundlePrefix") as! String
     private static let appGroupID = Bundle.main.object(forInfoDictionaryKey: "AppGroupID") as! String
-    private static let highGlucoseThreshold = Double(Bundle.main.object(forInfoDictionaryKey: "HighGlucoseThreshold") as! String)!
-    private static let lowGlucoseThreshold = Double(Bundle.main.object(forInfoDictionaryKey: "LowGlucoseThreshold") as! String)!
-    private static let glucoseStaleMinutes = Int(Bundle.main.object(forInfoDictionaryKey: "GlucoseStaleMinutes") as! String)!
-    private static let carbGraceHour = Int(Bundle.main.object(forInfoDictionaryKey: "CarbGraceHour") as! String)!
-    private static let carbGraceMinute = Int(Bundle.main.object(forInfoDictionaryKey: "CarbGraceMinute") as! String)!
+    /// xcconfig fallbacks. The resolver picks override-or-fallback per
+    /// re-arm decision so user threshold changes take effect on the next
+    /// monitoring interval.
+    private static let fallbackHighGlucose = Double(Bundle.main.object(forInfoDictionaryKey: "HighGlucoseThreshold") as! String)!
+    private static let fallbackLowGlucose = Double(Bundle.main.object(forInfoDictionaryKey: "LowGlucoseThreshold") as! String)!
+    private static let fallbackStaleMinutes = Int(Bundle.main.object(forInfoDictionaryKey: "GlucoseStaleMinutes") as! String)!
+    private static let fallbackCarbGraceHour = Int(Bundle.main.object(forInfoDictionaryKey: "CarbGraceHour") as! String)!
+    private static let fallbackCarbGraceMinute = Int(Bundle.main.object(forInfoDictionaryKey: "CarbGraceMinute") as! String)!
 
     private let logger = Logger(subsystem: "\(bundlePrefix).DeviceActivityMonitor", category: "monitor")
     private let defaults = UserDefaults(suiteName: appGroupID)
@@ -68,13 +96,19 @@ class DeviceActivityMonitorExtension: DeviceActivityMonitor {
     private func needsAttention() -> Bool {
         let now = Date()
 
+        let highThreshold = ThresholdResolver.highGlucose(defaults: defaults, fallback: Self.fallbackHighGlucose)
+        let lowThreshold = ThresholdResolver.lowGlucose(defaults: defaults, fallback: Self.fallbackLowGlucose)
+        let staleMinutes = ThresholdResolver.staleMinutes(defaults: defaults, fallback: Self.fallbackStaleMinutes)
+        let graceHour = ThresholdResolver.carbGraceHour(defaults: defaults, fallback: Self.fallbackCarbGraceHour)
+        let graceMinute = ThresholdResolver.carbGraceMinute(defaults: defaults, fallback: Self.fallbackCarbGraceMinute)
+
         let glucose = defaults?.double(forKey: "currentGlucose") ?? 0
         if let isoStr = defaults?.string(forKey: "glucoseFetchedAt"),
            let fetchedAt = ISO8601DateFormatter().date(from: isoStr) {
-            if glucose < Self.lowGlucoseThreshold || glucose > Self.highGlucoseThreshold {
+            if glucose < lowThreshold || glucose > highThreshold {
                 return true
             }
-            if now.timeIntervalSince(fetchedAt) / 60 > Double(Self.glucoseStaleMinutes) {
+            if now.timeIntervalSince(fetchedAt) / 60 > Double(staleMinutes) {
                 return true
             }
         } else {
@@ -84,8 +118,8 @@ class DeviceActivityMonitorExtension: DeviceActivityMonitor {
         let cal = Calendar.current
         let hour = cal.component(.hour, from: now)
         let minute = cal.component(.minute, from: now)
-        let isMorningGrace = hour < Self.carbGraceHour
-            || (hour == Self.carbGraceHour && minute < Self.carbGraceMinute)
+        let isMorningGrace = hour < graceHour
+            || (hour == graceHour && minute < graceMinute)
 
         if !isMorningGrace {
             if let isoStr = defaults?.string(forKey: "lastCarbEntryAt"),

--- a/iOS/SharedKit/Package.swift
+++ b/iOS/SharedKit/Package.swift
@@ -7,6 +7,12 @@ let package = Package(
     platforms: [
         .iOS(.v16),
         .watchOS(.v10),
+        // macOS isn't an app target — it's only declared so the SPM test
+        // target can compile and run on the host (`swift test`) without
+        // standing up an iOS Simulator. Pick the lowest version that
+        // satisfies the APIs SharedKit currently uses (URLSession async
+        // `data(for:)` requires macOS 12+).
+        .macOS(.v13),
     ],
     products: [
         .library(
@@ -20,6 +26,10 @@ let package = Package(
             resources: [
                 .process("Resources"),
             ]
+        ),
+        .testTarget(
+            name: "SharedKitTests",
+            dependencies: ["SharedKit"]
         ),
     ]
 )

--- a/iOS/SharedKit/Sources/SharedKit/ThresholdResolver.swift
+++ b/iOS/SharedKit/Sources/SharedKit/ThresholdResolver.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Centralised resolver for the user-tweakable attention thresholds.
+///
+/// The main app writes overrides to the App Group `UserDefaults` suite when
+/// the user changes them in Settings. Every surface that compares a glucose
+/// or carb value against a threshold (home screen, shield UI, shield action,
+/// status widget, watch app, device activity monitor) **must** go through
+/// this resolver so the override-vs-fallback contract can't drift again.
+///
+/// See `AGENTS.md` → "Shared App Group Container" → "Settings override
+/// precedence" for the documented contract.
+///
+/// Each helper takes:
+/// - `defaults`: the App Group `UserDefaults` to read the override from. Pass
+///   `nil` if the suite couldn't be opened — the helper falls back to
+///   `fallback`.
+/// - `fallback`: the xcconfig default the caller already parsed out of its
+///   own target's `Info.plist`. Per-target plists keep the same xcconfig
+///   sources of truth, so the fallback is always correct for that target.
+public enum ThresholdResolver {
+    public static let highGlucoseKey = "highGlucoseThreshold"
+    public static let lowGlucoseKey = "lowGlucoseThreshold"
+    public static let staleMinutesKey = "glucoseStaleMinutes"
+    public static let carbGraceHourKey = "carbGraceHour"
+    public static let carbGraceMinuteKey = "carbGraceMinute"
+
+    public static func highGlucose(defaults: UserDefaults?, fallback: Double) -> Double {
+        (defaults?.object(forKey: highGlucoseKey) as? Double) ?? fallback
+    }
+
+    public static func lowGlucose(defaults: UserDefaults?, fallback: Double) -> Double {
+        (defaults?.object(forKey: lowGlucoseKey) as? Double) ?? fallback
+    }
+
+    public static func staleMinutes(defaults: UserDefaults?, fallback: Int) -> Int {
+        (defaults?.object(forKey: staleMinutesKey) as? Int) ?? fallback
+    }
+
+    public static func carbGraceHour(defaults: UserDefaults?, fallback: Int) -> Int {
+        (defaults?.object(forKey: carbGraceHourKey) as? Int) ?? fallback
+    }
+
+    public static func carbGraceMinute(defaults: UserDefaults?, fallback: Int) -> Int {
+        (defaults?.object(forKey: carbGraceMinuteKey) as? Int) ?? fallback
+    }
+}

--- a/iOS/SharedKit/Tests/SharedKitTests/ThresholdResolverTests.swift
+++ b/iOS/SharedKit/Tests/SharedKitTests/ThresholdResolverTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import XCTest
+@testable import SharedKit
+
+/// Pins the override-with-fallback contract documented in
+/// `AGENTS.md` → "Settings override precedence". When the App Group
+/// `UserDefaults` carries a user override, every helper returns the
+/// override; when the override is absent (never written), every helper
+/// returns the xcconfig default the caller supplied. Regressing this
+/// contract is what shipped issue #77, so these tests exist to catch
+/// the next drift.
+final class ThresholdResolverTests: XCTestCase {
+    private let suiteName = "ThresholdResolverTests.suite.\(UUID().uuidString)"
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        super.tearDown()
+    }
+
+    // MARK: - Override absent → fallback wins
+
+    func testFallbackUsedWhenNoOverride() {
+        XCTAssertEqual(ThresholdResolver.highGlucose(defaults: defaults, fallback: 9.5), 9.5)
+        XCTAssertEqual(ThresholdResolver.lowGlucose(defaults: defaults, fallback: 4.0), 4.0)
+        XCTAssertEqual(ThresholdResolver.staleMinutes(defaults: defaults, fallback: 30), 30)
+        XCTAssertEqual(ThresholdResolver.carbGraceHour(defaults: defaults, fallback: 9), 9)
+        XCTAssertEqual(ThresholdResolver.carbGraceMinute(defaults: defaults, fallback: 30), 30)
+    }
+
+    func testFallbackUsedWhenDefaultsIsNil() {
+        XCTAssertEqual(ThresholdResolver.highGlucose(defaults: nil, fallback: 9.5), 9.5)
+        XCTAssertEqual(ThresholdResolver.lowGlucose(defaults: nil, fallback: 4.0), 4.0)
+        XCTAssertEqual(ThresholdResolver.staleMinutes(defaults: nil, fallback: 30), 30)
+        XCTAssertEqual(ThresholdResolver.carbGraceHour(defaults: nil, fallback: 9), 9)
+        XCTAssertEqual(ThresholdResolver.carbGraceMinute(defaults: nil, fallback: 30), 30)
+    }
+
+    // MARK: - Override present → override wins
+
+    func testOverrideUsedWhenSet() {
+        defaults.set(8.5, forKey: ThresholdResolver.highGlucoseKey)
+        defaults.set(3.5, forKey: ThresholdResolver.lowGlucoseKey)
+        defaults.set(45, forKey: ThresholdResolver.staleMinutesKey)
+        defaults.set(7, forKey: ThresholdResolver.carbGraceHourKey)
+        defaults.set(15, forKey: ThresholdResolver.carbGraceMinuteKey)
+
+        XCTAssertEqual(ThresholdResolver.highGlucose(defaults: defaults, fallback: 9.5), 8.5)
+        XCTAssertEqual(ThresholdResolver.lowGlucose(defaults: defaults, fallback: 4.0), 3.5)
+        XCTAssertEqual(ThresholdResolver.staleMinutes(defaults: defaults, fallback: 30), 45)
+        XCTAssertEqual(ThresholdResolver.carbGraceHour(defaults: defaults, fallback: 9), 7)
+        XCTAssertEqual(ThresholdResolver.carbGraceMinute(defaults: defaults, fallback: 30), 15)
+    }
+
+    /// Exact reproduction of the issue-#77 scenario: the user pulls the high
+    /// threshold below the current glucose value. Before the fix, every
+    /// surface except `ShieldManager` ignored the override and kept comparing
+    /// against the xcconfig default — so the home icon stayed green while
+    /// shields were armed. With the resolver, the same comparison the user
+    /// runs in their head ("8.0 mmol/L > new high threshold 6.5") returns
+    /// true via every call site.
+    func testIssue77Scenario_lowerHighThresholdBelowCurrentGlucose() {
+        let xcconfigHigh = 9.5
+        let userOverride = 6.5
+        let currentGlucose = 8.0
+
+        XCTAssertGreaterThan(currentGlucose, userOverride)
+        XCTAssertLessThan(currentGlucose, xcconfigHigh)
+
+        defaults.set(userOverride, forKey: ThresholdResolver.highGlucoseKey)
+
+        let resolved = ThresholdResolver.highGlucose(defaults: defaults, fallback: xcconfigHigh)
+        XCTAssertEqual(resolved, userOverride)
+        XCTAssertTrue(currentGlucose > resolved, "Glucose must register as 'high' against the user override.")
+    }
+
+    /// `effectiveX` accessors on `SharedDataManager` (App target only) plus
+    /// the local resolver duplicates in `ShieldAction` and
+    /// `DeviceActivityMonitor` all use the same key strings. If they ever
+    /// diverge from `ThresholdResolver`, the App Group write/read pair
+    /// silently breaks. Pin the keys.
+    func testKeyStringsMatchAppGroupContract() {
+        XCTAssertEqual(ThresholdResolver.highGlucoseKey, "highGlucoseThreshold")
+        XCTAssertEqual(ThresholdResolver.lowGlucoseKey, "lowGlucoseThreshold")
+        XCTAssertEqual(ThresholdResolver.staleMinutesKey, "glucoseStaleMinutes")
+        XCTAssertEqual(ThresholdResolver.carbGraceHourKey, "carbGraceHour")
+        XCTAssertEqual(ThresholdResolver.carbGraceMinuteKey, "carbGraceMinute")
+    }
+}

--- a/iOS/ShieldAction/ShieldActionExtension.swift
+++ b/iOS/ShieldAction/ShieldActionExtension.swift
@@ -2,6 +2,31 @@ import Foundation
 import ManagedSettings
 import os
 
+/// Duplicate of `SharedKit.ThresholdResolver` — this extension does not link
+/// SharedKit (kept lean per the extension memory cap), so the contract is
+/// re-stated locally. Keep in sync with SharedKit/ThresholdResolver.swift.
+private enum ThresholdResolver {
+    static func highGlucose(defaults: UserDefaults?, fallback: Double) -> Double {
+        (defaults?.object(forKey: "highGlucoseThreshold") as? Double) ?? fallback
+    }
+
+    static func lowGlucose(defaults: UserDefaults?, fallback: Double) -> Double {
+        (defaults?.object(forKey: "lowGlucoseThreshold") as? Double) ?? fallback
+    }
+
+    static func staleMinutes(defaults: UserDefaults?, fallback: Int) -> Int {
+        (defaults?.object(forKey: "glucoseStaleMinutes") as? Int) ?? fallback
+    }
+
+    static func carbGraceHour(defaults: UserDefaults?, fallback: Int) -> Int {
+        (defaults?.object(forKey: "carbGraceHour") as? Int) ?? fallback
+    }
+
+    static func carbGraceMinute(defaults: UserDefaults?, fallback: Int) -> Int {
+        (defaults?.object(forKey: "carbGraceMinute") as? Int) ?? fallback
+    }
+}
+
 class ShieldActionExtension: ShieldActionDelegate {
     private static let bundlePrefix = Bundle.main.object(forInfoDictionaryKey: "BundlePrefix") as! String
     private static let appGroupID = Bundle.main.object(forInfoDictionaryKey: "AppGroupID") as! String
@@ -34,11 +59,17 @@ class ShieldActionExtension: ShieldActionDelegate {
         let carbDate = defaults?.string(forKey: "lastCarbEntryAt")
             .flatMap { ISO8601DateFormatter().date(from: $0) }
 
-        let highThreshold = Double(Bundle.main.object(forInfoDictionaryKey: "HighGlucoseThreshold") as! String)!
-        let lowThreshold = Double(Bundle.main.object(forInfoDictionaryKey: "LowGlucoseThreshold") as! String)!
-        let staleMinutes = Int(Bundle.main.object(forInfoDictionaryKey: "GlucoseStaleMinutes") as! String)!
-        let carbGraceHour = Int(Bundle.main.object(forInfoDictionaryKey: "CarbGraceHour") as! String)!
-        let carbGraceMinute = Int(Bundle.main.object(forInfoDictionaryKey: "CarbGraceMinute") as! String)!
+        let fallbackHigh = Double(Bundle.main.object(forInfoDictionaryKey: "HighGlucoseThreshold") as! String)!
+        let fallbackLow = Double(Bundle.main.object(forInfoDictionaryKey: "LowGlucoseThreshold") as! String)!
+        let fallbackStale = Int(Bundle.main.object(forInfoDictionaryKey: "GlucoseStaleMinutes") as! String)!
+        let fallbackGraceHour = Int(Bundle.main.object(forInfoDictionaryKey: "CarbGraceHour") as! String)!
+        let fallbackGraceMinute = Int(Bundle.main.object(forInfoDictionaryKey: "CarbGraceMinute") as! String)!
+
+        let highThreshold = ThresholdResolver.highGlucose(defaults: defaults, fallback: fallbackHigh)
+        let lowThreshold = ThresholdResolver.lowGlucose(defaults: defaults, fallback: fallbackLow)
+        let staleMinutes = ThresholdResolver.staleMinutes(defaults: defaults, fallback: fallbackStale)
+        let carbGraceHour = ThresholdResolver.carbGraceHour(defaults: defaults, fallback: fallbackGraceHour)
+        let carbGraceMinute = ThresholdResolver.carbGraceMinute(defaults: defaults, fallback: fallbackGraceMinute)
 
         let now = Date()
         let cal = Calendar.current

--- a/iOS/ShieldConfig/ShieldConfigurationExtension.swift
+++ b/iOS/ShieldConfig/ShieldConfigurationExtension.swift
@@ -6,11 +6,13 @@ import UIKit
 
 class ShieldConfigurationExtension: ShieldConfigurationDataSource {
     private static let appGroupID = Bundle.main.object(forInfoDictionaryKey: "AppGroupID") as! String
-    private static let highGlucoseThreshold = Double(Bundle.main.object(forInfoDictionaryKey: "HighGlucoseThreshold") as! String)!
-    private static let lowGlucoseThreshold = Double(Bundle.main.object(forInfoDictionaryKey: "LowGlucoseThreshold") as! String)!
-    private static let glucoseStaleMinutes = Int(Bundle.main.object(forInfoDictionaryKey: "GlucoseStaleMinutes") as! String)!
-    private static let carbGraceHour = Int(Bundle.main.object(forInfoDictionaryKey: "CarbGraceHour") as! String)!
-    private static let carbGraceMinute = Int(Bundle.main.object(forInfoDictionaryKey: "CarbGraceMinute") as! String)!
+    /// xcconfig fallbacks — the resolver picks user override or these,
+    /// per render, so settings changes show up in the shield UI.
+    private static let fallbackHighGlucose = Double(Bundle.main.object(forInfoDictionaryKey: "HighGlucoseThreshold") as! String)!
+    private static let fallbackLowGlucose = Double(Bundle.main.object(forInfoDictionaryKey: "LowGlucoseThreshold") as! String)!
+    private static let fallbackStaleMinutes = Int(Bundle.main.object(forInfoDictionaryKey: "GlucoseStaleMinutes") as! String)!
+    private static let fallbackCarbGraceHour = Int(Bundle.main.object(forInfoDictionaryKey: "CarbGraceHour") as! String)!
+    private static let fallbackCarbGraceMinute = Int(Bundle.main.object(forInfoDictionaryKey: "CarbGraceMinute") as! String)!
 
     override func configuration(shielding application: Application) -> ShieldConfiguration {
         makeConfiguration()
@@ -47,11 +49,11 @@ class ShieldConfigurationExtension: ShieldConfigurationDataSource {
             glucoseFetchedAt: glucoseDate,
             lastCarbGrams: carbGrams > 0 ? carbGrams : nil,
             lastCarbEntryAt: carbDate,
-            highGlucoseThreshold: Self.highGlucoseThreshold,
-            lowGlucoseThreshold: Self.lowGlucoseThreshold,
-            glucoseStaleMinutes: Self.glucoseStaleMinutes,
-            carbGraceHour: Self.carbGraceHour,
-            carbGraceMinute: Self.carbGraceMinute,
+            highGlucoseThreshold: ThresholdResolver.highGlucose(defaults: defaults, fallback: Self.fallbackHighGlucose),
+            lowGlucoseThreshold: ThresholdResolver.lowGlucose(defaults: defaults, fallback: Self.fallbackLowGlucose),
+            glucoseStaleMinutes: ThresholdResolver.staleMinutes(defaults: defaults, fallback: Self.fallbackStaleMinutes),
+            carbGraceHour: ThresholdResolver.carbGraceHour(defaults: defaults, fallback: Self.fallbackCarbGraceHour),
+            carbGraceMinute: ThresholdResolver.carbGraceMinute(defaults: defaults, fallback: Self.fallbackCarbGraceMinute),
             glucoseUnit: unit,
             customChecks: customChecks,
             strings: .fromPackage()

--- a/iOS/StatusWidget/StatusWidget.swift
+++ b/iOS/StatusWidget/StatusWidget.swift
@@ -28,11 +28,13 @@ struct StatusWidgetIntent: WidgetConfigurationIntent {
 
 private enum EntryBuilder {
     static let appGroupID = Bundle.main.object(forInfoDictionaryKey: "AppGroupID") as! String
-    static let highGlucoseThreshold = Double(Bundle.main.object(forInfoDictionaryKey: "HighGlucoseThreshold") as! String)!
-    static let lowGlucoseThreshold = Double(Bundle.main.object(forInfoDictionaryKey: "LowGlucoseThreshold") as! String)!
-    static let glucoseStaleMinutes = Int(Bundle.main.object(forInfoDictionaryKey: "GlucoseStaleMinutes") as! String)!
-    static let carbGraceHour = Int(Bundle.main.object(forInfoDictionaryKey: "CarbGraceHour") as! String)!
-    static let carbGraceMinute = Int(Bundle.main.object(forInfoDictionaryKey: "CarbGraceMinute") as! String)!
+    /// xcconfig fallbacks for when no user override has been written to the
+    /// App Group yet. The resolver picks override-or-fallback per render.
+    static let fallbackHighGlucose = Double(Bundle.main.object(forInfoDictionaryKey: "HighGlucoseThreshold") as! String)!
+    static let fallbackLowGlucose = Double(Bundle.main.object(forInfoDictionaryKey: "LowGlucoseThreshold") as! String)!
+    static let fallbackStaleMinutes = Int(Bundle.main.object(forInfoDictionaryKey: "GlucoseStaleMinutes") as! String)!
+    static let fallbackCarbGraceHour = Int(Bundle.main.object(forInfoDictionaryKey: "CarbGraceHour") as! String)!
+    static let fallbackCarbGraceMinute = Int(Bundle.main.object(forInfoDictionaryKey: "CarbGraceMinute") as! String)!
 
     static func makeEntry(now: Date, metric: MetricType) -> StatusEntry {
         let defaults = UserDefaults(suiteName: appGroupID)
@@ -54,11 +56,11 @@ private enum EntryBuilder {
             glucoseFetchedAt: glucoseDate,
             lastCarbGrams: carbGrams > 0 ? carbGrams : nil,
             lastCarbEntryAt: carbDate,
-            highGlucoseThreshold: highGlucoseThreshold,
-            lowGlucoseThreshold: lowGlucoseThreshold,
-            glucoseStaleMinutes: glucoseStaleMinutes,
-            carbGraceHour: carbGraceHour,
-            carbGraceMinute: carbGraceMinute,
+            highGlucoseThreshold: ThresholdResolver.highGlucose(defaults: defaults, fallback: fallbackHighGlucose),
+            lowGlucoseThreshold: ThresholdResolver.lowGlucose(defaults: defaults, fallback: fallbackLowGlucose),
+            glucoseStaleMinutes: ThresholdResolver.staleMinutes(defaults: defaults, fallback: fallbackStaleMinutes),
+            carbGraceHour: ThresholdResolver.carbGraceHour(defaults: defaults, fallback: fallbackCarbGraceHour),
+            carbGraceMinute: ThresholdResolver.carbGraceMinute(defaults: defaults, fallback: fallbackCarbGraceMinute),
             glucoseUnit: unit,
             strings: strings,
             now: now

--- a/iOS/WatchShared/WatchDataManager.swift
+++ b/iOS/WatchShared/WatchDataManager.swift
@@ -4,11 +4,15 @@ import SharedKit
 enum WatchDataManager {
     private static let defaults = UserDefaults(suiteName: Constants.appGroupID)
 
-    private static let highGlucoseThreshold = Double(Bundle.main.object(forInfoDictionaryKey: "HighGlucoseThreshold") as! String)!
-    private static let lowGlucoseThreshold = Double(Bundle.main.object(forInfoDictionaryKey: "LowGlucoseThreshold") as! String)!
-    private static let glucoseStaleMinutes = Int(Bundle.main.object(forInfoDictionaryKey: "GlucoseStaleMinutes") as! String)!
-    private static let carbGraceHour = Int(Bundle.main.object(forInfoDictionaryKey: "CarbGraceHour") as! String)!
-    private static let carbGraceMinute = Int(Bundle.main.object(forInfoDictionaryKey: "CarbGraceMinute") as! String)!
+    /// xcconfig fallbacks. Watch resolution stays a 3-tier chain
+    /// (`bridgeContext > defaults > xcconfig`) — see `content(now:)` — so the
+    /// extra simulator-bridge layer is preserved on top of `ThresholdResolver`'s
+    /// defaults+fallback. This keeps Phase-5 / screenshot-harness flows working.
+    private static let fallbackHighGlucose = Double(Bundle.main.object(forInfoDictionaryKey: "HighGlucoseThreshold") as! String)!
+    private static let fallbackLowGlucose = Double(Bundle.main.object(forInfoDictionaryKey: "LowGlucoseThreshold") as! String)!
+    private static let fallbackStaleMinutes = Int(Bundle.main.object(forInfoDictionaryKey: "GlucoseStaleMinutes") as! String)!
+    private static let fallbackCarbGraceHour = Int(Bundle.main.object(forInfoDictionaryKey: "CarbGraceHour") as! String)!
+    private static let fallbackCarbGraceMinute = Int(Bundle.main.object(forInfoDictionaryKey: "CarbGraceMinute") as! String)!
 
     static var isMockModeEnabled: Bool {
         if let bridgeContext = SimulatorWatchBridge.loadContext(),
@@ -41,20 +45,15 @@ enum WatchDataManager {
             ?? .mmolL
 
         let high = (bridgeContext?["highGlucoseThreshold"] as? Double)
-            ?? defaults?.object(forKey: "highGlucoseThreshold") as? Double
-            ?? highGlucoseThreshold
+            ?? ThresholdResolver.highGlucose(defaults: defaults, fallback: fallbackHighGlucose)
         let low = (bridgeContext?["lowGlucoseThreshold"] as? Double)
-            ?? defaults?.object(forKey: "lowGlucoseThreshold") as? Double
-            ?? lowGlucoseThreshold
+            ?? ThresholdResolver.lowGlucose(defaults: defaults, fallback: fallbackLowGlucose)
         let stale = (bridgeContext?["glucoseStaleMinutes"] as? Int)
-            ?? defaults?.object(forKey: "glucoseStaleMinutes") as? Int
-            ?? glucoseStaleMinutes
+            ?? ThresholdResolver.staleMinutes(defaults: defaults, fallback: fallbackStaleMinutes)
         let graceHour = (bridgeContext?["carbGraceHour"] as? Int)
-            ?? defaults?.object(forKey: "carbGraceHour") as? Int
-            ?? carbGraceHour
+            ?? ThresholdResolver.carbGraceHour(defaults: defaults, fallback: fallbackCarbGraceHour)
         let graceMinute = (bridgeContext?["carbGraceMinute"] as? Int)
-            ?? defaults?.object(forKey: "carbGraceMinute") as? Int
-            ?? carbGraceMinute
+            ?? ThresholdResolver.carbGraceMinute(defaults: defaults, fallback: fallbackCarbGraceMinute)
         let customChecks = customChecks(from: bridgeContext) ?? AttentionScenario.loadCustomChecks(from: defaults)
 
         return ShieldContent(


### PR DESCRIPTION
## Summary

Closes #77. Settings that change attention thresholds (high / low / stale-minutes / carb-grace) only took effect inside `ShieldManager` (and `WatchDataManager`). Every other surface re-read xcconfig defaults from `Info.plist` and ignored the App Group override, so the home icon, status panel, app-icon badge, status widget, shield UI, shield-action evaluation, and DeviceActivityMonitor re-arm all kept comparing against the build-time defaults. Result: shields would arm correctly while the rest of the app still said \"all clear\".

This PR centralises the override-with-fallback into one helper so the next call site can't drift again.

## What changed

### New: `SharedKit.ThresholdResolver`

`iOS/SharedKit/Sources/SharedKit/ThresholdResolver.swift` — pure, no dependencies beyond Foundation:

\`\`\`swift
public enum ThresholdResolver {
    public static func highGlucose(defaults: UserDefaults?, fallback: Double) -> Double
    public static func lowGlucose(defaults: UserDefaults?, fallback: Double) -> Double
    public static func staleMinutes(defaults: UserDefaults?, fallback: Int) -> Int
    public static func carbGraceHour(defaults: UserDefaults?, fallback: Int) -> Int
    public static func carbGraceMinute(defaults: UserDefaults?, fallback: Int) -> Int
}
\`\`\`

Each helper returns the App Group override if present, otherwise the caller-supplied xcconfig fallback. Key strings are also exposed as `public static let *Key` constants so the App Group write/read pair has one source of truth.

### Migrated call sites

| File | Before | After |
|---|---|---|
| `iOS/App/SharedDataManager.swift` (new `effectiveX` accessors) | n/a | Wrap `ThresholdResolver` + `SettingsDefaults` so App-target callers stay one-liner |
| `iOS/App/SharedDataManager.swift` (`refreshAttentionBadge`) | xcconfig only — drove app icon badge | `effectiveHighGlucoseThreshold` etc. |
| `iOS/App/HomeView.swift` | `static let` xcconfig pinned at app launch — drove home icon + status panel | `data.effectiveX`, read per render |
| `iOS/App/ShieldManager.swift` (`needsAttention`) | Already correct (`?? SettingsDefaults`) | Routed through `effectiveX` for consistency |
| `iOS/StatusWidget/StatusWidget.swift` | xcconfig only — drove widget tint | `ThresholdResolver.x(defaults: appGroup, fallback: localXcconfig)` |
| `iOS/ShieldConfig/ShieldConfigurationExtension.swift` | xcconfig only — drove shield UI text | Same as widget |
| `iOS/ShieldAction/ShieldActionExtension.swift` | xcconfig only — drove shield action evaluation | Local `private enum ThresholdResolver` (see decision below) |
| `iOS/DeviceActivityMonitor/DeviceActivityMonitorExtension.swift` | xcconfig only — drove periodic re-arm decision | Local `private enum ThresholdResolver` (see decision below) |
| `iOS/WatchShared/WatchDataManager.swift` | `bridgeContext > defaults > xcconfig` (correct, but inlined) | Tail of chain delegates to `ThresholdResolver` so phone + watch agree |
| `iOS/App/SettingsView.swift` (`SettingsDefaults`) | xcconfig only | **Untouched on purpose** — these IS the fallback |

### Decisions worth flagging

1. **`ShieldAction` and `DeviceActivityMonitor` get a local resolver duplicate**, not a `SharedKit` import. The two extensions don't link `SharedKit` today, and `AGENTS.md` explicitly calls out that extensions need to stay lean for the iOS memory cap. Adding `SharedKit` would require pbxproj surgery without Xcode UI (the bridge has been flaky this session) for marginal benefit — the helper is five 1-line functions. Each duplicate carries a doc comment pointing back to `SharedKit/ThresholdResolver.swift` so a future rename is easy to keep in sync. Worth revisiting if any of these extensions ever grow enough that the import overhead disappears.

2. **`WatchDataManager` keeps its 3-tier chain** (`bridgeContext > defaults > xcconfig`). The simulator-bridge layer is the screenshot-harness override mechanism — flattening it would regress that flow. Only the `defaults > xcconfig` tail of each chain now delegates to `ThresholdResolver`, so the phone and watch use identical override semantics for real-device reads.

3. **`HomeView` previously cached the xcconfig values in `static let`s** pinned at first access (which on a real device is app launch). Even before #77, those constants meant a settings change in-session never affected `HomeView` until the next launch. The new code reads `data.effectiveX` per render so settings changes show up immediately.

### Tests

Added `iOS/SharedKit/Tests/SharedKitTests/ThresholdResolverTests.swift` with five tests pinning the contract:

- `testFallbackUsedWhenNoOverride` — empty App Group → all helpers return fallback.
- `testFallbackUsedWhenDefaultsIsNil` — nil suite → all helpers return fallback.
- `testOverrideUsedWhenSet` — override present → all helpers return override.
- `testIssue77Scenario_lowerHighThresholdBelowCurrentGlucose` — exact reproduction of the bug: lower high threshold below current glucose → \"needs attention\" registers via the resolved value.
- `testKeyStringsMatchAppGroupContract` — pins the App Group key strings so a future rename doesn't silently break the write/read pair across the inline duplicates in `ShieldAction` and `DeviceActivityMonitor`.

`Package.swift` declares `.macOS(.v13)` purely so the test target compiles on the host (`swift test`) without standing up an iOS Simulator. SharedKit isn't shipped to a macOS app.

## Test plan

- [x] **Build clean (xcodebuild):** \`xcodebuild -project iOS/App.xcodeproj -scheme App -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build\` → \`** BUILD SUCCEEDED **\`.
- [x] **Unit tests pass:** \`cd iOS/SharedKit && swift test\` → 5 tests, 0 failures.
- [ ] **Hardware verification (owner — device is connected this session):**
  1. Have shielding enabled with **Only when attention is needed** mode on, and a glucose value `G` showing on Home.
  2. Settings → Attention rules → set **High glucose threshold** to `G − 0.5` mmol/L.
  3. Confirm shields are armed (open a non-allowed app — the shield appears).
  4. Look at the GluWink **home screen**: the icon should now be **red** within seconds, status panel should list the breach item.
  5. Force-quit the app and re-open: red state persists.
  6. Repeat for **low threshold** (above `G`), **stale-minutes**, **carb-grace** — same expected behaviour.
  7. Shield UI text and Status widget should reflect user thresholds.
  8. Periodic shield re-arm via `DeviceActivityMonitor` should use user thresholds (visible at the next interval boundary, ≥ 15 minutes per `QUIRKS.md`).
  9. **No regression:** users who never opened Settings should still see xcconfig defaults applied.


Made with [Cursor](https://cursor.com)