### PR TITLE
fix(ios): reorder glucose thresholds as low, high, critical

### DIFF
--- a/iOS/App/SettingsView.swift
+++ b/iOS/App/SettingsView.swift
@@ -324,6 +324,15 @@ struct AttentionRulesSettingsView: View {
         List {
             Section {
                 HStack {
+                    Text("settings.lowThreshold", tableName: "Localizable")
+                    Spacer()
+                    Text(String(format: thresholdFormat, lowThreshold))
+                        .monospacedDigit()
+                        .foregroundStyle(.secondary)
+                }
+                Slider(value: $lowThreshold, in: lowRange, step: lowStep)
+
+                HStack {
                     Text("settings.highThreshold", tableName: "Localizable")
                     Spacer()
                     Text(String(format: thresholdFormat, highThreshold))
@@ -346,15 +355,6 @@ struct AttentionRulesSettingsView: View {
                         .foregroundStyle(BrandTint.red)
                         .font(.caption)
                 }
-
-                HStack {
-                    Text("settings.lowThreshold", tableName: "Localizable")
-                    Spacer()
-                    Text(String(format: thresholdFormat, lowThreshold))
-                        .monospacedDigit()
-                        .foregroundStyle(.secondary)
-                }
-                Slider(value: $lowThreshold, in: lowRange, step: lowStep)
             } header: {
                 Text(String(localized: "settings.glucoseHeader \(unit.label)"))
             } footer: {


### PR DESCRIPTION
## Summary

The attention-rules settings screen listed the glucose thresholds as **high, critical, low** — a zigzag across the value axis that made the critical-above-high invariant harder to see at a glance. This reorders them along the axis: **low → high → critical**, top to bottom.

The inline validation label stays anchored under the critical slider (since the invariant is about critical vs. high), and the section header/footer copy is untouched.

## Changes

- `iOS/App/SettingsView.swift` — move the low-threshold slider to the top of the section in `AttentionRulesSettingsView`.

## Test plan

- [ ] Open Settings → Attention rules and verify the order reads low, high, critical.
- [ ] Drag `high` above `critical` and confirm the validation label still appears directly under the critical slider.
- [ ] Save, reopen, and confirm values persist.


Made with [Cursor](https://cursor.com)