### PR TITLE
refactor(healthkit): use effectiveGlucoseStaleMinutes in deliveringRecently

### DIFF
--- a/iOS/App/SharedDataManager.swift
+++ b/iOS/App/SharedDataManager.swift
@@ -196,12 +196,12 @@ final class SharedDataManager {
     /// stale-but-non-nil timestamp left over from a since-disabled source
     /// can't masquerade as HK delivery.
     ///
-    /// Falls back to a 30-minute window when no user override is set so
-    /// we don't have to read `Info.plist` from extension bundles where
-    /// the key may not be present.
+    /// Honours the same override-with-xcconfig-fallback contract as every
+    /// other staleness check in the app (see `ThresholdResolver`): user
+    /// override wins, otherwise the build-time `GlucoseStaleMinutes` default.
     var healthKitDeliveringRecently: Bool {
         guard healthKitEverDelivered, let last = glucoseFetchedAt else { return false }
-        let minutes = glucoseStaleMinutes ?? 30
+        let minutes = effectiveGlucoseStaleMinutes
         return Date().timeIntervalSince(last) < TimeInterval(minutes * 60)
     }
 


### PR DESCRIPTION
## Summary

Tiny follow-up to PR #79. `SharedDataManager.healthKitDeliveringRecently` was still doing:

```swift
let minutes = glucoseStaleMinutes ?? 30
```

That literal `30` predated the `ThresholdResolver` work in #77, and once #79 added `effectiveGlucoseStaleMinutes` (delegates to `ThresholdResolver.staleMinutes` with the `SettingsDefaults.staleMinutes` xcconfig fallback) this call site became the odd one out. Every other staleness check in the app routes through the resolver — if the `GlucoseStaleMinutes` xcconfig default ever moves off 30, this spot would silently disagree with all of them.

## Change

One-line swap in `iOS/App/SharedDataManager.swift`:

- `let minutes = glucoseStaleMinutes ?? 30` → `let minutes = effectiveGlucoseStaleMinutes`
- Updated the adjacent doc comment so it describes the current contract (override-or-xcconfig-fallback) instead of the now-obsolete "hard-coded 30 so extensions don't need Info.plist" justification.

Observable behaviour is identical today: `GLUCOSE_STALE_MINUTES = 30` in `Config.xcconfig`, so with no user override the effective value is still 30. The guarantee that matters is structural — one source of truth for staleness, no drift if the default changes.

## Verification

- ✅ `cd iOS/SharedKit && swift test` — 18 / 18 pass, including `testIssue77Scenario_lowerHighThresholdBelowCurrentGlucose` and the rest of `ThresholdResolverTests`.
- ✅ `xcodebuild -project iOS/App.xcodeproj -scheme App -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -derivedDataPath <tmp> build` — `** BUILD SUCCEEDED **` (tmp derived-data dir per #82 guidance so no cross-contamination).
- No UI changes, no new strings, no behaviour change at current default.

## Out of scope

- Touching any other `?? <literal>` fallbacks — only `healthKitDeliveringRecently` was called out in the #79 "decisions" section as drifting from the post-#77 contract.

Refs #77, #79.
Closes #80.

Made with [Cursor](https://cursor.com)