### PR TITLE
fix(ios): hide critical "cannot be dismissed" copy when shielding is off

### DIFF
--- a/iOS/App/HomeView.swift
+++ b/iOS/App/HomeView.swift
@@ -341,14 +341,17 @@ struct HomeView: View {
                 if content.isCriticalGlucose {
                     // Critical glucose: the shield cannot be dismissed, so
                     // don't offer the interactive check-in that pretends it
-                    // can. Show the read-only list plus the explanatory
-                    // text, matching the shield extension's non-dismissible
-                    // state. The hard gate also lives in
-                    // `ShieldManager.disarmShields()` — this branch is UX
-                    // polish, not the security boundary.
+                    // can. Show the read-only list, and — only when
+                    // shielding is actually enabled — also the explanatory
+                    // "cannot be dismissed until…" copy, matching the
+                    // shield extension's non-dismissible state. The hard
+                    // gate also lives in `ShieldManager.disarmShields()` —
+                    // this branch is UX polish, not the security boundary.
+                    // When shielding is off, the copy would be nonsensical
+                    // (there's no shield to talk about), so suppress it.
                     VStack(spacing: 12) {
                         AttentionListView(items: content.attentionItems)
-                        if let criticalText = content.criticalCannotDismissText {
+                        if shieldingEnabled, let criticalText = content.criticalCannotDismissText {
                             Text(criticalText)
                                 .font(.footnote)
                                 .foregroundStyle(.secondary)


### PR DESCRIPTION
## Summary

When glucose is at/above the critical threshold, `HomeView`'s status panel shows an explanatory footnote pulled from `ShieldContent.criticalCannotDismissText` — *"The shield cannot be dismissed until your glucose is below X."* That copy was rendered unconditionally, including when the shielding feature is off. In that state the sentence refers to something the user hasn't configured: confusing at best, misleading at worst.

This PR gates the render on `shieldingEnabled` in `statusPanel`. The attention checklist still appears in both states; only the shield-specific explanation is suppressed when there's no shield.

## Changes

- `iOS/App/HomeView.swift` — `statusPanel`'s `isCriticalGlucose` branch now wraps the `Text(criticalText)` render in an `if shieldingEnabled` guard. Comment updated to call out the suppression rationale.

Localized strings (`shield.criticalCannotDismiss %@` in EN/NL) are untouched — they're still used by the shield extension itself, which only runs when shielding is enabled by definition.

## Contracts preserved

- The hard no-disarm gate lives in `ShieldAction.handleAction` (rejects `.defer` in the critical state regardless of which button was tapped). This PR does not touch it — per `AGENTS.md` the shield-action gate is the security boundary; the home-view copy is UX polish.
- The shield extension's subtitle still includes the "cannot be dismissed until…" line via `ShieldContent.subtitle` — unchanged.
- `ShieldContent.criticalCannotDismissText` remains the single source of truth for the critical-state explanation. This PR just stops one caller from rendering it in a context where it doesn't apply.

## Test plan

- [ ] In simulator with the ladybug mock controls: toggle `mockShieldingEnabled = false`, set glucose above the critical threshold → footnote is absent; attention list still shown.
- [ ] Same preset with `mockShieldingEnabled = true` → footnote shown as before.
- [ ] Non-critical attention states (high/low/stale/carbgap) unaffected in both shielding on/off modes.
- [ ] Verify on device: set shielding off in Settings, force a critical reading → HomeView matches expectation.

Made with [Cursor](https://cursor.com)