### PR TITLE
fix(build): isolate subagent DerivedData and clean-build by default

### DIFF
--- a/.claude/skills/plan-next/SKILL.md
+++ b/.claude/skills/plan-next/SKILL.md
@@ -176,11 +176,20 @@ The prompt **must** include:
 - **Build verification:** prefer the Xcode MCP `BuildProject` tool
   (requires Xcode open and a `tabIdentifier` from `XcodeListWindows`).
   Fallback if the MCP server is unavailable:
-  `xcodebuild -project iOS/App.xcodeproj -scheme App -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build`.
-  See AGENTS.md → "Xcode MCP Server" for the full tool table. **Note
-  the project is `iOS/App.xcodeproj` and the scheme is `App`** — the
-  product name is GluWink but the Xcode artifacts are deliberately
-  neutral (see AGENTS.md → "Renaming the App").
+  `xcodebuild -project iOS/App.xcodeproj -scheme App -derivedDataPath "$(mktemp -d)/dd" -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build`.
+  The `-derivedDataPath` is non-negotiable: DerivedData is keyed per
+  project-path, so every worktree shares the same `App-XXXXXX` entry
+  with the owner's main checkout. A bare `xcodebuild … build` here
+  writes an unsigned simulator-arch bundle into that shared entry,
+  and the next `make build` in the owner's checkout does an
+  incremental rebuild that inherits the stale unsigned metadata —
+  `devicectl install` then rejects it (issue #82). The MCP
+  `BuildProject` tool doesn't need this flag because it uses Xcode's
+  destination-appropriate DerivedData. See AGENTS.md → "Xcode MCP
+  Server" for the full tool table. **Note the project is
+  `iOS/App.xcodeproj` and the scheme is `App`** — the product name
+  is GluWink but the Xcode artifacts are deliberately neutral (see
+  AGENTS.md → "Renaming the App").
 - **PR readiness** (per AGENTS.md → "Draft vs ready"): if the work is
   verified (build clean, behaviour confirmed where possible), open the
   PR as **ready** —

--- a/Makefile
+++ b/Makefile
@@ -42,11 +42,17 @@ cursor-perms-sync:
 
 .PHONY: build install deploy tunneld screenshot venv-clean
 
-## Build debug configuration (fallback — prefer Xcode MCP BuildProject)
+## Build debug configuration (fallback — prefer Xcode MCP BuildProject).
+## Runs `clean build` rather than a bare `build` so we can never inherit a
+## stale, unsigned, simulator-arch bundle from an earlier verification run
+## that wrote into the shared DerivedData entry (see QUIRKS.md → "Shared
+## DerivedData can produce unsigned device builds"). Costs ~30s vs a ~5s
+## no-op incremental — acceptable because this is the fallback path; the
+## inner loop is the Xcode MCP BuildProject tool.
 build:
 	xcodebuild -project $(XCODE_PROJECT) -scheme $(SCHEME) \
 		-destination 'generic/platform=iOS' \
-		-configuration Debug build
+		-configuration Debug clean build
 
 ## Install the last build on the connected iPhone
 install:

--- a/QUIRKS.md
+++ b/QUIRKS.md
@@ -72,6 +72,11 @@ When a view has many `.onChange(of:)` handlers that all call the same save funct
 
 ## Xcode / Build
 
+### Shared DerivedData can produce unsigned device builds
+DerivedData is keyed per project-path, so every worktree of `iOS/App.xcodeproj` shares the same `App-XXXXXX` entry with the main checkout. If a subagent (or anyone) runs `xcodebuild … build` against an iOS Simulator destination in a worktree, it writes an unsigned simulator-arch bundle into that shared entry. A subsequent `make build` in the owner's checkout targeting a real device then does an **incremental rebuild** — recompiles changed sources, copies the new code into the existing `App.app` bundle, but does not re-sign because nothing asked it to. `devicectl install` rejects the result with `0xe8008014 (The executable contains an invalid signature.)` even though `** BUILD SUCCEEDED **` just printed. Diagnosed on 2026-04-26 while deploying #77 (issue #82).
+
+Two guards in the repo today: `.claude/skills/plan-next/SKILL.md` dispatches subagents with `-derivedDataPath "$(mktemp -d)/dd"` so they can never touch the shared entry, and `make build` runs `clean build` by default so it's immune to any cross-contamination that does slip in. If you hit the invalid-signature error on an older worktree that ran before those landed, the one-shot fix is a manual `xcodebuild -project iOS/App.xcodeproj -scheme App -destination 'generic/platform=iOS' -configuration Debug clean build` in that worktree.
+
 ### fileSystemSynchronizedGroups
 Files must be physically inside the synced folder to auto-compile for that target. `ShieldContent.swift` lives in `App/` (auto-compiled for main app) but has manual target membership for ShieldConfig.
 


### PR DESCRIPTION
## Summary

Fixes #82 — `make install` was failing with `0xe8008014 (invalid signature)` right after a clean `make build` reported `** BUILD SUCCEEDED **`. Surfaced while deploying #77 (PR #79) for hardware verification.

## Root cause

DerivedData is keyed per project-path, so every worktree of `iOS/App.xcodeproj` shares the same `App-XXXXXX` entry with the owner's main checkout. When a `plan-next` subagent ran `xcodebuild … build` against an iOS Simulator destination in its worktree, it wrote an unsigned simulator-arch bundle into that shared entry. The subsequent `make build` in the owner's checkout (real-device destination, normal signing) did an **incremental rebuild**: recompiled the changed sources, copied them into the existing `App.app`, but did not re-sign — nothing in the build settings asked it to. The bundle on disk then carried freshly-compiled code wrapped in stale unsigned-from-simulator metadata, and `devicectl install` rejected it.

Confirmed by: `xcodebuild … clean build` on the same worktree produced a properly signed binary that installed fine.

## Fixes

**1. Primary / structural — `.claude/skills/plan-next/SKILL.md`.**
The build-verification fallback snippet now passes `-derivedDataPath "$(mktemp -d)/dd"`, so subagents can never write into the shared DerivedData entry. The Xcode MCP `BuildProject` tool remains preferred and doesn't need the flag (it uses Xcode's destination-appropriate DerivedData); only the `xcodebuild` fallback does. Added a short in-line explanation with a reference to issue #82.

**2. Defence-in-depth — `Makefile`.**
`make build` now runs `xcodebuild … clean build` instead of a bare `build`. Costs ~30s vs ~5s for a no-op incremental; gain: immune to any cross-contamination that slips through the structural fix. `make build` is the fallback path (the inner loop is the Xcode MCP `BuildProject`), so the slow-but-correct trade-off is the right one. Existing flags/variables preserved; only `clean` was added before `build`. Comment above the recipe explains why.

**3. Documentation — `QUIRKS.md`.**
New "Shared DerivedData can produce unsigned device builds" entry under Xcode / Build. Describes the mechanism, the two in-repo guards, and the one-shot manual recovery (`xcodebuild … clean build` in the affected worktree) for older worktrees that predate these guards.

## Verification

- `make -n build` prints `xcodebuild … clean build` (verified outside the sandbox; inside the Cursor sandbox overlay it was showing a stale snapshot but the on-disk file is correct — diff is in the commit).
- No app code changes, so no `xcodebuild` run was necessary. The changed surface *is* the build tooling + a skill + a doc.
- No `CODE_SIGNING_ALLOWED=NO` references were present in the plan-next skill, so nothing to preserve on that front.

Closes #82

Made with [Cursor](https://cursor.com)