### PR TITLE
fix(ios): refresh attention badge from all data paths

### DIFF
--- a/iOS/App/App.swift
+++ b/iOS/App/App.swift
@@ -117,11 +117,18 @@ struct MainApp: App {
                         }
                     }
 
+                    // Reconcile the badge once startup settles. The HK and
+                    // Nightscout fetches above each refresh it on success, but
+                    // a denied / dataless install takes neither branch and
+                    // would otherwise launch with a stale badge inherited
+                    // from the previous session.
+                    await SharedDataManager.shared.refreshAttentionBadge()
+
                     WatchSessionManager.shared.sendLatestContext()
                 }
                 .onChange(of: scenePhase) {
                     if scenePhase == .active {
-                        Task {
+                        Task { @MainActor in
                             if HKHealthStore().authorizationStatus(for: HKQuantityType(.bloodGlucose)) != .notDetermined {
                                 await HealthKitManager.shared.fetchLatestGlucose()
                                 await HealthKitManager.shared.fetchLatestCarbs()
@@ -129,6 +136,12 @@ struct MainApp: App {
                             if SharedDataManager.shared.nightscoutEnabled {
                                 await NightscoutManager.shared.fetchAll()
                             }
+                            // Always reconcile on foreground — staleness and
+                            // carb-grace transitions cross thresholds on
+                            // wall-clock time alone, with no fetch event to
+                            // ride. Without this the badge only updates on
+                            // actual data changes.
+                            SharedDataManager.shared.refreshAttentionBadge()
                         }
                     } else if scenePhase == .background {
                         if SharedDataManager.shared.nightscoutEnabled {

--- a/iOS/App/HealthKitManager.swift
+++ b/iOS/App/HealthKitManager.swift
@@ -124,13 +124,17 @@ final class HealthKitManager {
                 SharedDataManager.shared.saveGlucose(mmol: mmol, at: sample.startDate)
                 SharedDataManager.shared.markHealthKitDelivered()
                 logger.info("Glucose updated: \(String(format: "%.1f", mmol)) mmol/L")
-                SharedDataManager.shared.refreshAttentionBadge()
                 ShieldManager.shared.reevaluateShields()
                 WidgetCenter.shared.reloadAllTimelines()
             }
         } catch {
             logger.error("Failed to fetch glucose: \(error.localizedDescription)")
         }
+
+        // Reconcile the badge unconditionally — a sample-free observer wake
+        // (no new data, denied read access) still means time has passed, so
+        // stale/carb-gap transitions must be re-evaluated or the badge drifts.
+        await SharedDataManager.shared.refreshAttentionBadge()
 
         // Piggyback: when HealthKit wakes us up (including background delivery),
         // also poll Nightscout so the two sources stay aligned. "Save if newer"
@@ -157,13 +161,14 @@ final class HealthKitManager {
                 SharedDataManager.shared.saveCarbs(grams: grams, at: sample.startDate)
                 SharedDataManager.shared.markHealthKitDelivered()
                 logger.info("Carbs updated: \(String(format: "%.0f", grams))g")
-                SharedDataManager.shared.refreshAttentionBadge()
                 ShieldManager.shared.reevaluateShields()
                 WidgetCenter.shared.reloadAllTimelines()
             }
         } catch {
             logger.error("Failed to fetch carbs: \(error.localizedDescription)")
         }
+
+        await SharedDataManager.shared.refreshAttentionBadge()
 
         await NightscoutManager.shared.fetchAll()
     }

--- a/iOS/App/SettingsView.swift
+++ b/iOS/App/SettingsView.swift
@@ -1,6 +1,7 @@
 import FamilyControls
 import SharedKit
 import SwiftUI
+import UserNotifications
 import WidgetKit
 
 // MARK: - Shared defaults
@@ -76,6 +77,12 @@ struct SettingsView: View {
                             SharedDataManager.shared.glucoseUnit = newValue
                             SharedDataManager.shared.flush()
                             WidgetCenter.shared.reloadAllTimelines()
+                            // The badge renders the glucose number in the
+                            // display unit, so a unit flip must re-run the
+                            // badge recompute — otherwise `.always` mode
+                            // keeps showing the value in the old unit until
+                            // the next fetch.
+                            SharedDataManager.shared.refreshAttentionBadge()
                         }
                     )) {
                         Text("mmol/L").tag(GlucoseUnit.mmolL)
@@ -212,9 +219,33 @@ struct SettingsView: View {
             }
             .onChange(of: badgeMode) {
                 SharedDataManager.shared.glucoseBadgeMode = badgeMode
-                SharedDataManager.shared.refreshAttentionBadge()
+                // `setBadgeCount` silently no-ops without notification auth,
+                // so a user who picks a non-`.off` mode here without having
+                // done the setup-checklist prompt would see no badge at all.
+                // Request auth inline; iOS surfaces its own system sheet
+                // and remembers prior answers, so re-prompting is cheap.
+                if badgeMode != .off {
+                    Task { @MainActor in
+                        await Self.ensureBadgeAuthorization()
+                        SharedDataManager.shared.refreshAttentionBadge()
+                    }
+                } else {
+                    SharedDataManager.shared.refreshAttentionBadge()
+                }
             }
         }
+    }
+
+    /// Request notification authorization with the badge bit if the user
+    /// hasn't been prompted yet. No-op once the user has made a choice
+    /// (granted or denied) — iOS no longer shows the sheet after the
+    /// first response, so re-asking is harmless but also pointless.
+    @MainActor
+    private static func ensureBadgeAuthorization() async {
+        let center = UNUserNotificationCenter.current()
+        let settings = await center.notificationSettings()
+        guard settings.authorizationStatus == .notDetermined else { return }
+        _ = try? await center.requestAuthorization(options: [.alert, .badge, .sound])
     }
 }
 

--- a/iOS/App/SharedDataManager.swift
+++ b/iOS/App/SharedDataManager.swift
@@ -74,40 +74,29 @@ final class SharedDataManager {
     /// green/orange/red variants (`AppIcon-Green`, `AppIcon-Orange`, `AppIcon-Red`) are only used by
     /// surfaces we can pick at render time (shield UI, in-app screens, future
     /// notification attachments).
+    ///
+    /// Attention is computed by delegating to `ShieldContent` so the badge,
+    /// the shield extension, the widgets, and the home screen agree on the
+    /// ladder. Duplicate ladders previously drifted (e.g. "no carb data ever"
+    /// was attention in `ShieldContent` but not in the badge).
     @MainActor
     func refreshAttentionBadge() {
-        let glucose = defaults?.double(forKey: "currentGlucose") ?? 0
-        let glucoseDate = defaults?.string(forKey: "glucoseFetchedAt")
-            .flatMap { ISO8601DateFormatter().date(from: $0) }
-        let carbDate = defaults?.string(forKey: "lastCarbEntryAt")
-            .flatMap { ISO8601DateFormatter().date(from: $0) }
-
-        let highThreshold = effectiveHighGlucoseThreshold
-        let lowThreshold = effectiveLowGlucoseThreshold
-        let staleMinutes = effectiveGlucoseStaleMinutes
-        let carbGraceHour = effectiveCarbGraceHour
-        let carbGraceMinute = effectiveCarbGraceMinute
-
-        let now = Date()
-        let cal = Calendar.current
-        let currentHour = cal.component(.hour, from: now)
-        let currentMin = cal.component(.minute, from: now)
-        let isMorningGrace = currentHour < carbGraceHour
-            || (currentHour == carbGraceHour && currentMin < carbGraceMinute)
-
-        var needsAttention = false
-        if glucose > 0, let gDate = glucoseDate {
-            let minutesAgo = Int(now.timeIntervalSince(gDate) / 60)
-            if glucose < lowThreshold || glucose > highThreshold { needsAttention = true }
-            if minutesAgo > staleMinutes { needsAttention = true }
-        } else {
-            needsAttention = true
-        }
-        if !isMorningGrace, let cDate = carbDate, now.timeIntervalSince(cDate) / 3600 > 4 {
-            needsAttention = true
-        }
-
-        updateBadge(glucose: glucose, needsAttention: needsAttention)
+        let glucose = currentGlucose ?? 0
+        let content = ShieldContent(
+            glucose: glucose,
+            glucoseFetchedAt: glucoseFetchedAt,
+            lastCarbGrams: lastCarbGrams,
+            lastCarbEntryAt: lastCarbEntryAt,
+            highGlucoseThreshold: effectiveHighGlucoseThreshold,
+            lowGlucoseThreshold: effectiveLowGlucoseThreshold,
+            criticalGlucoseThreshold: effectiveCriticalGlucoseThreshold,
+            glucoseStaleMinutes: effectiveGlucoseStaleMinutes,
+            carbGraceHour: effectiveCarbGraceHour,
+            carbGraceMinute: effectiveCarbGraceMinute,
+            glucoseUnit: glucoseUnit,
+            strings: ShieldContent.Strings.fromPackage()
+        )
+        updateBadge(glucose: glucose, needsAttention: content.needsAttention)
     }
 
     @MainActor

--- a/iOS/SharedKit/Tests/SharedKitTests/ShieldContentAttentionTests.swift
+++ b/iOS/SharedKit/Tests/SharedKitTests/ShieldContentAttentionTests.swift
@@ -1,0 +1,153 @@
+import Foundation
+import XCTest
+@testable import SharedKit
+
+/// Pins the `needsAttention` contract that `SharedDataManager.refreshAttentionBadge`
+/// delegates to. Before issue #4 the badge had its own attention ladder that
+/// diverged from `ShieldContent` (e.g. "no carb data ever" didn't flip the
+/// badge), which left the app icon silently out of sync with the shield and
+/// widgets. These tests lock the ladder so the next drift fails fast.
+final class ShieldContentAttentionTests: XCTestCase {
+    // MARK: - Fixture
+
+    private let strings = ShieldContent.Strings(
+        positiveTitles: ["clear"],
+        attentionTitles: ["attention"],
+        doneButton: "Done",
+        checkInButton: "I will",
+        criticalCannotDismiss: "Cannot dismiss until below %@",
+        openAppTo: "Open app to:",
+        glucose: "%@ · %@ (%@ ago)",
+        glucoseNoData: "No glucose data",
+        carbsEntry: "%d g · %@ (%@ ago)",
+        carbsNoData: "No carb data",
+        agoMinutes: "%dm",
+        agoHoursMinutes: "%dh %dm",
+        scenarioChecks: [:]
+    )
+
+    /// Fixed reference date inside the morning grace window (before 09:30,
+    /// the xcconfig default). Keeping it at 08:00 local time means the
+    /// "no carb data" assertions aren't accidentally passing because the
+    /// carb-gap rule kicked in.
+    private var morning: Date {
+        var comps = DateComponents()
+        comps.year = 2026; comps.month = 4; comps.day = 25
+        comps.hour = 8; comps.minute = 0
+        return Calendar.current.date(from: comps)!
+    }
+
+    private func make(
+        glucose: Double = 6.5,
+        glucoseFetchedAt: Date?,
+        lastCarbGrams: Double? = 20,
+        lastCarbEntryAt: Date?,
+        now: Date
+    ) -> ShieldContent {
+        ShieldContent(
+            glucose: glucose,
+            glucoseFetchedAt: glucoseFetchedAt,
+            lastCarbGrams: lastCarbGrams,
+            lastCarbEntryAt: lastCarbEntryAt,
+            highGlucoseThreshold: 14.0,
+            lowGlucoseThreshold: 4.0,
+            criticalGlucoseThreshold: 20.0,
+            glucoseStaleMinutes: 30,
+            carbGraceHour: 9,
+            carbGraceMinute: 30,
+            glucoseUnit: .mmolL,
+            strings: strings,
+            now: now
+        )
+    }
+
+    // MARK: - Clear
+
+    func testClearWhenFreshGlucoseAndRecentCarbs() {
+        let now = morning
+        let content = make(
+            glucoseFetchedAt: now.addingTimeInterval(-5 * 60),
+            lastCarbEntryAt: now.addingTimeInterval(-30 * 60),
+            now: now
+        )
+        XCTAssertFalse(content.needsAttention)
+        XCTAssertEqual(content.attentionLevel, .clear)
+    }
+
+    // MARK: - Attention (the badge must match these)
+
+    func testNoCarbDataEverIsAttention() {
+        let now = morning
+        let content = make(
+            glucoseFetchedAt: now.addingTimeInterval(-5 * 60),
+            lastCarbGrams: nil,
+            lastCarbEntryAt: nil,
+            now: now
+        )
+        XCTAssertTrue(
+            content.needsAttention,
+            "Missing carb history must flip the badge even during morning grace — the badge previously ignored this case."
+        )
+        XCTAssertEqual(content.attentionLevel, .attention)
+    }
+
+    func testStaleGlucoseCrossingThresholdIsAttention() {
+        let now = morning
+        let fresh = make(
+            glucoseFetchedAt: now.addingTimeInterval(-29 * 60),
+            lastCarbEntryAt: now.addingTimeInterval(-30 * 60),
+            now: now
+        )
+        XCTAssertFalse(fresh.needsAttention, "29m ago is still fresh at staleMinutes=30")
+
+        let stale = make(
+            glucoseFetchedAt: now.addingTimeInterval(-31 * 60),
+            lastCarbEntryAt: now.addingTimeInterval(-30 * 60),
+            now: now
+        )
+        XCTAssertTrue(stale.needsAttention, "31m ago crosses staleMinutes=30 and must flip the badge")
+        XCTAssertEqual(stale.attentionLevel, .attention)
+    }
+
+    func testCarbGapOutsideGraceIsAttention() {
+        var comps = DateComponents()
+        comps.year = 2026; comps.month = 4; comps.day = 25
+        comps.hour = 14; comps.minute = 0
+        let afternoon = Calendar.current.date(from: comps)!
+
+        let content = make(
+            glucoseFetchedAt: afternoon.addingTimeInterval(-5 * 60),
+            lastCarbEntryAt: afternoon.addingTimeInterval(-5 * 3600),
+            now: afternoon
+        )
+        XCTAssertTrue(content.needsAttention)
+        XCTAssertEqual(content.attentionLevel, .attention)
+    }
+
+    func testHighGlucoseIsAttention() {
+        let now = morning
+        let content = make(
+            glucose: 15.0,
+            glucoseFetchedAt: now.addingTimeInterval(-5 * 60),
+            lastCarbEntryAt: now.addingTimeInterval(-30 * 60),
+            now: now
+        )
+        XCTAssertTrue(content.needsAttention)
+        XCTAssertEqual(content.attentionLevel, .attention)
+    }
+
+    // MARK: - Critical
+
+    func testCriticalGlucoseIsCritical() {
+        let now = morning
+        let content = make(
+            glucose: 21.0,
+            glucoseFetchedAt: now.addingTimeInterval(-5 * 60),
+            lastCarbEntryAt: now.addingTimeInterval(-30 * 60),
+            now: now
+        )
+        XCTAssertTrue(content.needsAttention)
+        XCTAssertTrue(content.isCriticalGlucose)
+        XCTAssertEqual(content.attentionLevel, .critical)
+    }
+}


### PR DESCRIPTION
## Summary

- `SharedDataManager.refreshAttentionBadge` had its own hand-rolled attention ladder that drifted from `ShieldContent` (most visibly: "no carb data ever" was attention in the shield/widgets but not in the badge). It now delegates to `ShieldContent` so every surface agrees.
- Multiple code paths that change attention state didn't reach the badge: sample-free HealthKit observer wakes, app launch without new data, foregrounding after long idle, unit flips in Settings, and enabling `glucoseBadgeMode` after the setup-checklist auth prompt. Each is now wired up.
- `setBadgeCount` silently no-ops without notification authorization — if the user enables the badge from Settings without having accepted the setup-checklist prompt, we now request auth inline.

## Changes

- `iOS/App/SharedDataManager.swift` — `refreshAttentionBadge` delegates to `ShieldContent.needsAttention`.
- `iOS/App/HealthKitManager.swift` — move `refreshAttentionBadge()` calls *out* of the `if let sample = …` blocks so sample-free observer wakes still reconcile time-based transitions (staleness, carb grace boundary).
- `iOS/App/App.swift` — refresh the badge explicitly at the end of the startup `.task` and after the `.active` scenePhase fetch batch. Wraps `.active` `Task` in `@MainActor` so the new refresh call doesn't hop threads.
- `iOS/App/SettingsView.swift` — refresh the badge when `glucoseUnit` or `glucoseBadgeMode` change; request notification authorization (`.alert .badge .sound`) on the first non-`.off` flip if authorization is still `.notDetermined`.
- `iOS/SharedKit/Tests/SharedKitTests/ShieldContentAttentionTests.swift` — new unit tests pinning the six scenarios the badge now inherits from `ShieldContent` (clear, high, critical, stale, carb-gap outside grace, no-carb-data-ever).

## Testing

- `xcodebuild -project iOS/App.xcodeproj -scheme App -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build` → **BUILD SUCCEEDED**, no new warnings.
- `swift test --package-path iOS/SharedKit` → 18 tests passing (6 new).
- No simulator run: per AGENTS.md, Screen Time + background delivery don't run in the simulator, and this is a timing/race bug so simulator observation is unreliable.

### Needs verification on device

This PR is drafted because the bug is inherently timing-dependent and only manifests on physical hardware. Please verify:

1. **Background refresh while idle** — leave the phone idle with a fresh sensor, wait for a new CGM reading to arrive via HealthKit background delivery, confirm the badge transitions to/from the attention number without opening the app.
2. **Stale-sensor transition** — detach the sensor, wait out `glucoseStaleMinutes`, open the app briefly to trigger `.active`, confirm the badge now reflects attention (was previously blind to time-only transitions on a sample-free wake).
3. **Settings badge toggle** — on an install that never accepted the notification prompt (fresh install or denied-then-reset), flip `glucoseBadgeMode` from `.off` to `.onlyWhenAttention`. The iOS notification permission sheet should appear once; grant and confirm the badge appears.
4. **Unit flip** — in `.always` mode, change `glucoseUnit` and confirm the badge number updates immediately to the new unit instead of waiting for the next CGM reading.

Closes #4

Made with [Cursor](https://cursor.com)