### PR TITLE
refactor(shield): link SharedKit to extensions, drop ThresholdResolver duplicates

### DIFF
--- a/iOS/App.xcodeproj/project.pbxproj
+++ b/iOS/App.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		DBE056742F90EECF005A1419 /* SharedKit in Frameworks */ = {isa = PBXBuildFile; productRef = B2A67E1682675154AD1117EA /* SharedKit */; };
 		DBE056752F90EECF005A1419 /* SharedKit in Frameworks */ = {isa = PBXBuildFile; productRef = 4BA5AFC5A839CE49647F7997 /* SharedKit */; };
 		DBE056762F90EECF005A1419 /* SharedKit in Frameworks */ = {isa = PBXBuildFile; productRef = 2EFFC9355B4ACCC74A7332B1 /* SharedKit */; };
+		DB8110812F90EECF005A1419 /* SharedKit in Frameworks */ = {isa = PBXBuildFile; productRef = DB8110832F90EECF005A1419 /* SharedKit */; };
+		DB8110822F90EECF005A1419 /* SharedKit in Frameworks */ = {isa = PBXBuildFile; productRef = DB8110842F90EECF005A1419 /* SharedKit */; };
 		DBE4DB0A2F8CD6A6003E49C0 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DBE4DB092F8CD6A6003E49C0 /* WidgetKit.framework */; };
 		DBE4DB0C2F8CD6A6003E49C0 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DBE4DB0B2F8CD6A6003E49C0 /* SwiftUI.framework */; };
 		DBE4DB192F8CD6A7003E49C0 /* StatusWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = DBE4DB082F8CD6A6003E49C0 /* StatusWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -286,6 +288,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DB8110812F90EECF005A1419 /* SharedKit in Frameworks */,
 				DB30151F2F8A57FB008F9A4E /* ManagedSettings.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -294,6 +297,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DB8110822F90EECF005A1419 /* SharedKit in Frameworks */,
 				DB3015322F8A5814008F9A4E /* DeviceActivity.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -485,6 +489,9 @@
 				DB3015202F8A57FB008F9A4E /* ShieldAction */,
 			);
 			name = ShieldAction;
+			packageProductDependencies = (
+				DB8110832F90EECF005A1419 /* SharedKit */,
+			);
 			productName = ShieldAction;
 			productReference = DB30151E2F8A57FB008F9A4E /* ShieldAction.appex */;
 			productType = "com.apple.product-type.app-extension";
@@ -505,6 +512,9 @@
 				DB3015332F8A5814008F9A4E /* DeviceActivityMonitor */,
 			);
 			name = DeviceActivityMonitor;
+			packageProductDependencies = (
+				DB8110842F90EECF005A1419 /* SharedKit */,
+			);
 			productName = DeviceActivityMonitor;
 			productReference = DB3015302F8A5814008F9A4E /* DeviceActivityMonitor.appex */;
 			productType = "com.apple.product-type.app-extension";
@@ -1405,6 +1415,16 @@
 			productName = SharedKit;
 		};
 		D957BBF3E8CBC9DC370CF1EC /* SharedKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 92BBEB1D292F12C9BEF0E8C6 /* XCLocalSwiftPackageReference "SharedKit" */;
+			productName = SharedKit;
+		};
+		DB8110832F90EECF005A1419 /* SharedKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 92BBEB1D292F12C9BEF0E8C6 /* XCLocalSwiftPackageReference "SharedKit" */;
+			productName = SharedKit;
+		};
+		DB8110842F90EECF005A1419 /* SharedKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 92BBEB1D292F12C9BEF0E8C6 /* XCLocalSwiftPackageReference "SharedKit" */;
 			productName = SharedKit;

--- a/iOS/DeviceActivityMonitor/DeviceActivityMonitorExtension.swift
+++ b/iOS/DeviceActivityMonitor/DeviceActivityMonitorExtension.swift
@@ -3,40 +3,7 @@ import FamilyControls
 import Foundation
 import ManagedSettings
 import os
-
-/// Duplicate of `SharedKit.ThresholdResolver` — this extension does not link
-/// SharedKit (kept lean per the extension memory cap), so the contract is
-/// re-stated locally. Keep in sync with SharedKit/ThresholdResolver.swift.
-private enum ThresholdResolver {
-    static func highGlucose(defaults: UserDefaults?, fallback: Double) -> Double {
-        (defaults?.object(forKey: "highGlucoseThreshold") as? Double) ?? fallback
-    }
-
-    static func lowGlucose(defaults: UserDefaults?, fallback: Double) -> Double {
-        (defaults?.object(forKey: "lowGlucoseThreshold") as? Double) ?? fallback
-    }
-
-    /// Duplicate of SharedKit.ThresholdResolver.criticalGlucose — see that
-    /// file for the read-time contract. DeviceActivityMonitor does not make
-    /// dismissal decisions (that's ShieldAction's job), but the key is
-    /// resolved here anyway so re-arm heuristics stay in sync with the
-    /// rest of the attention pipeline and #81's refactor finds no drift.
-    static func criticalGlucose(defaults: UserDefaults?, fallback: Double) -> Double {
-        (defaults?.object(forKey: "criticalGlucoseThreshold") as? Double) ?? fallback
-    }
-
-    static func staleMinutes(defaults: UserDefaults?, fallback: Int) -> Int {
-        (defaults?.object(forKey: "glucoseStaleMinutes") as? Int) ?? fallback
-    }
-
-    static func carbGraceHour(defaults: UserDefaults?, fallback: Int) -> Int {
-        (defaults?.object(forKey: "carbGraceHour") as? Int) ?? fallback
-    }
-
-    static func carbGraceMinute(defaults: UserDefaults?, fallback: Int) -> Int {
-        (defaults?.object(forKey: "carbGraceMinute") as? Int) ?? fallback
-    }
-}
+import SharedKit
 
 class DeviceActivityMonitorExtension: DeviceActivityMonitor {
     private static let bundlePrefix = Bundle.main.object(forInfoDictionaryKey: "BundlePrefix") as! String

--- a/iOS/ShieldAction/ShieldActionExtension.swift
+++ b/iOS/ShieldAction/ShieldActionExtension.swift
@@ -1,35 +1,7 @@
 import Foundation
 import ManagedSettings
 import os
-
-/// Duplicate of `SharedKit.ThresholdResolver` — this extension does not link
-/// SharedKit (kept lean per the extension memory cap), so the contract is
-/// re-stated locally. Keep in sync with SharedKit/ThresholdResolver.swift.
-private enum ThresholdResolver {
-    static func highGlucose(defaults: UserDefaults?, fallback: Double) -> Double {
-        (defaults?.object(forKey: "highGlucoseThreshold") as? Double) ?? fallback
-    }
-
-    static func lowGlucose(defaults: UserDefaults?, fallback: Double) -> Double {
-        (defaults?.object(forKey: "lowGlucoseThreshold") as? Double) ?? fallback
-    }
-
-    static func criticalGlucose(defaults: UserDefaults?, fallback: Double) -> Double {
-        (defaults?.object(forKey: "criticalGlucoseThreshold") as? Double) ?? fallback
-    }
-
-    static func staleMinutes(defaults: UserDefaults?, fallback: Int) -> Int {
-        (defaults?.object(forKey: "glucoseStaleMinutes") as? Int) ?? fallback
-    }
-
-    static func carbGraceHour(defaults: UserDefaults?, fallback: Int) -> Int {
-        (defaults?.object(forKey: "carbGraceHour") as? Int) ?? fallback
-    }
-
-    static func carbGraceMinute(defaults: UserDefaults?, fallback: Int) -> Int {
-        (defaults?.object(forKey: "carbGraceMinute") as? Int) ?? fallback
-    }
-}
+import SharedKit
 
 class ShieldActionExtension: ShieldActionDelegate {
     private static let bundlePrefix = Bundle.main.object(forInfoDictionaryKey: "BundlePrefix") as! String


### PR DESCRIPTION
## Summary

- Removes the two `private enum ThresholdResolver` duplicates the `ShieldAction` and `DeviceActivityMonitor` extensions have been carrying since #77 / #79, replacing them with `import SharedKit`.
- Pure refactor — no behaviour change. `SharedKit.ThresholdResolver`'s public API already matches the duplicates call-for-call (same signatures, same fallback order, same keys).
- Completes the follow-up surfaced in PR #79's "decisions worth revisiting" section.

## Changes

- Link `SharedKit` from the `ShieldAction` and `DeviceActivityMonitor` targets in `iOS/App.xcodeproj/project.pbxproj` — mirrored the shape already used by `App` / `ShieldConfig` / `StatusWidgetExtension` / `WatchApp` / `WatchWidget` (PBXBuildFile entry + PBXFrameworksBuildPhase reference + `packageProductDependencies` on the target + `XCSwiftPackageProductDependency` record).
- Added `import SharedKit` to `ShieldActionExtension.swift` and `DeviceActivityMonitorExtension.swift`.
- Deleted the local `private enum ThresholdResolver` blocks (≈ 30 lines in each extension). Call sites were already `ThresholdResolver.foo(...)` and resolve to `SharedKit.ThresholdResolver` unchanged — no rewriting needed.

## Testing

- `xcodebuild -project iOS/App.xcodeproj -scheme ShieldAction -destination 'generic/platform=iOS' build` → **BUILD SUCCEEDED** (pulls the full dependency graph including App, ShieldConfig, ShieldAction, DeviceActivityMonitor, StatusWidgetExtension, WatchApp, WatchWidget).
- `xcodebuild -project iOS/App.xcodeproj -scheme DeviceActivityMonitor -destination 'generic/platform=iOS' build` → **BUILD SUCCEEDED**.
- `swift test --package-path iOS/SharedKit` → **12/12 passed**, including `testKeyStringsMatchAppGroupContract`.

### Extension binary sizes (Debug, iphoneos)

Comparable across all three SharedKit-linking extensions — SharedKit is statically linked via SPM (no separate framework), so the overhead is already amortised into each `.debug.dylib`. Memory cap headroom is fine.

| Extension | executable | `.debug.dylib` |
|---|---|---|
| `ShieldConfig.appex` (already linked SharedKit) | 89,664 B | 582,352 B |
| `ShieldAction.appex` (newly linked) | 89,664 B | 601,264 B |
| `DeviceActivityMonitor.appex` (newly linked) | 89,696 B | 631,888 B |

Extension memory caps are a runtime concern, not a binary-size one, but nothing here is conspicuously large — the new dylibs are within ~50 KB of the already-linking sibling. Runtime behaviour is owner-verified on device.

## Notes

- `testKeyStringsMatchAppGroupContract` is no longer the "safety net against duplicate drift" that #79 framed it as (there are no duplicates left to drift). The invariant it pins — App Group key strings match the `SharedKit` contract — is still worth having, so it stays.
- Out of scope: linking `SharedKit` from anywhere else. `ShieldConfig`, `StatusWidgetExtension`, `WatchApp`, and `WatchWidget` already link it; nothing else needs to.

Closes #81.
Refs #77, #79.

Made with [Cursor](https://cursor.com)