### PR TITLE
feat(ios): store glucose and carbs per source with unified reads

### DIFF
--- a/.claude/skills/appstore-screenshots/SKILL.md
+++ b/.claude/skills/appstore-screenshots/SKILL.md
@@ -100,7 +100,7 @@ Repeat until the title reads well in marketing context.
 
 ## Side effects on the simulator
 
-The settings scene writes `mockModeEnabled`, `shieldingEnabled`, and `healthKitEverDelivered` to the shared App Group so the rows render as "configured". The harness resets those flags to `false` on every non-settings launch, so running the full deck leaves the sim in a clean state. But if you capture only `--scene settings` and then launch the app normally (no `-UITest_Scene`), you'll see shielding + demo mode turned on until you uninstall/reinstall.
+The settings scene writes `mockModeEnabled`, `shieldingEnabled`, and `healthKitEnabled` to the shared App Group so the rows render as "configured". The harness resets those flags to `false` on every non-settings launch (keeping `mockModeEnabled` on only when the scene has seeded Demo values via `UnifiedDataReader`), so running the full deck leaves the sim in a clean state. But if you capture only `--scene settings` and then launch the app normally (no `-UITest_Scene`), you'll see shielding + demo mode turned on until you uninstall/reinstall.
 
 ## What this skill does NOT do (yet)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -306,10 +306,21 @@ Stored keys:
 
 | Key | Type | Written by | Read by |
 |-----|------|-----------|---------|
-| `currentGlucose` | Double (mmol/L) | Main app (HealthKit) or Watch app (HealthKit) | ShieldConfig, WatchWidget |
-| `glucoseFetchedAt` | Date (ISO 8601) | Main app (HealthKit) or Watch app (HealthKit) | ShieldConfig, WatchWidget |
-| `lastCarbEntryGrams` | Double | Main app (HealthKit) or Watch app (HealthKit) | ShieldConfig, WatchWidget |
-| `lastCarbEntryAt` | Date (ISO 8601) | Main app (HealthKit) or Watch app (HealthKit) | ShieldConfig, WatchWidget |
+| `healthKitGlucose` | Double (mmol/L) | Main app (HealthKitManager) | `SharedKit.UnifiedDataReader` |
+| `healthKitGlucoseSampleAt` | Date (ISO 8601) | Main app (HealthKitManager) | `SharedKit.UnifiedDataReader` |
+| `healthKitCarbs` | Double | Main app (HealthKitManager) | `SharedKit.UnifiedDataReader` |
+| `healthKitCarbsSampleAt` | Date (ISO 8601) | Main app (HealthKitManager) | `SharedKit.UnifiedDataReader` |
+| `nightscoutGlucose` | Double (mmol/L) | Main app (NightscoutManager), StatusWidget (WidgetNightscoutRefresh) | `SharedKit.UnifiedDataReader` |
+| `nightscoutGlucoseSampleAt` | Date (ISO 8601) | Main app (NightscoutManager), StatusWidget (WidgetNightscoutRefresh) | `SharedKit.UnifiedDataReader` |
+| `nightscoutCarbs` | Double | Main app (NightscoutManager), StatusWidget (WidgetNightscoutRefresh) | `SharedKit.UnifiedDataReader` |
+| `nightscoutCarbsSampleAt` | Date (ISO 8601) | Main app (NightscoutManager), StatusWidget (WidgetNightscoutRefresh) | `SharedKit.UnifiedDataReader` |
+| `demoGlucose` | Double (mmol/L) | Main app (MockDataSettingsView, ScreenshotHarness) | `SharedKit.UnifiedDataReader` |
+| `demoGlucoseSampleAt` | Date (ISO 8601) | Main app (MockDataSettingsView, ScreenshotHarness) | `SharedKit.UnifiedDataReader` |
+| `demoCarbs` | Double | Main app (MockDataSettingsView, ScreenshotHarness) | `SharedKit.UnifiedDataReader` |
+| `demoCarbsSampleAt` | Date (ISO 8601) | Main app (MockDataSettingsView, ScreenshotHarness) | `SharedKit.UnifiedDataReader` |
+| `healthKitEnabled` | Bool | Main app (HealthKitSettingsView toggle via `HealthKitManager.enable/disable`) | `SharedKit.UnifiedDataReader`, `SharedDataManager.hasAnyDataSource` |
+| `nightscoutEnabled` | Bool | Main app (NightscoutSettingsView toggle) | `SharedKit.UnifiedDataReader`, `SharedDataManager.hasAnyDataSource`, `WidgetNightscoutRefresh` |
+| `mockModeEnabled` | Bool | Main app (MockDataSettingsView toggle, ScreenshotHarness) | `SharedKit.UnifiedDataReader`, `SharedDataManager.hasAnyDataSource`, `WidgetNightscoutRefresh` |
 | `attentionDeferredAt` | Date (ISO 8601) or absent | ShieldAction | ShieldConfig |
 | `shieldDismissedAt` | Date (ISO 8601) | ShieldAction | DeviceActivityMonitor |
 | `allowedAppTokens` | Data (encoded `Set<ApplicationToken>`) | Main app (FamilyActivityPicker) | Main app (ManagedSettingsStore) |
@@ -323,6 +334,8 @@ Stored keys:
 | `carbGraceMinute` | Int or absent | Main app (settings / WatchConnectivity sync) | ShieldConfig, WatchApp, WatchWidget |
 | `glucoseUnit` | String ("mmolL" or "mgdL") or absent | Main app (settings / HealthKit auto-detect / WatchConnectivity sync) | ShieldConfig, StatusWidget, Main app, WatchApp, WatchWidget |
 | `glucoseBadgeMode` | String ("off", "always", "onlyWhenAttention") or absent | Main app (settings) | Main app (badge update) |
+
+> **Per-source storage + unified reads (issue #83):** each of the three data sources (HealthKit, Nightscout, Demo) writes to its own `<source>{Glucose,Carbs}{,SampleAt}` keys. Every reader — home screen, shield extensions, widgets, watch — goes through `SharedKit.UnifiedDataReader`, which implements a single resolution rule: Demo wins when `mockModeEnabled` is on; otherwise the freshest sample among currently-enabled sources wins (glucose and carbs resolved independently). Disabled sources are ignored even if they have cached values. Never read the per-source keys directly outside the reader.
 
 > **Settings override precedence:** Extensions read settings keys from App Group first; if absent (never changed), they fall back to `Info.plist` values (from xcconfig). The passphrase itself is NOT in the App Group — it's in the device Keychain.
 
@@ -519,15 +532,15 @@ func fetchLatestGlucose() async {
     if let sample = try? await descriptor.result(for: healthStore).first {
         let mgdl = sample.quantity.doubleValue(for: .gramUnit(with: .milli).unitDivided(by: .literUnit(with: .deci)))
         let mmol = mgdl / 18.018
-        
-        let defaults = UserDefaults(suiteName: "group.nl.fokkezb.GluWink")
-        defaults?.set(mmol, forKey: "currentGlucose")
-        defaults?.set(sample.startDate.ISO8601Format(), forKey: "glucoseFetchedAt")
+
+        // Write to the per-source HealthKit bucket; `SharedKit.UnifiedDataReader`
+        // picks the freshest across enabled sources at read time.
+        SharedDataManager.shared.saveHealthKitGlucose(mmol: mmol, at: sample.startDate)
     }
 }
 ```
 
-Use the same pattern for carbs with `HKQuantityType(.dietaryCarbohydrates)`, writing `lastCarbEntryGrams` and `lastCarbEntryAt` to the App Group.
+Use the same pattern for carbs with `HKQuantityType(.dietaryCarbohydrates)` via `SharedDataManager.shared.saveHealthKitCarbs(grams:at:)`. Nightscout and Demo writers use their own `saveNightscout*` / `saveDemo*` counterparts.
 
 ### Prerequisite
 
@@ -682,20 +695,21 @@ The app supports three data sources for glucose / carbs: **Apple Health**, **Nig
 
 ### Definitions
 
-- **Nightscout / Demo:** straightforward — `nightscoutEnabled` / `isMockModeEnabled` are user-controlled toggles. Reading the flag is the truth.
-- **Apple Health:** iOS privacy-masks read-auth status (`HKHealthStore.authorizationStatus(for:)` returns `.sharingDenied` for both "user denied" and "we never asked", and `!= .notDetermined` once we've prompted — even after the user later revokes access). So we infer "active" from sample freshness via `SharedDataManager.healthKitDeliveringRecently`: HK has delivered at least once *and* the latest stored glucose timestamp is fresher than `glucoseStaleMinutes`.
-  - `healthKitEverDelivered` is kept as a stored flag, but only as the historical "we got data once" signal. Never use it as the gate for UI or shielding.
+All three sources are explicit user toggles now (issue #83):
+
+- **`healthKitEnabled`** — flipped by the Apple Health settings screen via `HealthKitManager.enable()` / `disable()`. iOS privacy-masks read-auth status so we can't infer "the user granted HK" from the system; the toggle is our authoritative signal. `enable()` re-requests permission and starts observers; `disable()` stops observers, disables background delivery, and clears the HK per-source cache.
+- **`nightscoutEnabled`** — flipped by the Nightscout settings screen after verifying the URL + token.
+- **`mockModeEnabled` (Demo)** — flipped by the Demo settings screen.
+
+`SharedDataManager.hasAnyDataSource` is the OR of the three. Shielding and the welcome panel gate off it; the unified reader in `SharedKit.UnifiedDataReader` also ignores disabled sources entirely.
 
 ### Disable handlers MUST clean up
 
-When the user toggles off Nightscout or Demo from Settings, the handler MUST call `SharedDataManager.handleInAppSourceDisabled()` after flipping the flag. That helper wipes the cached glucose / carb values **only** when no in-app source remains, so:
+When the user toggles any source off, the handler MUST call `SharedDataManager.handleSourceDisabled(_:)` after flipping the flag. That clears just that source's cached values so neither the resolver nor the per-source "Latest data" row in Settings shows stale numbers from it. With per-source storage, this is always safe — clearing HK never affects Nightscout's cache and vice versa.
 
-- Disabling Demo while Nightscout is still on → values stay (Nightscout will keep them fresh on the next poll).
-- Disabling the last in-app source → values are cleared. If HK is still authorized + delivering, its next observer fire repopulates them within seconds; if not, the cleared state is honest and `HomeView` returns to the welcome panel.
+Disable paths should also kick remaining live sources (`NightscoutManager.fetchAll()`, `HealthKitManager.refreshIfAuthorized()`) so the UI reflects the new picture immediately instead of waiting for the next poll. `HealthKitManager.disable()` does both in one call.
 
-Disable paths should also kick remaining live sources (`NightscoutManager.fetchAll()`, `HealthKitManager.refreshIfAuthorized()`) so the UI reflects the new picture immediately instead of waiting for the next poll.
-
-The shield gate (`ShieldManager.disableIfNoDataSource()`) reads `hasAnyDataSource` too — when sources go quiet for longer than `glucoseStaleMinutes`, shielding auto-disables on the next launch / re-evaluation. That's deliberate: shielding without fresh data would treat every wake as `needsAttention` and never let the user back in.
+The shield gate (`ShieldManager.disableIfNoDataSource()`) reads `hasAnyDataSource` too — when the last source is toggled off, shielding auto-disables on the next launch / re-evaluation. That's deliberate: shielding without any live source would treat every wake as `needsAttention` and never let the user back in.
 
 ### Welcome state UI rules
 
@@ -703,11 +717,11 @@ When `!hasAnyDataSource` the home screen is in *welcome* mode and must follow th
 
 - **Icon:** blue (`AppIcon-Blue`). Never red/green: with no live source there's no signal to colour against.
 - **Status panel:** hidden entirely. No glucose number, no carb number, no attention checks. `HomeView.showsWelcome` returning `true` swaps the whole panel for `welcomePanel`.
-- **Cached values:** wiped by `handleInAppSourceDisabled()` whenever the last in-app source is turned off. We don't ship migrations for pre-release state — disable handlers are the only thing keeping the cache honest, so they must run on every disable path.
+- **Cached values:** wiped by `handleSourceDisabled(_:)` on every disable. Each source owns its own cache now, so disabling Demo while Nightscout keeps polling leaves Nightscout's values untouched — but the resolver also ignores disabled sources at read time, so even a stale cache can't leak into the UI. Disable handlers must still run so the per-source "Latest data" rows in Settings are honest.
 - **Setup checklist:** *only* the data-source picker (Apple Health / Nightscout / Demo). The recommended group (shielding, passphrase, notifications) is suppressed in welcome state regardless of `setupTipsHidden`. Picking a source is the one decision that unblocks everything else; burying it under other rows dilutes the CTA.
 - **`setupTipsHidden` is overridden for the data-source picker.** Even if the user previously hid the checklist, the picker reappears the moment every source goes away. They have no other path back to a working app.
 
-Toggling a source on/off must always re-fetch (or wipe). Enable paths trigger the source's own fetch (`NightscoutManager.configurationDidChange()`, `HealthKitManager.requestAuthorization() → fetchLatest…`, `MockDataSettingsView.saveMockData()` writes directly). Disable paths run `handleInAppSourceDisabled()` + kick remaining live sources via `refreshIfAuthorized()` / `fetchAll()`. Never leave a stale value visible across a toggle.
+Toggling a source on/off must always re-fetch (or wipe). Enable paths trigger the source's own fetch (`NightscoutManager.configurationDidChange()`, `HealthKitManager.enable()` which wraps request + observers + fetch, `MockDataSettingsView.saveMockData()` writes directly to demo keys). Disable paths run `handleSourceDisabled(_:)` + kick remaining live sources via `HealthKitManager.refreshIfAuthorized()` / `NightscoutManager.fetchAll()`. Never leave a stale value visible across a toggle.
 
 ## Coding Conventions
 

--- a/iOS/App/App.swift
+++ b/iOS/App/App.swift
@@ -31,7 +31,7 @@ struct MainApp: App {
         // whether we've moved past `.notDetermined` — that's the only state
         // the HealthKit API reports reliably for read-only permissions.
         WatchSessionManager.shared.activate()
-        if HKHealthStore().authorizationStatus(for: HKQuantityType(.bloodGlucose)) != .notDetermined {
+        if SharedDataManager.shared.healthKitEnabled {
             HealthKitManager.shared.startObserving()
         }
 
@@ -68,17 +68,15 @@ struct MainApp: App {
                     }
                     #endif
 
-                    // HealthKit: re-request + enable background delivery
-                    // if the user has been asked at least once, and try an
-                    // immediate fetch. Fetching first matters: a successful
-                    // sample flips `healthKitEverDelivered` via
-                    // `markHealthKitDelivered`, which is what the
-                    // `hasAnyDataSource` / shielding-gate logic below keys
-                    // off. A user who denied the prompt (or revoked access
-                    // in the Health app) gets no sample, the flag stays
-                    // false, and `disableIfNoDataSource` below safely
-                    // disarms residual shielding state.
-                    if HKHealthStore().authorizationStatus(for: HKQuantityType(.bloodGlucose)) != .notDetermined {
+                    // HealthKit: only re-request + fetch when the user has
+                    // explicitly opted in via the Settings toggle. iOS
+                    // privacy-masks the read-auth state for read-only
+                    // requests, so the toggle is our authoritative signal
+                    // — not the HKHealthStore status. Anyone who flipped
+                    // the toggle off doesn't pay for a fetch, and a user
+                    // who denied the prompt but left the toggle on
+                    // harmlessly no-ops on the fetch.
+                    if data.healthKitEnabled {
                         await HealthKitManager.shared.requestAuthorization()
                         await HealthKitManager.shared.enableBackgroundDelivery()
                         await HealthKitManager.shared.fetchLatestGlucose()
@@ -129,7 +127,7 @@ struct MainApp: App {
                 .onChange(of: scenePhase) {
                     if scenePhase == .active {
                         Task { @MainActor in
-                            if HKHealthStore().authorizationStatus(for: HKQuantityType(.bloodGlucose)) != .notDetermined {
+                            if SharedDataManager.shared.healthKitEnabled {
                                 await HealthKitManager.shared.fetchLatestGlucose()
                                 await HealthKitManager.shared.fetchLatestCarbs()
                             }

--- a/iOS/App/HealthKitManager.swift
+++ b/iOS/App/HealthKitManager.swift
@@ -13,7 +13,55 @@ final class HealthKitManager {
     private let glucoseType = HKQuantityType(.bloodGlucose)
     private let carbType = HKQuantityType(.dietaryCarbohydrates)
 
+    /// Whether the observer queries are currently active. We can't cancel
+    /// started observer queries with the modern HealthKit API without
+    /// holding the `HKObserverQuery` instances, so we keep a reference
+    /// here and `stop` them when the user disables HealthKit from
+    /// Settings. A re-enable simply re-executes fresh queries.
+    private var glucoseObserver: HKObserverQuery?
+    private var carbObserver: HKObserverQuery?
+
     private init() {}
+
+    // MARK: - Toggle lifecycle
+
+    /// Turn on the HealthKit data source: prompt for read permission
+    /// (iOS shows the sheet on the *first* call per type; subsequent
+    /// calls are a no-op even if the user previously denied), flip the
+    /// `healthKitEnabled` toggle on, enable background delivery, start
+    /// observers, and kick an immediate fetch. Idempotent — safe to call
+    /// from a Settings toggle binding.
+    func enable() async {
+        SharedDataManager.shared.healthKitEnabled = true
+        await requestAuthorization()
+        await enableBackgroundDelivery()
+        startObserving()
+        await fetchLatestGlucose()
+        await fetchLatestCarbs()
+        logger.info("HealthKit data source enabled")
+    }
+
+    /// Turn off the HealthKit data source. Stops observers, disables
+    /// background delivery, clears cached HealthKit values, and flips
+    /// the toggle off. iOS doesn't let us programmatically revoke
+    /// read permission — the toggle itself is the authoritative
+    /// "use this data?" gate from this point forward.
+    func disable() async {
+        SharedDataManager.shared.healthKitEnabled = false
+        stopObserving()
+        do {
+            try await healthStore.disableBackgroundDelivery(for: glucoseType)
+            try await healthStore.disableBackgroundDelivery(for: carbType)
+        } catch {
+            logger.error("Failed to disable background delivery: \(error.localizedDescription)")
+        }
+        SharedDataManager.shared.handleSourceDisabled(.healthKit)
+        await SharedDataManager.shared.refreshAttentionBadge()
+        ShieldManager.shared.reevaluateShields()
+        WidgetCenter.shared.reloadAllTimelines()
+        WatchSessionManager.shared.sendLatestContext()
+        logger.info("HealthKit data source disabled")
+    }
 
     // MARK: - Authorization
 
@@ -63,7 +111,9 @@ final class HealthKitManager {
     // MARK: - Observer Queries
 
     func startObserving() {
-        let glucoseObserver = HKObserverQuery(sampleType: glucoseType, predicate: nil) { [weak self] _, completionHandler, error in
+        stopObserving()
+
+        let glucose = HKObserverQuery(sampleType: glucoseType, predicate: nil) { [weak self] _, completionHandler, error in
             if let error {
                 self?.logger.error("Glucose observer error: \(error.localizedDescription)")
                 completionHandler()
@@ -74,9 +124,10 @@ final class HealthKitManager {
                 completionHandler()
             }
         }
-        healthStore.execute(glucoseObserver)
+        healthStore.execute(glucose)
+        glucoseObserver = glucose
 
-        let carbObserver = HKObserverQuery(sampleType: carbType, predicate: nil) { [weak self] _, completionHandler, error in
+        let carbs = HKObserverQuery(sampleType: carbType, predicate: nil) { [weak self] _, completionHandler, error in
             if let error {
                 self?.logger.error("Carb observer error: \(error.localizedDescription)")
                 completionHandler()
@@ -87,24 +138,39 @@ final class HealthKitManager {
                 completionHandler()
             }
         }
-        healthStore.execute(carbObserver)
+        healthStore.execute(carbs)
+        carbObserver = carbs
 
         logger.info("Started observing glucose and carb samples")
+    }
+
+    private func stopObserving() {
+        if let glucoseObserver {
+            healthStore.stop(glucoseObserver)
+            self.glucoseObserver = nil
+        }
+        if let carbObserver {
+            healthStore.stop(carbObserver)
+            self.carbObserver = nil
+        }
     }
 
     // MARK: - Fetch Latest Values
 
     /// Convenience: refresh both glucose and carbs *only* if the user has
-    /// ever been prompted for HealthKit. Safe to call from anywhere — does
-    /// nothing when authorization was never requested, so it won't trigger
-    /// a permission prompt as a side-effect.
+    /// HealthKit enabled. Safe to call from anywhere — does nothing when
+    /// the toggle is off, so it won't reach HealthKit at all in that case.
     func refreshIfAuthorized() async {
-        guard healthStore.authorizationStatus(for: glucoseType) != .notDetermined else { return }
+        guard SharedDataManager.shared.healthKitEnabled else { return }
         await fetchLatestGlucose()
         await fetchLatestCarbs()
     }
 
     func fetchLatestGlucose() async {
+        guard SharedDataManager.shared.healthKitEnabled else {
+            logger.info("HealthKit disabled — skipping glucose fetch")
+            return
+        }
         guard !SharedDataManager.shared.isMockModeEnabled else {
             logger.info("Mock mode active — skipping HealthKit glucose fetch")
             return
@@ -121,8 +187,7 @@ final class HealthKitManager {
             if let sample = try await descriptor.result(for: healthStore).first {
                 let mgdl = sample.quantity.doubleValue(for: .gramUnit(with: .milli).unitDivided(by: .literUnit(with: .deci)))
                 let mmol = mgdl / 18.018
-                SharedDataManager.shared.saveGlucose(mmol: mmol, at: sample.startDate)
-                SharedDataManager.shared.markHealthKitDelivered()
+                SharedDataManager.shared.saveHealthKitGlucose(mmol: mmol, at: sample.startDate)
                 logger.info("Glucose updated: \(String(format: "%.1f", mmol)) mmol/L")
                 ShieldManager.shared.reevaluateShields()
                 WidgetCenter.shared.reloadAllTimelines()
@@ -137,12 +202,16 @@ final class HealthKitManager {
         await SharedDataManager.shared.refreshAttentionBadge()
 
         // Piggyback: when HealthKit wakes us up (including background delivery),
-        // also poll Nightscout so the two sources stay aligned. "Save if newer"
-        // guarantees whichever timestamp is freshest wins.
+        // also poll Nightscout so the two sources stay aligned. Each source
+        // writes to its own keys; the resolver picks the freshest at read time.
         await NightscoutManager.shared.fetchAll()
     }
 
     func fetchLatestCarbs() async {
+        guard SharedDataManager.shared.healthKitEnabled else {
+            logger.info("HealthKit disabled — skipping carb fetch")
+            return
+        }
         guard !SharedDataManager.shared.isMockModeEnabled else {
             logger.info("Mock mode active — skipping HealthKit carb fetch")
             return
@@ -158,8 +227,7 @@ final class HealthKitManager {
         do {
             if let sample = try await descriptor.result(for: healthStore).first {
                 let grams = sample.quantity.doubleValue(for: .gram())
-                SharedDataManager.shared.saveCarbs(grams: grams, at: sample.startDate)
-                SharedDataManager.shared.markHealthKitDelivered()
+                SharedDataManager.shared.saveHealthKitCarbs(grams: grams, at: sample.startDate)
                 logger.info("Carbs updated: \(String(format: "%.0f", grams))g")
                 ShieldManager.shared.reevaluateShields()
                 WidgetCenter.shared.reloadAllTimelines()

--- a/iOS/App/HealthKitSettingsView.swift
+++ b/iOS/App/HealthKitSettingsView.swift
@@ -1,62 +1,64 @@
 import HealthKit
+import SharedKit
 import SwiftUI
 import UIKit
 
 struct HealthKitSettingsView: View {
-    @State private var authorizationStatus: HKAuthorizationStatus
+    @State private var enabled: Bool
     @State private var isRequesting = false
-
-    private let store = HKHealthStore()
-    private let glucoseType = HKQuantityType(.bloodGlucose)
+    @State private var latestGlucose: GlucoseReading?
+    @State private var latestCarbs: CarbsReading?
 
     init() {
-        _authorizationStatus = State(
-            initialValue: HKHealthStore().authorizationStatus(for: HKQuantityType(.bloodGlucose))
-        )
-    }
-
-    /// `HKHealthStore.authorizationStatus(for:)` reports `.notDetermined`
-    /// reliably (we've never prompted), but for read-only requests returns
-    /// `.sharingDenied` as a privacy mask regardless of whether the user
-    /// actually granted read access. We can only tell "have we asked" vs
-    /// "haven't asked yet" — never "is it currently granted".
-    private var hasRequested: Bool {
-        authorizationStatus != .notDetermined
+        let data = SharedDataManager.shared
+        _enabled = State(initialValue: data.healthKitEnabled)
+        _latestGlucose = State(initialValue: data.glucoseReading(source: .healthKit))
+        _latestCarbs = State(initialValue: data.carbsReading(source: .healthKit))
     }
 
     var body: some View {
         List {
             Section {
                 HStack {
-                    Label(String(localized: "healthkit.settings.statusLabel"), systemImage: "heart.text.square")
-                    Spacer()
-                    Text(statusText)
-                        .foregroundStyle(.secondary)
+                    Toggle(String(localized: "healthkit.settings.enabledToggle"), isOn: Binding(
+                        get: { enabled },
+                        set: { newValue in
+                            if newValue {
+                                Task { await enable() }
+                            } else {
+                                Task { await disable() }
+                            }
+                        }
+                    ))
+                    .disabled(isRequesting)
+                    if isRequesting {
+                        ProgressView()
+                    }
                 }
-            } header: {
-                Text("healthkit.settings.statusHeader", tableName: "Localizable")
             } footer: {
-                Text(hasRequested
-                    ? String(localized: "healthkit.settings.statusFooterRequested")
-                    : String(localized: "healthkit.settings.statusFooterNotDetermined"))
+                Text("healthkit.settings.enabledFooter", tableName: "Localizable")
             }
 
             Section {
-                if !hasRequested {
-                    Button {
-                        Task { await requestAuthorization() }
-                    } label: {
-                        HStack {
-                            Label(String(localized: "healthkit.settings.requestButton"), systemImage: "heart.fill")
-                            Spacer()
-                            if isRequesting {
-                                ProgressView()
-                            }
-                        }
-                    }
-                    .disabled(isRequesting)
-                }
+                latestSampleRow(
+                    label: String(localized: "healthkit.settings.latestGlucose"),
+                    value: latestGlucose.map { SharedDataManager.shared.glucoseUnit.formattedWithUnit($0.mmol) },
+                    at: latestGlucose?.sampleAt,
+                    emptyMessage: String(localized: "healthkit.settings.noGlucoseYet")
+                )
+                latestSampleRow(
+                    label: String(localized: "healthkit.settings.latestCarbs"),
+                    value: latestCarbs.map { "\(Int($0.grams)) g" },
+                    at: latestCarbs?.sampleAt,
+                    emptyMessage: String(localized: "healthkit.settings.noCarbsYet")
+                )
+            } header: {
+                Text("healthkit.settings.latestDataHeader", tableName: "Localizable")
+            } footer: {
+                Text("healthkit.settings.statusFooterRequested", tableName: "Localizable")
+            }
 
+            Section {
                 Button {
                     openHealthApp()
                 } label: {
@@ -68,30 +70,72 @@ struct HealthKitSettingsView: View {
         }
         .navigationTitle(String(localized: "healthkit.settings.title"))
         .navigationBarTitleDisplayMode(.inline)
-        .onAppear { refreshStatus() }
+        .task {
+            // Refresh every 5 s so a HealthKit observer fire in the
+            // background shows up here without forcing the user to
+            // leave and re-enter the screen. Mirrors Nightscout's
+            // settings screen refresh loop.
+            while !Task.isCancelled {
+                refreshLatestSamples()
+                try? await Task.sleep(nanoseconds: 5_000_000_000)
+            }
+        }
     }
 
-    private var statusText: String {
-        hasRequested
-            ? String(localized: "healthkit.settings.statusRequested")
-            : String(localized: "healthkit.settings.statusNotConnected")
+    private func refreshLatestSamples() {
+        let data = SharedDataManager.shared
+        enabled = data.healthKitEnabled
+        latestGlucose = data.glucoseReading(source: .healthKit)
+        latestCarbs = data.carbsReading(source: .healthKit)
     }
 
-    private func refreshStatus() {
-        authorizationStatus = store.authorizationStatus(for: glucoseType)
+    /// Shared layout for "Latest data" rows — same shape as Nightscout's
+    /// settings screen uses so the two per-source screens feel
+    /// symmetrical.
+    @ViewBuilder
+    private func latestSampleRow(label: String, value: String?, at: Date?, emptyMessage: String) -> some View {
+        if let value, let at {
+            HStack(alignment: .firstTextBaseline) {
+                Text(label)
+                Spacer()
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text(value)
+                        .monospacedDigit()
+                    Text(at, style: .relative)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        } else {
+            HStack {
+                Text(label)
+                Spacer()
+                Text(emptyMessage)
+                    .foregroundStyle(.secondary)
+            }
+        }
     }
 
     @MainActor
-    private func requestAuthorization() async {
+    private func enable() async {
         isRequesting = true
         defer { isRequesting = false }
+        await HealthKitManager.shared.enable()
+        enabled = SharedDataManager.shared.healthKitEnabled
+        refreshLatestSamples()
+    }
 
-        await HealthKitManager.shared.requestAuthorization()
-        await HealthKitManager.shared.enableBackgroundDelivery()
-        HealthKitManager.shared.startObserving()
-        await HealthKitManager.shared.fetchLatestGlucose()
-        await HealthKitManager.shared.fetchLatestCarbs()
-        refreshStatus()
+    @MainActor
+    private func disable() async {
+        isRequesting = true
+        defer { isRequesting = false }
+        await HealthKitManager.shared.disable()
+        enabled = SharedDataManager.shared.healthKitEnabled
+        // After disabling, shielding may need to come down if HK was
+        // the last remaining source. Mirrors Nightscout/Demo disable
+        // paths.
+        ShieldManager.shared.disableIfNoDataSource()
+        refreshLatestSamples()
     }
 
     private func openHealthApp() {

--- a/iOS/App/HomeView.swift
+++ b/iOS/App/HomeView.swift
@@ -112,11 +112,13 @@ struct HomeView: View {
             now: now
         )
         #else
+        let glucoseReading = data.currentGlucoseReading
+        let carbsReading = data.currentCarbsReading
         return ShieldContent(
-            glucose: data.currentGlucose ?? 0,
-            glucoseFetchedAt: data.glucoseFetchedAt,
-            lastCarbGrams: data.lastCarbGrams,
-            lastCarbEntryAt: data.lastCarbEntryAt,
+            glucose: glucoseReading?.mmol ?? 0,
+            glucoseFetchedAt: glucoseReading?.sampleAt,
+            lastCarbGrams: carbsReading?.grams,
+            lastCarbEntryAt: carbsReading?.sampleAt,
             highGlucoseThreshold: highThreshold,
             lowGlucoseThreshold: lowThreshold,
             criticalGlucoseThreshold: criticalThreshold,
@@ -137,11 +139,9 @@ struct HomeView: View {
     ///
     /// Intentionally does NOT also check for cached glucose values:
     /// without an active source those values are stale by definition
-    /// (see `SharedDataManager.hasAnyDataSource`'s recency window) and
-    /// surfacing them next to "no source configured" is confusing. The
-    /// launch-time migration in `MainApp` clears the cache in that
-    /// case, but if a user is mid-toggle and we momentarily race, the
-    /// welcome panel is still the correct UI to show.
+    /// and surfacing them next to "no source configured" is confusing.
+    /// `handleSourceDisabled(_:)` clears each source's cache when its
+    /// toggle flips off, so there's nothing to leak here.
     private var showsWelcome: Bool {
         #if targetEnvironment(simulator)
         if let preset = ScreenshotHarness.current?.homeViewPreset {
@@ -424,7 +424,7 @@ struct HomeView: View {
             : Date()
         return hasGlucoseData ? now.addingTimeInterval(-glucoseMinutesAgo * 60) : nil
         #else
-        return SharedDataManager.shared.glucoseFetchedAt
+        return SharedDataManager.shared.currentGlucoseReading?.sampleAt
         #endif
     }
 
@@ -435,7 +435,7 @@ struct HomeView: View {
             : Date()
         return hasCarbData ? now.addingTimeInterval(-carbMinutesAgo * 60) : nil
         #else
-        return SharedDataManager.shared.lastCarbEntryAt
+        return SharedDataManager.shared.currentCarbsReading?.sampleAt
         #endif
     }
 

--- a/iOS/App/NightscoutManager.swift
+++ b/iOS/App/NightscoutManager.swift
@@ -8,9 +8,10 @@ import WidgetKit
 /// a singleton that keeps the same App Group keys up to date via
 /// `SharedDataManager`, reloads widgets, and refreshes shields/app icon.
 ///
-/// Designed to coexist with HealthKit. When both sources are enabled,
-/// `SharedDataManager.saveGlucose` / `saveCarbs` use "save if newer" so
-/// whichever source provides the most recent sample wins.
+/// Designed to coexist with HealthKit. Each source writes to its own
+/// per-source keys (see `SharedKit.DataSourceKeys`); the unified reader
+/// picks the freshest sample across enabled sources independently for
+/// glucose and carbs.
 @MainActor
 final class NightscoutManager {
     static let shared = NightscoutManager()
@@ -112,7 +113,7 @@ final class NightscoutManager {
     private func fetchGlucose(using client: NightscoutClient) async {
         do {
             if let sample = try await client.fetchLatestGlucose() {
-                SharedDataManager.shared.saveGlucose(mmol: sample.mmol, at: sample.date)
+                SharedDataManager.shared.saveNightscoutGlucose(mmol: sample.mmol, at: sample.date)
                 logger.info("Nightscout glucose: \(String(format: "%.1f", sample.mmol)) mmol/L at \(sample.date)")
             }
             SharedDataManager.shared.nightscoutLastError = nil
@@ -125,7 +126,7 @@ final class NightscoutManager {
     private func fetchCarbs(using client: NightscoutClient) async {
         do {
             if let entry = try await client.fetchLatestCarbs() {
-                SharedDataManager.shared.saveCarbs(grams: entry.grams, at: entry.date)
+                SharedDataManager.shared.saveNightscoutCarbs(grams: entry.grams, at: entry.date)
                 logger.info("Nightscout carbs: \(String(format: "%.0f", entry.grams))g at \(entry.date)")
             }
         } catch {

--- a/iOS/App/ScreenshotHarness.swift
+++ b/iOS/App/ScreenshotHarness.swift
@@ -232,22 +232,27 @@ extension ScreenshotHarness {
 
         guard let defaults = UserDefaults(suiteName: Constants.appGroupID) else { return }
 
+        // Per-source storage (issue #83): seed fixture data into the
+        // Demo bucket and flip `mockModeEnabled` on so the unified
+        // reader picks it up. This keeps every surface (home, widgets,
+        // watch, shield) reading from the same source of truth without
+        // racing against a real HK/Nightscout fetch during a capture.
         if preset.hasGlucoseData {
             let glucoseDate = Date().addingTimeInterval(-preset.glucoseMinutesAgo * 60)
-            defaults.set(preset.glucose, forKey: "currentGlucose")
-            defaults.set(glucoseDate.ISO8601Format(), forKey: "glucoseFetchedAt")
+            defaults.set(preset.glucose, forKey: UnifiedDataReader.glucoseValueKey(for: .demo))
+            defaults.set(glucoseDate.ISO8601Format(), forKey: UnifiedDataReader.glucoseDateKey(for: .demo))
         } else {
-            defaults.removeObject(forKey: "currentGlucose")
-            defaults.removeObject(forKey: "glucoseFetchedAt")
+            defaults.removeObject(forKey: UnifiedDataReader.glucoseValueKey(for: .demo))
+            defaults.removeObject(forKey: UnifiedDataReader.glucoseDateKey(for: .demo))
         }
 
         if preset.hasCarbData {
             let carbDate = Date().addingTimeInterval(-preset.carbMinutesAgo * 60)
-            defaults.set(preset.carbGrams, forKey: "lastCarbGrams")
-            defaults.set(carbDate.ISO8601Format(), forKey: "lastCarbEntryAt")
+            defaults.set(preset.carbGrams, forKey: UnifiedDataReader.carbsValueKey(for: .demo))
+            defaults.set(carbDate.ISO8601Format(), forKey: UnifiedDataReader.carbsDateKey(for: .demo))
         } else {
-            defaults.removeObject(forKey: "lastCarbGrams")
-            defaults.removeObject(forKey: "lastCarbEntryAt")
+            defaults.removeObject(forKey: UnifiedDataReader.carbsValueKey(for: .demo))
+            defaults.removeObject(forKey: UnifiedDataReader.carbsDateKey(for: .demo))
         }
 
         // Reset "data source / shielding configured" flags on every run
@@ -261,9 +266,13 @@ extension ScreenshotHarness {
         // first" subtitles don't sell the app, so for the settings scene
         // we stamp everything as "active, configured".
         let configured = (scene == .settings)
-        defaults.set(configured, forKey: "mockModeEnabled")
+        // All scenes that seed data also enable Demo mode so the unified
+        // reader surfaces the seeded values. The settings scene also wants
+        // HK + shielding switched on so the rows render as "configured".
+        let needsSeededData = preset.hasGlucoseData || preset.hasCarbData
+        defaults.set(configured || needsSeededData, forKey: DataSourceKeys.mockModeEnabled)
         defaults.set(configured, forKey: "shieldingEnabled")
-        defaults.set(configured, forKey: "healthKitEverDelivered")
+        defaults.set(configured, forKey: DataSourceKeys.healthKitEnabled)
 
         // Pin the display unit per locale so en-US reads as mg/dL.
         defaults.set(glucoseUnit.rawValue, forKey: "glucoseUnit")

--- a/iOS/App/SettingsView.swift
+++ b/iOS/App/SettingsView.swift
@@ -27,7 +27,7 @@ struct SettingsView: View {
     @State private var demoEnabled: Bool
     @State private var glucoseUnit: GlucoseUnit
     @State private var nightscoutEnabled: Bool
-    @State private var healthKitDelivering: Bool
+    @State private var healthKitEnabled: Bool
 
     init() {
         let data = SharedDataManager.shared
@@ -36,7 +36,7 @@ struct SettingsView: View {
         _demoEnabled = State(initialValue: data.isMockModeEnabled)
         _glucoseUnit = State(initialValue: data.glucoseUnit)
         _nightscoutEnabled = State(initialValue: data.nightscoutEnabled)
-        _healthKitDelivering = State(initialValue: data.healthKitDeliveringRecently)
+        _healthKitEnabled = State(initialValue: data.healthKitEnabled)
     }
 
     var body: some View {
@@ -120,16 +120,14 @@ struct SettingsView: View {
                         HStack {
                             Label(String(localized: "settings.healthKit"), systemImage: "heart.text.square")
                             Spacer()
-                            // Apple Health can't tell us whether read
-                            // access is currently granted (iOS privacy-
-                            // masks that for read-only requests), so we
-                            // show "On" only when HK has delivered a
-                            // recent sample — matching how the rest of
-                            // the app classifies it as a real source
-                            // (see `SharedDataManager.healthKitDeliveringRecently`).
-                            // A revoked-in-Health-app source naturally
-                            // flips back to "Off" once samples go stale.
-                            Text(healthKitDelivering
+                            // The HK source is gated by an explicit
+                            // user toggle now (see `healthKitEnabled`),
+                            // mirroring Nightscout and Demo. iOS still
+                            // privacy-masks the *read-authorization*
+                            // state, but the toggle is the app's
+                            // authoritative signal for "use this
+                            // source?".
+                            Text(healthKitEnabled
                                 ? String(localized: "settings.statusOn")
                                 : String(localized: "settings.statusOff"))
                                 .foregroundStyle(.secondary)
@@ -181,7 +179,7 @@ struct SettingsView: View {
                 shieldingEnabled = data.shieldingEnabled
                 demoEnabled = data.isMockModeEnabled
                 nightscoutEnabled = data.nightscoutEnabled
-                healthKitDelivering = data.healthKitDeliveringRecently
+                healthKitEnabled = data.healthKitEnabled
             }
             .navigationTitle(String(localized: "settings.title"))
             .navigationBarTitleDisplayMode(.inline)
@@ -660,12 +658,18 @@ struct MockDataSettingsView: View {
         let u = data.glucoseUnit
         unit = u
         _mockEnabled = State(initialValue: data.isMockModeEnabled)
-        _hasGlucoseData = State(initialValue: data.currentGlucose != nil)
-        _mockGlucose = State(initialValue: u.displayValue(data.currentGlucose ?? 6.4))
-        _glucoseDate = State(initialValue: data.glucoseFetchedAt ?? Date().addingTimeInterval(-5 * 60))
-        _hasCarbData = State(initialValue: data.lastCarbGrams != nil)
-        _mockCarbGrams = State(initialValue: data.lastCarbGrams ?? 20)
-        _carbDate = State(initialValue: data.lastCarbEntryAt ?? Date().addingTimeInterval(-120 * 60))
+        // The Demo panel edits Demo's per-source cache directly, so pull
+        // initial values from the Demo bucket rather than the resolver
+        // (which may be showing HK / Nightscout samples when Demo mode
+        // is currently off).
+        let demoGlucose = data.glucoseReading(source: .demo)
+        let demoCarbs = data.carbsReading(source: .demo)
+        _hasGlucoseData = State(initialValue: demoGlucose != nil)
+        _mockGlucose = State(initialValue: u.displayValue(demoGlucose?.mmol ?? 6.4))
+        _glucoseDate = State(initialValue: demoGlucose?.sampleAt ?? Date().addingTimeInterval(-5 * 60))
+        _hasCarbData = State(initialValue: demoCarbs != nil)
+        _mockCarbGrams = State(initialValue: demoCarbs?.grams ?? 20)
+        _carbDate = State(initialValue: demoCarbs?.sampleAt ?? Date().addingTimeInterval(-120 * 60))
     }
 
     var body: some View {
@@ -758,31 +762,25 @@ struct MockDataSettingsView: View {
             data.isMockModeEnabled = true
 
             if hasGlucoseData {
-                data.saveGlucose(
+                data.saveDemoGlucose(
                     mmol: unit.toMmol(mockGlucose),
-                    at: glucoseDate,
-                    force: true
+                    at: glucoseDate
                 )
             } else {
-                data.clearGlucoseData()
+                data.clearDemoGlucose()
             }
 
             if hasCarbData {
-                data.saveCarbs(
-                    grams: mockCarbGrams,
-                    at: carbDate,
-                    force: true
-                )
+                data.saveDemoCarbs(grams: mockCarbGrams, at: carbDate)
             } else {
-                data.clearCarbData()
+                data.clearDemoCarbs()
             }
         } else if data.isMockModeEnabled {
-            // `clearMockData` only wipes the cached values when no other
-            // in-app source is enabled (Nightscout/Demo share the same
-            // App Group keys as live sources). In that case, kick HK
-            // too — if it's still authorized and delivering, the UI
-            // repopulates within seconds; otherwise the cleared state
-            // is honest and HomeView returns to the welcome panel.
+            // Demo writes to its own per-source keys, so turning the
+            // toggle off is enough to remove Demo from the resolver —
+            // the other sources keep their cached values. `clearMockData`
+            // also wipes the Demo bucket so a stale mock value can't
+            // leak back in next time Demo is enabled.
             data.clearMockData()
             // Disable shielding too if Demo was the last live source —
             // there's nothing left to base attention decisions on.
@@ -807,8 +805,9 @@ struct NightscoutSettingsView: View {
     @State private var enabled: Bool
     @State private var baseURL: String
     @State private var token: String
-    @State private var lastFetchedAt: Date?
     @State private var lastError: String?
+    @State private var latestGlucose: GlucoseReading?
+    @State private var latestCarbs: CarbsReading?
     @State private var isTesting = false
     @State private var testResult: TestResult?
 
@@ -822,8 +821,9 @@ struct NightscoutSettingsView: View {
         _enabled = State(initialValue: data.nightscoutEnabled)
         _baseURL = State(initialValue: data.nightscoutBaseURL ?? "")
         _token = State(initialValue: data.nightscoutToken ?? "")
-        _lastFetchedAt = State(initialValue: data.nightscoutLastFetchedAt)
         _lastError = State(initialValue: data.nightscoutLastError)
+        _latestGlucose = State(initialValue: data.glucoseReading(source: .nightscout))
+        _latestCarbs = State(initialValue: data.carbsReading(source: .nightscout))
     }
 
     /// Toggling Nightscout on is only allowed once both URL and token have
@@ -835,27 +835,6 @@ struct NightscoutSettingsView: View {
 
     var body: some View {
         List {
-            Section {
-                TextField(
-                    String(localized: "settings.nightscoutURLPlaceholder"),
-                    text: $baseURL
-                )
-                .textContentType(.URL)
-                .keyboardType(.URL)
-                .autocorrectionDisabled()
-                .textInputAutocapitalization(.never)
-
-                SecureField(
-                    String(localized: "settings.nightscoutTokenPlaceholder"),
-                    text: $token
-                )
-                .textContentType(.password)
-            } header: {
-                Text("settings.nightscoutConfigHeader", tableName: "Localizable")
-            } footer: {
-                Text("settings.nightscoutConfigFooter", tableName: "Localizable")
-            }
-
             Section {
                 HStack {
                     Toggle(String(localized: "settings.nightscoutEnabled"), isOn: Binding(
@@ -888,6 +867,27 @@ struct NightscoutSettingsView: View {
                 if !newValue, enabled {
                     disable()
                 }
+            }
+
+            Section {
+                TextField(
+                    String(localized: "settings.nightscoutURLPlaceholder"),
+                    text: $baseURL
+                )
+                .textContentType(.URL)
+                .keyboardType(.URL)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+
+                SecureField(
+                    String(localized: "settings.nightscoutTokenPlaceholder"),
+                    text: $token
+                )
+                .textContentType(.password)
+            } header: {
+                Text("settings.nightscoutConfigHeader", tableName: "Localizable")
+            } footer: {
+                Text("settings.nightscoutConfigFooter", tableName: "Localizable")
             }
 
             Section {
@@ -929,30 +929,30 @@ struct NightscoutSettingsView: View {
             }
 
             Section {
-                if let lastFetchedAt {
-                    HStack {
-                        Text("settings.nightscoutLastFetch", tableName: "Localizable")
-                        Spacer()
-                        Text(lastFetchedAt, style: .relative)
-                            .foregroundStyle(.secondary)
-                    }
-                } else if enabled {
-                    Text("settings.nightscoutAwaitingFirstUpdate", tableName: "Localizable")
-                        .foregroundStyle(.secondary)
-                } else if hasCredentials {
-                    Text("settings.nightscoutDisabled", tableName: "Localizable")
-                        .foregroundStyle(.secondary)
-                } else {
-                    Text("settings.nightscoutNotConfigured", tableName: "Localizable")
-                        .foregroundStyle(.secondary)
-                }
-                if let lastError {
+                latestSampleRow(
+                    label: String(localized: "settings.nightscoutLatestGlucose"),
+                    value: latestGlucose.map { SharedDataManager.shared.glucoseUnit.formattedWithUnit($0.mmol) },
+                    at: latestGlucose?.sampleAt,
+                    emptyMessage: String(localized: "settings.nightscoutNoGlucoseYet")
+                )
+                latestSampleRow(
+                    label: String(localized: "settings.nightscoutLatestCarbs"),
+                    value: latestCarbs.map { "\(Int($0.grams)) g" },
+                    at: latestCarbs?.sampleAt,
+                    emptyMessage: String(localized: "settings.nightscoutNoCarbsYet")
+                )
+            } header: {
+                Text("settings.nightscoutLatestHeader", tableName: "Localizable")
+            }
+
+            if let lastError {
+                Section {
                     Label(lastError, systemImage: "exclamationmark.triangle")
                         .foregroundStyle(BrandTint.orange)
                         .font(.caption)
+                } header: {
+                    Text("settings.nightscoutStatusHeader", tableName: "Localizable")
                 }
-            } header: {
-                Text("settings.nightscoutStatusHeader", tableName: "Localizable")
             }
         }
         .navigationTitle(String(localized: "settings.nightscout"))
@@ -972,8 +972,38 @@ struct NightscoutSettingsView: View {
     }
 
     private func refreshStatusFields() {
-        lastFetchedAt = SharedDataManager.shared.nightscoutLastFetchedAt
-        lastError = SharedDataManager.shared.nightscoutLastError
+        let data = SharedDataManager.shared
+        lastError = data.nightscoutLastError
+        latestGlucose = data.glucoseReading(source: .nightscout)
+        latestCarbs = data.carbsReading(source: .nightscout)
+    }
+
+    /// Shared layout for the "Latest data" rows: either show the value +
+    /// a relative timestamp, or a muted "never seen" placeholder so the
+    /// screen doesn't collapse to blank rows when a source has nothing
+    /// cached yet.
+    @ViewBuilder
+    private func latestSampleRow(label: String, value: String?, at: Date?, emptyMessage: String) -> some View {
+        if let value, let at {
+            HStack(alignment: .firstTextBaseline) {
+                Text(label)
+                Spacer()
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text(value)
+                        .monospacedDigit()
+                    Text(at, style: .relative)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        } else {
+            HStack {
+                Text(label)
+                Spacer()
+                Text(emptyMessage)
+                    .foregroundStyle(.secondary)
+            }
+        }
     }
 
     private func persistFields() {
@@ -1046,11 +1076,14 @@ struct NightscoutSettingsView: View {
         data.nightscoutEnabled = false
         data.flush()
         NightscoutManager.shared.configurationDidChange()
-        // Wipe Nightscout's last cached values when no other in-app
-        // source remains — otherwise the home screen keeps showing the
-        // disabled source's stale data with a green status. Live HK
-        // (if any) will repopulate via the kick below.
-        data.handleInAppSourceDisabled()
+        // Clear Nightscout's cached glucose/carb values so the
+        // per-source "latest data" rows on this screen (and anywhere
+        // else the unified reader looks) don't show stale Nightscout
+        // numbers after the user disabled it. The resolver already
+        // ignores disabled sources, but clearing keeps the UI honest.
+        data.handleSourceDisabled(.nightscout)
+        latestGlucose = nil
+        latestCarbs = nil
         // Disabling the last data source must also disable shielding —
         // there's nothing left to base attention decisions on.
         ShieldManager.shared.disableIfNoDataSource()

--- a/iOS/App/SetupChecklistCard.swift
+++ b/iOS/App/SetupChecklistCard.swift
@@ -38,12 +38,12 @@ struct SetupChecklistCard: View {
     /// Mirror of `SharedDataManager.isMockModeEnabled` for the same reason
     /// as `nightscoutEnabled`.
     @State private var isMockModeEnabled: Bool
-    /// Mirror of `SharedDataManager.healthKitDeliveringRecently` for the
-    /// same reason as `nightscoutEnabled`. Recency-based rather than the
-    /// sticky `healthKitEverDelivered` so the card re-shows the
-    /// data-source rows when HK access is revoked or the sensor goes
-    /// offline (see issue #36 — no force-quit needed).
-    @State private var healthKitDeliveringRecently: Bool
+    /// Mirror of `SharedDataManager.healthKitEnabled` for the same
+    /// reason as `nightscoutEnabled`. Driven by an explicit user toggle
+    /// now (issue #83), so the data-source group re-appears as soon as
+    /// the user turns HealthKit off again without waiting for samples
+    /// to age out.
+    @State private var healthKitEnabled: Bool
     @State private var showHideConfirmation = false
 
     init(refreshToken: Binding<Int>) {
@@ -56,7 +56,7 @@ struct SetupChecklistCard: View {
         _shieldingEnabled = State(initialValue: data.shieldingEnabled)
         _nightscoutEnabled = State(initialValue: data.nightscoutEnabled)
         _isMockModeEnabled = State(initialValue: data.isMockModeEnabled)
-        _healthKitDeliveringRecently = State(initialValue: data.healthKitDeliveringRecently)
+        _healthKitEnabled = State(initialValue: data.healthKitEnabled)
     }
 
     var body: some View {
@@ -128,11 +128,11 @@ struct SetupChecklistCard: View {
     ///
     /// Mirrors `SharedDataManager.hasAnyDataSource` but reads from local
     /// @State so SwiftUI re-renders when any of the underlying flags
-    /// (`nightscoutEnabled`, `isMockModeEnabled`, `healthKitDeliveringRecently`)
+    /// (`nightscoutEnabled`, `isMockModeEnabled`, `healthKitEnabled`)
     /// changes. Reading the manager directly here would skip re-render
     /// because the body wouldn't observe those flags.
     private var hasAnyDataSource: Bool {
-        nightscoutEnabled || isMockModeEnabled || healthKitDeliveringRecently
+        nightscoutEnabled || isMockModeEnabled || healthKitEnabled
     }
 
     /// The shielding row stays visible until shielding is actually enabled —
@@ -326,7 +326,7 @@ struct SetupChecklistCard: View {
         shieldingEnabled = data.shieldingEnabled
         nightscoutEnabled = data.nightscoutEnabled
         isMockModeEnabled = data.isMockModeEnabled
-        healthKitDeliveringRecently = data.healthKitDeliveringRecently
+        healthKitEnabled = data.healthKitEnabled
         Task {
             let settings = await UNUserNotificationCenter.current().notificationSettings()
             await MainActor.run { notificationStatus = settings.authorizationStatus }

--- a/iOS/App/SharedDataManager.swift
+++ b/iOS/App/SharedDataManager.swift
@@ -23,47 +23,113 @@ final class SharedDataManager {
         }
     }
 
-    // MARK: - Glucose Data
+    // MARK: - Unified readings (single source of truth for display)
 
-    var currentGlucose: Double? {
-        let value = defaults?.double(forKey: "currentGlucose") ?? 0
-        return value > 0 ? value : nil
+    /// Glucose reading the app should display right now: Demo wins when
+    /// mock mode is on, otherwise the freshest reading among enabled
+    /// sources. Returns nil when no enabled source has a sample. See
+    /// `SharedKit.UnifiedDataReader` for the full contract.
+    var currentGlucoseReading: GlucoseReading? {
+        UnifiedDataReader.currentGlucoseReading(from: defaults)
     }
 
-    var glucoseFetchedAt: Date? {
-        guard let iso = defaults?.string(forKey: "glucoseFetchedAt") else { return nil }
-        return ISO8601DateFormatter().date(from: iso)
+    var currentCarbsReading: CarbsReading? {
+        UnifiedDataReader.currentCarbsReading(from: defaults)
     }
 
-    /// Persist a glucose sample. By default uses a "save if newer" strategy so
-    /// HealthKit and Nightscout (which both write to the same App Group keys)
-    /// never clobber a fresher reading from the other source. Pass `force: true`
-    /// when the caller has an explicit reason to overwrite — e.g. mock data
-    /// configuration where the user picks an older timestamp on purpose.
-    func saveGlucose(mmol: Double, at date: Date, force: Bool = false) {
-        if !force, let existing = glucoseFetchedAt, date <= existing { return }
-        defaults?.set(mmol, forKey: "currentGlucose")
-        defaults?.set(date.ISO8601Format(), forKey: "glucoseFetchedAt")
+    // MARK: - Per-source values (raw storage)
+
+    /// Returns the value and timestamp this source has cached, regardless
+    /// of whether it's currently the winning source in the resolver. Used
+    /// by the per-source settings screens ("last seen from this source"
+    /// rows) and by writers that need to compare against their own last
+    /// write.
+    func glucoseReading(source: DataSource) -> GlucoseReading? {
+        UnifiedDataReader.glucoseReading(source: source, from: defaults)
     }
 
-    // MARK: - Carb Data
-
-    var lastCarbGrams: Double? {
-        let value = defaults?.double(forKey: "lastCarbGrams") ?? 0
-        return value > 0 ? value : nil
+    func carbsReading(source: DataSource) -> CarbsReading? {
+        UnifiedDataReader.carbsReading(source: source, from: defaults)
     }
 
-    var lastCarbEntryAt: Date? {
-        guard let iso = defaults?.string(forKey: "lastCarbEntryAt") else { return nil }
-        return ISO8601DateFormatter().date(from: iso)
+    /// Write a glucose sample for a specific source. Default behaviour is
+    /// "save if newer" against that source's own timestamp so out-of-order
+    /// writes from HealthKit background deliveries can't overwrite a
+    /// fresher sample. Pass `force: true` when the caller is explicitly
+    /// stamping older data (Demo mode configuration).
+    func saveHealthKitGlucose(mmol: Double, at date: Date, force: Bool = false) {
+        saveGlucose(source: .healthKit, mmol: mmol, at: date, force: force)
     }
 
-    /// Persist a carb entry with the same "save if newer" semantics as
-    /// `saveGlucose`.
-    func saveCarbs(grams: Double, at date: Date, force: Bool = false) {
-        if !force, let existing = lastCarbEntryAt, date <= existing { return }
-        defaults?.set(grams, forKey: "lastCarbGrams")
-        defaults?.set(date.ISO8601Format(), forKey: "lastCarbEntryAt")
+    func saveNightscoutGlucose(mmol: Double, at date: Date, force: Bool = false) {
+        saveGlucose(source: .nightscout, mmol: mmol, at: date, force: force)
+    }
+
+    func saveDemoGlucose(mmol: Double, at date: Date, force: Bool = true) {
+        saveGlucose(source: .demo, mmol: mmol, at: date, force: force)
+    }
+
+    func saveHealthKitCarbs(grams: Double, at date: Date, force: Bool = false) {
+        saveCarbs(source: .healthKit, grams: grams, at: date, force: force)
+    }
+
+    func saveNightscoutCarbs(grams: Double, at date: Date, force: Bool = false) {
+        saveCarbs(source: .nightscout, grams: grams, at: date, force: force)
+    }
+
+    func saveDemoCarbs(grams: Double, at date: Date, force: Bool = true) {
+        saveCarbs(source: .demo, grams: grams, at: date, force: force)
+    }
+
+    /// Clear every cached value for a single source. Used when:
+    ///
+    /// - The user toggles HealthKit off (see `handleSourceDisabled(.healthKit)`).
+    /// - The user toggles Nightscout off and wants its last reading out of
+    ///   the way.
+    /// - Demo mode is disabled and its synthesised values should stop
+    ///   masquerading as real data.
+    func clearHealthKitData() { clearSource(.healthKit) }
+    func clearNightscoutData() { clearSource(.nightscout) }
+    func clearDemoData() { clearSource(.demo) }
+
+    /// Targeted per-metric clears — used by the Demo Settings panel
+    /// where each metric has its own "has data?" toggle, so clearing
+    /// glucose must not wipe the carbs the user is still editing.
+    func clearDemoGlucose() {
+        defaults?.removeObject(forKey: UnifiedDataReader.glucoseValueKey(for: .demo))
+        defaults?.removeObject(forKey: UnifiedDataReader.glucoseDateKey(for: .demo))
+    }
+
+    func clearDemoCarbs() {
+        defaults?.removeObject(forKey: UnifiedDataReader.carbsValueKey(for: .demo))
+        defaults?.removeObject(forKey: UnifiedDataReader.carbsDateKey(for: .demo))
+    }
+
+    private func saveGlucose(source: DataSource, mmol: Double, at date: Date, force: Bool) {
+        let valueKey = UnifiedDataReader.glucoseValueKey(for: source)
+        let dateKey = UnifiedDataReader.glucoseDateKey(for: source)
+        if !force, let existingIso = defaults?.string(forKey: dateKey),
+           let existing = ISO8601DateFormatter().date(from: existingIso),
+           date <= existing { return }
+        defaults?.set(mmol, forKey: valueKey)
+        defaults?.set(date.ISO8601Format(), forKey: dateKey)
+    }
+
+    private func saveCarbs(source: DataSource, grams: Double, at date: Date, force: Bool) {
+        let valueKey = UnifiedDataReader.carbsValueKey(for: source)
+        let dateKey = UnifiedDataReader.carbsDateKey(for: source)
+        if !force, let existingIso = defaults?.string(forKey: dateKey),
+           let existing = ISO8601DateFormatter().date(from: existingIso),
+           date <= existing { return }
+        defaults?.set(grams, forKey: valueKey)
+        defaults?.set(date.ISO8601Format(), forKey: dateKey)
+    }
+
+    private func clearSource(_ source: DataSource) {
+        defaults?.removeObject(forKey: UnifiedDataReader.glucoseValueKey(for: source))
+        defaults?.removeObject(forKey: UnifiedDataReader.glucoseDateKey(for: source))
+        defaults?.removeObject(forKey: UnifiedDataReader.carbsValueKey(for: source))
+        defaults?.removeObject(forKey: UnifiedDataReader.carbsDateKey(for: source))
     }
 
     // MARK: - Attention Badge
@@ -81,12 +147,14 @@ final class SharedDataManager {
     /// was attention in `ShieldContent` but not in the badge).
     @MainActor
     func refreshAttentionBadge() {
-        let glucose = currentGlucose ?? 0
+        let glucoseReading = currentGlucoseReading
+        let carbsReading = currentCarbsReading
+        let glucose = glucoseReading?.mmol ?? 0
         let content = ShieldContent(
             glucose: glucose,
-            glucoseFetchedAt: glucoseFetchedAt,
-            lastCarbGrams: lastCarbGrams,
-            lastCarbEntryAt: lastCarbEntryAt,
+            glucoseFetchedAt: glucoseReading?.sampleAt,
+            lastCarbGrams: carbsReading?.grams,
+            lastCarbEntryAt: carbsReading?.sampleAt,
             highGlucoseThreshold: effectiveHighGlucoseThreshold,
             lowGlucoseThreshold: effectiveLowGlucoseThreshold,
             criticalGlucoseThreshold: effectiveCriticalGlucoseThreshold,
@@ -124,123 +192,56 @@ final class SharedDataManager {
         return rearmAt.timeIntervalSinceNow > 0
     }
 
-    // MARK: - Mock Mode (DEBUG only, writes to same keys as HealthKit)
+    // MARK: - Data-source toggles
+
+    /// Whether the user has toggled Apple Health on in Settings. This is
+    /// the only authoritative "use HealthKit data?" signal — iOS privacy-
+    /// masks the read auth status, so we can't tell from the system
+    /// whether the user actually granted access. The toggle is the gate.
+    var healthKitEnabled: Bool {
+        get { defaults?.bool(forKey: DataSourceKeys.healthKitEnabled) ?? false }
+        set { defaults?.set(newValue, forKey: DataSourceKeys.healthKitEnabled) }
+    }
 
     var isMockModeEnabled: Bool {
-        get { defaults?.bool(forKey: "mockModeEnabled") ?? false }
-        set { defaults?.set(newValue, forKey: "mockModeEnabled") }
+        get { defaults?.bool(forKey: DataSourceKeys.mockModeEnabled) ?? false }
+        set { defaults?.set(newValue, forKey: DataSourceKeys.mockModeEnabled) }
     }
 
-    func clearGlucoseData() {
-        defaults?.removeObject(forKey: "currentGlucose")
-        defaults?.removeObject(forKey: "glucoseFetchedAt")
-    }
-
-    func clearCarbData() {
-        defaults?.removeObject(forKey: "lastCarbGrams")
-        defaults?.removeObject(forKey: "lastCarbEntryAt")
-    }
-
-    /// Disable mock mode. The cached glucose / carb values share storage
-    /// with HealthKit and Nightscout (see `saveGlucose` doc), so we can't
-    /// safely wipe them unconditionally — Nightscout-or-HK-sourced
-    /// values would disappear too. `handleInAppSourceDisabled` only
-    /// clears when no in-app source remains, leaving live sources to
-    /// re-publish on their own poll/observer cycle.
+    /// Disable mock mode. Clears Demo's cached values so the synthesised
+    /// numbers can't leak into the resolver on the next launch (the
+    /// resolver already ignores Demo when `mockModeEnabled == false`, but
+    /// clearing prevents the next "enable" from showing stale demo data
+    /// before the user reconfigures).
     func clearMockData() {
         isMockModeEnabled = false
-        handleInAppSourceDisabled()
+        clearDemoData()
         logger.info("Mock mode disabled")
     }
 
-    // MARK: - Data Sources
-
-    /// Set to true the first time Apple Health actually delivers a sample
-    /// (glucose or carb). Stays true afterwards — we have no reliable way
-    /// to detect that the user later revoked read access in the Health
-    /// app, so "has ever delivered" is the most honest "we successfully
-    /// got data from HK at some point" signal.
-    ///
-    /// Why not just use `HKHealthStore.authorizationStatus`? For read-only
-    /// requests iOS privacy-masks that status: it returns `.sharingDenied`
-    /// both when the user denied *and* when we haven't asked. A user who
-    /// denied HealthKit looks identical to a user who accepted it until a
-    /// sample arrives, so we wait for the sample.
-    ///
-    /// Treat this as historical only — for the "is HK currently a source
-    /// I should trust?" question, use `healthKitDeliveringRecently`. The
-    /// `hasAnyDataSource` gate combines that with the user-controlled
-    /// Nightscout / Demo toggles.
-    var healthKitEverDelivered: Bool {
-        get { defaults?.bool(forKey: "healthKitEverDelivered") ?? false }
-        set { defaults?.set(newValue, forKey: "healthKitEverDelivered") }
-    }
-
-    /// Call this from `HealthKitManager` as soon as a real sample is saved.
-    func markHealthKitDelivered() {
-        if healthKitEverDelivered { return }
-        healthKitEverDelivered = true
-        flush()
-        logger.info("HealthKit marked as delivering")
-    }
-
-    /// True when Apple Health both has delivered at least one sample AND
-    /// the latest stored glucose timestamp is fresher than `glucoseStaleMinutes`.
-    /// Used as the "HK is currently active" proxy because iOS doesn't let
-    /// us read the actual read-auth status (see `healthKitEverDelivered`).
-    ///
-    /// `glucoseFetchedAt` is shared across HK and Nightscout — that's
-    /// fine: if anyone wrote a fresh sample recently, *something* is
-    /// alive. When the user disables Nightscout/Demo the disable handler
-    /// clears the cached values (see `handleInAppSourceDisabled`), so a
-    /// stale-but-non-nil timestamp left over from a since-disabled source
-    /// can't masquerade as HK delivery.
-    ///
-    /// Honours the same override-with-xcconfig-fallback contract as every
-    /// other staleness check in the app (see `ThresholdResolver`): user
-    /// override wins, otherwise the build-time `GlucoseStaleMinutes` default.
-    var healthKitDeliveringRecently: Bool {
-        guard healthKitEverDelivered, let last = glucoseFetchedAt else { return false }
-        let minutes = effectiveGlucoseStaleMinutes
-        return Date().timeIntervalSince(last) < TimeInterval(minutes * 60)
-    }
-
-    /// True when at least one data source can credibly be supplying data
-    /// **right now**:
-    ///
-    /// - Nightscout / Demo: user has toggled them on.
-    /// - Apple Health: has delivered a sample within `glucoseStaleMinutes`
-    ///   (see `healthKitDeliveringRecently`).
-    ///
-    /// Drives both UI surfaces (welcome panel, setup checklist) and the
-    /// shielding gate. Shielding can't make red/green decisions without
-    /// fresh input, so disabling the last live source also disables
-    /// shielding (see `ShieldManager.disableIfNoDataSource()`).
+    /// True when at least one data source is toggled on. Drives the
+    /// welcome panel, the setup checklist, and the shielding gate. With
+    /// per-source toggles in place this is now a simple `OR` of the
+    /// three enabled flags — no recency heuristic needed.
     var hasAnyDataSource: Bool {
-        if nightscoutEnabled || isMockModeEnabled { return true }
-        return healthKitDeliveringRecently
+        healthKitEnabled || nightscoutEnabled || isMockModeEnabled
     }
 
-    /// Call after the user disables an in-app data-source toggle
-    /// (Nightscout, Demo). When no in-app source remains enabled, wipes
-    /// the cached glucose + carb values so the home screen returns to the
-    /// welcome state and the setup checklist re-shows the data-source
-    /// rows immediately, rather than the user staring at a stale "green
-    /// with data" panel and an empty checklist.
+    /// Call after a data-source toggle flips off. Clears the disabled
+    /// source's cached values so neither the resolver nor the
+    /// per-source settings screen shows stale numbers from it, and
+    /// returns so callers can decide whether to kick remaining live
+    /// sources.
     ///
-    /// HK is intentionally not in the "anything left" check here — we
-    /// can't programmatically tell whether HK read auth is still granted.
-    /// Two outcomes both end up correct:
-    /// - HK is still authorized and delivering → its next observer fire
-    ///   re-populates the cleared values within seconds.
-    /// - HK was revoked / never set up → the values stay cleared and the
-    ///   welcome / setup state is honest.
-    func handleInAppSourceDisabled() {
-        guard !nightscoutEnabled, !isMockModeEnabled else { return }
-        clearGlucoseData()
-        clearCarbData()
+    /// Unlike the previous "clear everything if nothing left" heuristic,
+    /// this is always safe: each source owns its own keys now, so
+    /// clearing HK never affects Nightscout's cache and vice versa. The
+    /// resolver ignores disabled sources anyway, so clearing is only
+    /// about keeping the per-source screens honest.
+    func handleSourceDisabled(_ source: DataSource) {
+        clearSource(source)
         flush()
-        logger.info("All in-app data sources disabled — cleared cached glucose/carb values")
+        logger.info("Cleared cached values for disabled source: \(source.rawValue)")
     }
 
     // MARK: - Glucose Unit
@@ -443,11 +444,13 @@ final class SharedDataManager {
             "glucoseStaleMinutes", "carbGraceHour", "carbGraceMinute",
             "attentionIntervalMinutes", "noAttentionIntervalMinutes",
             "cooldownSeconds", "shieldingEnabled", "onlyShieldWhenAttention",
-            "glucoseBadgeMode", "glucoseUnit", "rearmShieldsAt", "mockModeEnabled",
-            "nightscoutEnabled", "nightscoutBaseURL", "nightscoutToken",
+            "glucoseBadgeMode", "glucoseUnit", "rearmShieldsAt",
+            DataSourceKeys.mockModeEnabled,
+            DataSourceKeys.nightscoutEnabled,
+            DataSourceKeys.healthKitEnabled,
+            "nightscoutBaseURL", "nightscoutToken",
             "nightscoutLastFetchedAt", "nightscoutLastError",
             "setupTipsHidden",
-            "healthKitEverDelivered",
         ]
         for key in settingsKeys {
             defaults?.removeObject(forKey: key)
@@ -460,8 +463,8 @@ final class SharedDataManager {
     // MARK: - Nightscout
 
     var nightscoutEnabled: Bool {
-        get { defaults?.bool(forKey: "nightscoutEnabled") ?? false }
-        set { defaults?.set(newValue, forKey: "nightscoutEnabled") }
+        get { defaults?.bool(forKey: DataSourceKeys.nightscoutEnabled) ?? false }
+        set { defaults?.set(newValue, forKey: DataSourceKeys.nightscoutEnabled) }
     }
 
     var nightscoutBaseURL: String? {
@@ -572,4 +575,5 @@ final class SharedDataManager {
             return nil
         }
     }
+
 }

--- a/iOS/App/ShieldManager.swift
+++ b/iOS/App/ShieldManager.swift
@@ -70,10 +70,10 @@ final class ShieldManager {
         let graceHour = data.effectiveCarbGraceHour
         let graceMinute = data.effectiveCarbGraceMinute
 
-        let glucose = data.currentGlucose ?? 0
-        if glucose > 0, let fetchedAt = data.glucoseFetchedAt {
+        if let glucoseReading = data.currentGlucoseReading {
+            let glucose = glucoseReading.mmol
             if glucose < lowThreshold || glucose > highThreshold { return true }
-            if now.timeIntervalSince(fetchedAt) / 60 > Double(staleMinutes) { return true }
+            if now.timeIntervalSince(glucoseReading.sampleAt) / 60 > Double(staleMinutes) { return true }
         } else {
             return true
         }
@@ -84,8 +84,8 @@ final class ShieldManager {
         let isMorningGrace = hour < graceHour || (hour == graceHour && minute < graceMinute)
 
         if !isMorningGrace {
-            if let carbDate = data.lastCarbEntryAt {
-                if now.timeIntervalSince(carbDate) / 3600 > 4 { return true }
+            if let carbsReading = data.currentCarbsReading {
+                if now.timeIntervalSince(carbsReading.sampleAt) / 3600 > 4 { return true }
             } else {
                 return true
             }
@@ -147,7 +147,7 @@ final class ShieldManager {
     @discardableResult
     func disarmShields() -> Bool {
         let data = SharedDataManager.shared
-        let glucose = data.currentGlucose ?? 0
+        let glucose = data.currentGlucoseReading?.mmol ?? 0
         let criticalThreshold = data.effectiveCriticalGlucoseThreshold
         if glucose > 0, glucose >= criticalThreshold {
             logger.notice("Critical glucose \(glucose) >= \(criticalThreshold) — refusing to disarm")

--- a/iOS/App/WatchSessionManager.swift
+++ b/iOS/App/WatchSessionManager.swift
@@ -83,17 +83,13 @@ final class WatchSessionManager: NSObject, WCSessionDelegate {
         if let token = data.nightscoutToken { context["nightscoutToken"] = token }
 
         if data.isMockModeEnabled {
-            if let glucose = data.currentGlucose {
-                context["currentGlucose"] = glucose
+            if let glucoseReading = data.currentGlucoseReading {
+                context["currentGlucose"] = glucoseReading.mmol
+                context["glucoseFetchedAt"] = glucoseReading.sampleAt.ISO8601Format()
             }
-            if let glucoseFetchedAt = data.glucoseFetchedAt {
-                context["glucoseFetchedAt"] = glucoseFetchedAt.ISO8601Format()
-            }
-            if let lastCarbGrams = data.lastCarbGrams {
-                context["lastCarbGrams"] = lastCarbGrams
-            }
-            if let lastCarbEntryAt = data.lastCarbEntryAt {
-                context["lastCarbEntryAt"] = lastCarbEntryAt.ISO8601Format()
+            if let carbsReading = data.currentCarbsReading {
+                context["lastCarbGrams"] = carbsReading.grams
+                context["lastCarbEntryAt"] = carbsReading.sampleAt.ISO8601Format()
             }
         }
 

--- a/iOS/App/en.lproj/Localizable.strings
+++ b/iOS/App/en.lproj/Localizable.strings
@@ -41,6 +41,13 @@
 "healthkit.settings.requestButton" = "Connect Apple Health";
 "healthkit.settings.openHealthButton" = "Open Health app";
 "healthkit.settings.sectionFooter" = "Permissions are managed in the Health app under Sharing › Apps.";
+"healthkit.settings.enabledToggle" = "Enable Apple Health";
+"healthkit.settings.enabledFooter" = "Read glucose and carb samples from Apple Health. Turning this on will request permission if you haven't granted it yet. Turning it off stops using Health data even if permission is still granted.";
+"healthkit.settings.latestDataHeader" = "Latest data";
+"healthkit.settings.latestGlucose" = "Glucose";
+"healthkit.settings.latestCarbs" = "Carbs";
+"healthkit.settings.noGlucoseYet" = "No data yet";
+"healthkit.settings.noCarbsYet" = "No data yet";
 
 /* Settings - Data Sources */
 "settings.dataSources" = "Data Sources";
@@ -161,10 +168,11 @@
 "settings.nightscoutVersion %@" = "Version: %@";
 "settings.nightscoutUnits %@" = "Server units: %@";
 "settings.nightscoutStatusHeader" = "Status";
-"settings.nightscoutLastFetch" = "Last update";
-"settings.nightscoutNotConfigured" = "Not configured yet.";
-"settings.nightscoutDisabled" = "Disabled.";
-"settings.nightscoutAwaitingFirstUpdate" = "Awaiting first update…";
+"settings.nightscoutLatestHeader" = "Latest data";
+"settings.nightscoutLatestGlucose" = "Glucose";
+"settings.nightscoutLatestCarbs" = "Carbs";
+"settings.nightscoutNoGlucoseYet" = "No data yet";
+"settings.nightscoutNoCarbsYet" = "No data yet";
 
 /* Check-In Flow */
 "checkin.disarmButton" = "All Done";

--- a/iOS/App/nl.lproj/Localizable.strings
+++ b/iOS/App/nl.lproj/Localizable.strings
@@ -41,6 +41,13 @@
 "healthkit.settings.requestButton" = "Apple Gezondheid koppelen";
 "healthkit.settings.openHealthButton" = "Open Gezondheid-app";
 "healthkit.settings.sectionFooter" = "Rechten beheer je in de Gezondheid-app bij Delen › Apps.";
+"healthkit.settings.enabledToggle" = "Apple Gezondheid inschakelen";
+"healthkit.settings.enabledFooter" = "Lees glucose- en koolhydraatgegevens uit Apple Gezondheid. Als je dit inschakelt, wordt waar nodig om toestemming gevraagd. Uitschakelen zorgt dat de app geen Gezondheid-gegevens meer gebruikt, ook als de toestemming nog actief is.";
+"healthkit.settings.latestDataHeader" = "Laatste gegevens";
+"healthkit.settings.latestGlucose" = "Glucose";
+"healthkit.settings.latestCarbs" = "Koolhydraten";
+"healthkit.settings.noGlucoseYet" = "Nog geen gegevens";
+"healthkit.settings.noCarbsYet" = "Nog geen gegevens";
 
 /* Instellingen - Gegevensbronnen */
 "settings.dataSources" = "Gegevensbronnen";
@@ -161,10 +168,11 @@
 "settings.nightscoutVersion %@" = "Versie: %@";
 "settings.nightscoutUnits %@" = "Server-eenheid: %@";
 "settings.nightscoutStatusHeader" = "Status";
-"settings.nightscoutLastFetch" = "Laatste update";
-"settings.nightscoutNotConfigured" = "Nog niet ingesteld.";
-"settings.nightscoutDisabled" = "Uitgeschakeld.";
-"settings.nightscoutAwaitingFirstUpdate" = "Wachten op eerste update…";
+"settings.nightscoutLatestHeader" = "Laatste gegevens";
+"settings.nightscoutLatestGlucose" = "Glucose";
+"settings.nightscoutLatestCarbs" = "Koolhydraten";
+"settings.nightscoutNoGlucoseYet" = "Nog geen gegevens";
+"settings.nightscoutNoCarbsYet" = "Nog geen gegevens";
 
 /* Inchecken */
 "checkin.disarmButton" = "Klaar";

--- a/iOS/DeviceActivityMonitor/DeviceActivityMonitorExtension.swift
+++ b/iOS/DeviceActivityMonitor/DeviceActivityMonitorExtension.swift
@@ -79,13 +79,16 @@ class DeviceActivityMonitorExtension: DeviceActivityMonitor {
         let graceHour = ThresholdResolver.carbGraceHour(defaults: defaults, fallback: Self.fallbackCarbGraceHour)
         let graceMinute = ThresholdResolver.carbGraceMinute(defaults: defaults, fallback: Self.fallbackCarbGraceMinute)
 
-        let glucose = defaults?.double(forKey: "currentGlucose") ?? 0
-        if let isoStr = defaults?.string(forKey: "glucoseFetchedAt"),
-           let fetchedAt = ISO8601DateFormatter().date(from: isoStr) {
-            if glucose < lowThreshold || glucose > highThreshold {
+        // Per-source storage: use `UnifiedDataReader` so the Demo
+        // override and freshest-enabled-source rule apply here too.
+        let glucoseReading = UnifiedDataReader.currentGlucoseReading(from: defaults)
+        let carbsReading = UnifiedDataReader.currentCarbsReading(from: defaults)
+
+        if let glucoseReading {
+            if glucoseReading.mmol < lowThreshold || glucoseReading.mmol > highThreshold {
                 return true
             }
-            if now.timeIntervalSince(fetchedAt) / 60 > Double(staleMinutes) {
+            if now.timeIntervalSince(glucoseReading.sampleAt) / 60 > Double(staleMinutes) {
                 return true
             }
         } else {
@@ -99,9 +102,8 @@ class DeviceActivityMonitorExtension: DeviceActivityMonitor {
             || (hour == graceHour && minute < graceMinute)
 
         if !isMorningGrace {
-            if let isoStr = defaults?.string(forKey: "lastCarbEntryAt"),
-               let carbDate = ISO8601DateFormatter().date(from: isoStr) {
-                if now.timeIntervalSince(carbDate) / 3600 > 4 {
+            if let carbsReading {
+                if now.timeIntervalSince(carbsReading.sampleAt) / 3600 > 4 {
                     return true
                 }
             } else {

--- a/iOS/SharedKit/Sources/SharedKit/UnifiedDataReader.swift
+++ b/iOS/SharedKit/Sources/SharedKit/UnifiedDataReader.swift
@@ -1,0 +1,190 @@
+import Foundation
+
+/// The three data sources that can supply glucose + carb samples to the app.
+///
+/// Each source writes to its own set of App Group `UserDefaults` keys
+/// (`<source>Glucose`, `<source>GlucoseSampleAt`, `<source>Carbs`,
+/// `<source>CarbsSampleAt`). Readers across the app — home screen, shield
+/// extensions, widgets, watch — go through `UnifiedDataReader` so a single
+/// resolution rule decides which source's values actually get displayed.
+public enum DataSource: String, Sendable, CaseIterable {
+    case healthKit
+    case nightscout
+    case demo
+}
+
+/// Centralised key strings for everything tied to the per-source data
+/// contract. Shield extensions and the Device Activity Monitor read App
+/// Group `UserDefaults` directly (no `SharedDataManager` available there),
+/// so these constants are the single source of truth for keys the App
+/// target writes and everyone else reads.
+public enum DataSourceKeys {
+    public static let healthKitGlucose = "healthKitGlucose"
+    public static let healthKitGlucoseSampleAt = "healthKitGlucoseSampleAt"
+    public static let healthKitCarbs = "healthKitCarbs"
+    public static let healthKitCarbsSampleAt = "healthKitCarbsSampleAt"
+
+    public static let nightscoutGlucose = "nightscoutGlucose"
+    public static let nightscoutGlucoseSampleAt = "nightscoutGlucoseSampleAt"
+    public static let nightscoutCarbs = "nightscoutCarbs"
+    public static let nightscoutCarbsSampleAt = "nightscoutCarbsSampleAt"
+
+    public static let demoGlucose = "demoGlucose"
+    public static let demoGlucoseSampleAt = "demoGlucoseSampleAt"
+    public static let demoCarbs = "demoCarbs"
+    public static let demoCarbsSampleAt = "demoCarbsSampleAt"
+
+    public static let healthKitEnabled = "healthKitEnabled"
+    public static let nightscoutEnabled = "nightscoutEnabled"
+    public static let mockModeEnabled = "mockModeEnabled"
+}
+
+public struct GlucoseReading: Sendable, Equatable {
+    public let mmol: Double
+    public let sampleAt: Date
+    public let source: DataSource
+
+    public init(mmol: Double, sampleAt: Date, source: DataSource) {
+        self.mmol = mmol
+        self.sampleAt = sampleAt
+        self.source = source
+    }
+}
+
+public struct CarbsReading: Sendable, Equatable {
+    public let grams: Double
+    public let sampleAt: Date
+    public let source: DataSource
+
+    public init(grams: Double, sampleAt: Date, source: DataSource) {
+        self.grams = grams
+        self.sampleAt = sampleAt
+        self.source = source
+    }
+}
+
+/// Resolves which source's glucose + carb values should be displayed
+/// right now, given the enabled toggles and per-source timestamps.
+///
+/// Resolution rule (mirrored for glucose and carbs independently):
+///
+/// 1. **Demo override.** When `mockModeEnabled == true`, Demo's value
+///    for that metric wins — regardless of age, and regardless of
+///    whether HealthKit / Nightscout also have fresher samples. The
+///    user turning Demo on is an explicit "show me the fake data"
+///    signal.
+/// 2. **Freshest enabled source wins.** Otherwise, among the enabled
+///    sources (`healthKitEnabled` → HealthKit, `nightscoutEnabled` →
+///    Nightscout), pick the one with the newest `*SampleAt`. Glucose
+///    and carbs are resolved independently, so it's fine (and expected)
+///    for glucose to come from HealthKit while carbs come from
+///    Nightscout.
+/// 3. **Nil when no enabled source has a sample.** The caller is
+///    responsible for rendering an empty / welcome state.
+///
+/// Disabled sources are ignored entirely — a user who toggles HealthKit
+/// off keeps whatever cached `healthKit*` values are in storage, but
+/// this reader never returns them. This is deliberate: we can't revoke
+/// iOS HealthKit authorization programmatically, so the toggle is the
+/// only authoritative "use this source?" signal.
+public enum UnifiedDataReader {
+    /// Build a glucose reading from the active source resolution rule.
+    /// Returns nil when no enabled source has a stored sample.
+    public static func currentGlucoseReading(from defaults: UserDefaults?) -> GlucoseReading? {
+        guard let defaults else { return nil }
+
+        if defaults.bool(forKey: DataSourceKeys.mockModeEnabled) {
+            return glucoseReading(source: .demo, from: defaults)
+        }
+
+        var candidates: [GlucoseReading] = []
+        if defaults.bool(forKey: DataSourceKeys.healthKitEnabled),
+           let reading = glucoseReading(source: .healthKit, from: defaults) {
+            candidates.append(reading)
+        }
+        if defaults.bool(forKey: DataSourceKeys.nightscoutEnabled),
+           let reading = glucoseReading(source: .nightscout, from: defaults) {
+            candidates.append(reading)
+        }
+        return candidates.max(by: { $0.sampleAt < $1.sampleAt })
+    }
+
+    /// Build a carbs reading from the active source resolution rule.
+    /// Returns nil when no enabled source has a stored sample.
+    public static func currentCarbsReading(from defaults: UserDefaults?) -> CarbsReading? {
+        guard let defaults else { return nil }
+
+        if defaults.bool(forKey: DataSourceKeys.mockModeEnabled) {
+            return carbsReading(source: .demo, from: defaults)
+        }
+
+        var candidates: [CarbsReading] = []
+        if defaults.bool(forKey: DataSourceKeys.healthKitEnabled),
+           let reading = carbsReading(source: .healthKit, from: defaults) {
+            candidates.append(reading)
+        }
+        if defaults.bool(forKey: DataSourceKeys.nightscoutEnabled),
+           let reading = carbsReading(source: .nightscout, from: defaults) {
+            candidates.append(reading)
+        }
+        return candidates.max(by: { $0.sampleAt < $1.sampleAt })
+    }
+
+    /// Per-source glucose reading, regardless of whether the source is the
+    /// one currently winning the resolution rule. Used by the per-source
+    /// settings screens to show "latest from this source" rows.
+    public static func glucoseReading(source: DataSource, from defaults: UserDefaults?) -> GlucoseReading? {
+        guard let defaults else { return nil }
+        let value = defaults.double(forKey: glucoseValueKey(for: source))
+        guard value > 0, let date = defaults.iso8601(forKey: glucoseDateKey(for: source)) else { return nil }
+        return GlucoseReading(mmol: value, sampleAt: date, source: source)
+    }
+
+    public static func carbsReading(source: DataSource, from defaults: UserDefaults?) -> CarbsReading? {
+        guard let defaults else { return nil }
+        let value = defaults.double(forKey: carbsValueKey(for: source))
+        guard value > 0, let date = defaults.iso8601(forKey: carbsDateKey(for: source)) else { return nil }
+        return CarbsReading(grams: value, sampleAt: date, source: source)
+    }
+
+    public static func glucoseValueKey(for source: DataSource) -> String {
+        switch source {
+        case .healthKit: return DataSourceKeys.healthKitGlucose
+        case .nightscout: return DataSourceKeys.nightscoutGlucose
+        case .demo: return DataSourceKeys.demoGlucose
+        }
+    }
+
+    public static func glucoseDateKey(for source: DataSource) -> String {
+        switch source {
+        case .healthKit: return DataSourceKeys.healthKitGlucoseSampleAt
+        case .nightscout: return DataSourceKeys.nightscoutGlucoseSampleAt
+        case .demo: return DataSourceKeys.demoGlucoseSampleAt
+        }
+    }
+
+    public static func carbsValueKey(for source: DataSource) -> String {
+        switch source {
+        case .healthKit: return DataSourceKeys.healthKitCarbs
+        case .nightscout: return DataSourceKeys.nightscoutCarbs
+        case .demo: return DataSourceKeys.demoCarbs
+        }
+    }
+
+    public static func carbsDateKey(for source: DataSource) -> String {
+        switch source {
+        case .healthKit: return DataSourceKeys.healthKitCarbsSampleAt
+        case .nightscout: return DataSourceKeys.nightscoutCarbsSampleAt
+        case .demo: return DataSourceKeys.demoCarbsSampleAt
+        }
+    }
+}
+
+extension UserDefaults {
+    /// Read an ISO8601-formatted date string and parse it. Returns nil on
+    /// missing value or malformed string.
+    fileprivate func iso8601(forKey key: String) -> Date? {
+        guard let iso = string(forKey: key) else { return nil }
+        return ISO8601DateFormatter().date(from: iso)
+    }
+}

--- a/iOS/SharedKit/Sources/SharedKit/WidgetNightscoutRefresh.swift
+++ b/iOS/SharedKit/Sources/SharedKit/WidgetNightscoutRefresh.swift
@@ -48,8 +48,8 @@ public enum WidgetNightscoutRefresh {
     ///   from. Pass the same suite the widget's `EntryBuilder` uses.
     public static func refreshIfDue(defaults: UserDefaults?) async {
         guard let defaults else { return }
-        guard defaults.bool(forKey: "nightscoutEnabled") else { return }
-        guard !defaults.bool(forKey: "mockModeEnabled") else { return }
+        guard defaults.bool(forKey: DataSourceKeys.nightscoutEnabled) else { return }
+        guard !defaults.bool(forKey: DataSourceKeys.mockModeEnabled) else { return }
         guard let urlString = defaults.string(forKey: "nightscoutBaseURL"),
               !urlString.isEmpty else { return }
 
@@ -99,8 +99,8 @@ public enum WidgetNightscoutRefresh {
         if let glucose {
             saveIfNewer(
                 defaults: defaults,
-                valueKey: "currentGlucose",
-                dateKey: "glucoseFetchedAt",
+                valueKey: UnifiedDataReader.glucoseValueKey(for: .nightscout),
+                dateKey: UnifiedDataReader.glucoseDateKey(for: .nightscout),
                 value: glucose.mmol,
                 date: glucose.date
             )
@@ -108,8 +108,8 @@ public enum WidgetNightscoutRefresh {
         if let carbs {
             saveIfNewer(
                 defaults: defaults,
-                valueKey: "lastCarbGrams",
-                dateKey: "lastCarbEntryAt",
+                valueKey: UnifiedDataReader.carbsValueKey(for: .nightscout),
+                dateKey: UnifiedDataReader.carbsDateKey(for: .nightscout),
                 value: carbs.grams,
                 date: carbs.date
             )
@@ -122,9 +122,11 @@ public enum WidgetNightscoutRefresh {
         defaults.set(Date().ISO8601Format(), forKey: "nightscoutLastFetchedAt")
     }
 
-    /// Mirror the "save if newer" semantics in `SharedDataManager.saveGlucose`
-    /// / `saveCarbs` so a HealthKit sample written by the main app since the
-    /// last poll isn't clobbered by an older Nightscout reading.
+    /// Mirror the "save if newer" semantics in `SharedDataManager.saveNightscoutGlucose`
+    /// / `saveNightscoutCarbs` so an out-of-order widget-initiated fetch doesn't
+    /// overwrite a Nightscout sample the main app has already cached as newer.
+    /// (Writes are scoped to Nightscout's own per-source keys now, so they
+    /// can't collide with HealthKit samples anyway.)
     private static func saveIfNewer(
         defaults: UserDefaults,
         valueKey: String,

--- a/iOS/SharedKit/Tests/SharedKitTests/UnifiedDataReaderTests.swift
+++ b/iOS/SharedKit/Tests/SharedKitTests/UnifiedDataReaderTests.swift
@@ -1,0 +1,171 @@
+import Foundation
+import XCTest
+@testable import SharedKit
+
+/// Pins the resolution rule documented in `UnifiedDataReader`:
+///
+/// 1. When Demo mode is on, Demo wins for both metrics regardless of
+///    real-source freshness.
+/// 2. Otherwise the freshest enabled source wins, independently for
+///    glucose and carbs.
+/// 3. Disabled sources are ignored even if they have stored values.
+/// 4. When nothing is stored, the reader returns nil.
+final class UnifiedDataReaderTests: XCTestCase {
+    private let suiteName = "UnifiedDataReaderTests.suite.\(UUID().uuidString)"
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        super.tearDown()
+    }
+
+    // MARK: - Nothing stored
+
+    func testReturnsNilWhenNothingStored() {
+        XCTAssertNil(UnifiedDataReader.currentGlucoseReading(from: defaults))
+        XCTAssertNil(UnifiedDataReader.currentCarbsReading(from: defaults))
+    }
+
+    func testReturnsNilWhenDefaultsIsNil() {
+        XCTAssertNil(UnifiedDataReader.currentGlucoseReading(from: nil))
+        XCTAssertNil(UnifiedDataReader.currentCarbsReading(from: nil))
+    }
+
+    // MARK: - Demo override
+
+    func testDemoOverrideWinsForGlucoseEvenWhenOlderThanHealthKit() {
+        defaults.set(true, forKey: DataSourceKeys.mockModeEnabled)
+        defaults.set(true, forKey: DataSourceKeys.healthKitEnabled)
+
+        writeGlucose(source: .demo, value: 8.0, minutesAgo: 60)
+        writeGlucose(source: .healthKit, value: 6.4, minutesAgo: 5)
+
+        let reading = UnifiedDataReader.currentGlucoseReading(from: defaults)
+        XCTAssertEqual(reading?.source, .demo)
+        XCTAssertEqual(reading?.mmol, 8.0)
+    }
+
+    func testDemoOverrideWinsForCarbsEvenWhenOlderThanNightscout() {
+        defaults.set(true, forKey: DataSourceKeys.mockModeEnabled)
+        defaults.set(true, forKey: DataSourceKeys.nightscoutEnabled)
+
+        writeCarbs(source: .demo, value: 30, minutesAgo: 180)
+        writeCarbs(source: .nightscout, value: 12, minutesAgo: 10)
+
+        let reading = UnifiedDataReader.currentCarbsReading(from: defaults)
+        XCTAssertEqual(reading?.source, .demo)
+        XCTAssertEqual(reading?.grams, 30)
+    }
+
+    func testDemoModeReturnsNilWhenDemoHasNoStoredGlucose() {
+        defaults.set(true, forKey: DataSourceKeys.mockModeEnabled)
+        // Real sources have data but the Demo override should not fall
+        // through to them.
+        defaults.set(true, forKey: DataSourceKeys.healthKitEnabled)
+        writeGlucose(source: .healthKit, value: 6.4, minutesAgo: 5)
+
+        XCTAssertNil(UnifiedDataReader.currentGlucoseReading(from: defaults))
+    }
+
+    // MARK: - Freshest wins (demo off)
+
+    func testHealthKitWinsWhenFresherThanNightscout() {
+        defaults.set(true, forKey: DataSourceKeys.healthKitEnabled)
+        defaults.set(true, forKey: DataSourceKeys.nightscoutEnabled)
+
+        writeGlucose(source: .healthKit, value: 6.4, minutesAgo: 3)
+        writeGlucose(source: .nightscout, value: 7.1, minutesAgo: 15)
+
+        let reading = UnifiedDataReader.currentGlucoseReading(from: defaults)
+        XCTAssertEqual(reading?.source, .healthKit)
+        XCTAssertEqual(reading?.mmol, 6.4)
+    }
+
+    func testNightscoutWinsWhenFresherThanHealthKit() {
+        defaults.set(true, forKey: DataSourceKeys.healthKitEnabled)
+        defaults.set(true, forKey: DataSourceKeys.nightscoutEnabled)
+
+        writeGlucose(source: .healthKit, value: 6.4, minutesAgo: 30)
+        writeGlucose(source: .nightscout, value: 7.1, minutesAgo: 5)
+
+        let reading = UnifiedDataReader.currentGlucoseReading(from: defaults)
+        XCTAssertEqual(reading?.source, .nightscout)
+    }
+
+    /// Glucose and carbs resolve independently — one source can win for
+    /// glucose while the other wins for carbs.
+    func testGlucoseAndCarbsResolveIndependently() {
+        defaults.set(true, forKey: DataSourceKeys.healthKitEnabled)
+        defaults.set(true, forKey: DataSourceKeys.nightscoutEnabled)
+
+        // HK glucose is fresher; NS carbs are fresher.
+        writeGlucose(source: .healthKit, value: 6.4, minutesAgo: 3)
+        writeGlucose(source: .nightscout, value: 7.1, minutesAgo: 20)
+        writeCarbs(source: .healthKit, value: 25, minutesAgo: 200)
+        writeCarbs(source: .nightscout, value: 40, minutesAgo: 30)
+
+        XCTAssertEqual(UnifiedDataReader.currentGlucoseReading(from: defaults)?.source, .healthKit)
+        XCTAssertEqual(UnifiedDataReader.currentCarbsReading(from: defaults)?.source, .nightscout)
+    }
+
+    // MARK: - Disabled sources ignored
+
+    func testDisabledHealthKitIgnoredEvenWithStoredData() {
+        defaults.set(false, forKey: DataSourceKeys.healthKitEnabled)
+        defaults.set(true, forKey: DataSourceKeys.nightscoutEnabled)
+
+        writeGlucose(source: .healthKit, value: 6.4, minutesAgo: 1) // fresher
+        writeGlucose(source: .nightscout, value: 7.1, minutesAgo: 10)
+
+        let reading = UnifiedDataReader.currentGlucoseReading(from: defaults)
+        XCTAssertEqual(reading?.source, .nightscout)
+        XCTAssertEqual(reading?.mmol, 7.1)
+    }
+
+    func testAllSourcesDisabledReturnsNil() {
+        defaults.set(false, forKey: DataSourceKeys.healthKitEnabled)
+        defaults.set(false, forKey: DataSourceKeys.nightscoutEnabled)
+        defaults.set(false, forKey: DataSourceKeys.mockModeEnabled)
+
+        writeGlucose(source: .healthKit, value: 6.4, minutesAgo: 1)
+        writeGlucose(source: .nightscout, value: 7.1, minutesAgo: 2)
+        writeGlucose(source: .demo, value: 8.0, minutesAgo: 3)
+
+        XCTAssertNil(UnifiedDataReader.currentGlucoseReading(from: defaults))
+        XCTAssertNil(UnifiedDataReader.currentCarbsReading(from: defaults))
+    }
+
+    // MARK: - Per-source accessors
+
+    func testPerSourceReadingReturnsStoredValueIgnoringToggles() {
+        // Even with HK disabled, the per-source accessor still exposes
+        // whatever is stored — the settings UI uses this to show the
+        // user the last value it saw, independent of the resolution rule.
+        defaults.set(false, forKey: DataSourceKeys.healthKitEnabled)
+        writeGlucose(source: .healthKit, value: 6.4, minutesAgo: 5)
+
+        let reading = UnifiedDataReader.glucoseReading(source: .healthKit, from: defaults)
+        XCTAssertEqual(reading?.mmol, 6.4)
+    }
+
+    // MARK: - Helpers
+
+    private func writeGlucose(source: DataSource, value: Double, minutesAgo: Double) {
+        let date = Date().addingTimeInterval(-minutesAgo * 60)
+        defaults.set(value, forKey: UnifiedDataReader.glucoseValueKey(for: source))
+        defaults.set(date.ISO8601Format(), forKey: UnifiedDataReader.glucoseDateKey(for: source))
+    }
+
+    private func writeCarbs(source: DataSource, value: Double, minutesAgo: Double) {
+        let date = Date().addingTimeInterval(-minutesAgo * 60)
+        defaults.set(value, forKey: UnifiedDataReader.carbsValueKey(for: source))
+        defaults.set(date.ISO8601Format(), forKey: UnifiedDataReader.carbsDateKey(for: source))
+    }
+}

--- a/iOS/ShieldAction/ShieldActionExtension.swift
+++ b/iOS/ShieldAction/ShieldActionExtension.swift
@@ -29,11 +29,14 @@ class ShieldActionExtension: ShieldActionDelegate {
 
         let defaults = UserDefaults(suiteName: Self.appGroupID)
 
-        let glucose = defaults?.double(forKey: "currentGlucose") ?? 0
-        let glucoseDate = defaults?.string(forKey: "glucoseFetchedAt")
-            .flatMap { ISO8601DateFormatter().date(from: $0) }
-        let carbDate = defaults?.string(forKey: "lastCarbEntryAt")
-            .flatMap { ISO8601DateFormatter().date(from: $0) }
+        // Per-source storage: go through `UnifiedDataReader` so the
+        // shield honours Demo override + freshest-enabled-source wins,
+        // same as every other reader.
+        let glucoseReading = UnifiedDataReader.currentGlucoseReading(from: defaults)
+        let carbsReading = UnifiedDataReader.currentCarbsReading(from: defaults)
+        let glucose = glucoseReading?.mmol ?? 0
+        let glucoseDate = glucoseReading?.sampleAt
+        let carbDate = carbsReading?.sampleAt
 
         let fallbackHigh = Double(Bundle.main.object(forInfoDictionaryKey: "HighGlucoseThreshold") as! String)!
         let fallbackLow = Double(Bundle.main.object(forInfoDictionaryKey: "LowGlucoseThreshold") as! String)!

--- a/iOS/ShieldConfig/ShieldConfigurationExtension.swift
+++ b/iOS/ShieldConfig/ShieldConfigurationExtension.swift
@@ -34,22 +34,23 @@ class ShieldConfigurationExtension: ShieldConfigurationDataSource {
     private func makeConfiguration() -> ShieldConfiguration {
         let defaults = UserDefaults(suiteName: Self.appGroupID)
 
-        let glucoseDate = defaults?.string(forKey: "glucoseFetchedAt")
-            .flatMap { ISO8601DateFormatter().date(from: $0) }
-        let carbDate = defaults?.string(forKey: "lastCarbEntryAt")
-            .flatMap { ISO8601DateFormatter().date(from: $0) }
+        // Per-source storage: resolve the winning glucose/carb reading
+        // via `UnifiedDataReader` instead of reading raw keys. Demo
+        // wins when mock mode is on; otherwise the freshest enabled
+        // source wins for each metric independently.
+        let glucoseReading = UnifiedDataReader.currentGlucoseReading(from: defaults)
+        let carbsReading = UnifiedDataReader.currentCarbsReading(from: defaults)
 
-        let carbGrams = defaults?.double(forKey: "lastCarbGrams") ?? 0
         let customChecks = AttentionScenario.loadCustomChecks(from: defaults)
 
         let unit: GlucoseUnit = defaults?.string(forKey: "glucoseUnit")
             .flatMap { GlucoseUnit(rawValue: $0) } ?? .mmolL
 
         let content = ShieldContent(
-            glucose: defaults?.double(forKey: "currentGlucose") ?? 0,
-            glucoseFetchedAt: glucoseDate,
-            lastCarbGrams: carbGrams > 0 ? carbGrams : nil,
-            lastCarbEntryAt: carbDate,
+            glucose: glucoseReading?.mmol ?? 0,
+            glucoseFetchedAt: glucoseReading?.sampleAt,
+            lastCarbGrams: carbsReading?.grams,
+            lastCarbEntryAt: carbsReading?.sampleAt,
             highGlucoseThreshold: ThresholdResolver.highGlucose(defaults: defaults, fallback: Self.fallbackHighGlucose),
             lowGlucoseThreshold: ThresholdResolver.lowGlucose(defaults: defaults, fallback: Self.fallbackLowGlucose),
             criticalGlucoseThreshold: ThresholdResolver.criticalGlucose(defaults: defaults, fallback: Self.fallbackCriticalGlucose),

--- a/iOS/StatusWidget/StatusWidget.swift
+++ b/iOS/StatusWidget/StatusWidget.swift
@@ -43,12 +43,14 @@ private enum EntryBuilder {
     static func makeEntry(now: Date, metric: MetricType) -> StatusEntry {
         let defaults = appGroupDefaults
 
-        let glucose = defaults?.double(forKey: "currentGlucose") ?? 0
-        let glucoseDate = defaults?.string(forKey: "glucoseFetchedAt")
-            .flatMap { ISO8601DateFormatter().date(from: $0) }
-        let carbGrams = defaults?.double(forKey: "lastCarbGrams") ?? 0
-        let carbDate = defaults?.string(forKey: "lastCarbEntryAt")
-            .flatMap { ISO8601DateFormatter().date(from: $0) }
+        // Per-source storage: resolve the winning glucose/carb readings
+        // via `UnifiedDataReader` so widgets honour the Demo override
+        // and freshest-enabled-source rule alongside the home screen
+        // and shield UI.
+        let glucoseReading = UnifiedDataReader.currentGlucoseReading(from: defaults)
+        let carbsReading = UnifiedDataReader.currentCarbsReading(from: defaults)
+        let glucoseDate = glucoseReading?.sampleAt
+        let carbDate = carbsReading?.sampleAt
 
         let unit: GlucoseUnit = defaults?.string(forKey: "glucoseUnit")
             .flatMap { GlucoseUnit(rawValue: $0) } ?? .mmolL
@@ -56,9 +58,9 @@ private enum EntryBuilder {
         let strings = ShieldContent.Strings.fromPackage()
 
         let content = ShieldContent(
-            glucose: glucose,
+            glucose: glucoseReading?.mmol ?? 0,
             glucoseFetchedAt: glucoseDate,
-            lastCarbGrams: carbGrams > 0 ? carbGrams : nil,
+            lastCarbGrams: carbsReading?.grams,
             lastCarbEntryAt: carbDate,
             highGlucoseThreshold: ThresholdResolver.highGlucose(defaults: defaults, fallback: fallbackHighGlucose),
             lowGlucoseThreshold: ThresholdResolver.lowGlucose(defaults: defaults, fallback: fallbackLowGlucose),


### PR DESCRIPTION
## Summary

Refactors `SharedDataManager` away from one shared `currentGlucose` / `glucoseFetchedAt` / `lastCarb*` tuple (written by whichever source fired last) to per-source buckets for HealthKit, Nightscout, and Demo. All readers go through the new `SharedKit.UnifiedDataReader` which resolves displayed glucose and carbs **independently**:

- **Demo override** — when mock mode is on, Demo wins for both metrics regardless of age.
- **Otherwise, freshest-wins per metric** — glucose can come from HealthKit while carbs come from Nightscout on the same screen, if that's what the timestamps say.
- **Disabled sources are ignored** even if stored data remains. `handleSourceDisabled(_:)` clears the source's cache so the settings screens stay honest.

## What changed

### Data layer
- New `SharedKit/UnifiedDataReader.swift` — `DataSource` enum, `DataSourceKeys` (every App Group key in one place), `GlucoseReading` / `CarbsReading` value types, and the resolution logic.
- `SharedDataManager` rewritten around per-source storage: `saveHealthKitGlucose(mmol:at:)` / `saveNightscoutGlucose(...)` / `saveDemoGlucose(...)` and their carb counterparts, plus `glucoseReading(source:)` / `carbsReading(source:)` for per-source inspection.
- `NightscoutManager` and `HealthKitManager` now write to their own buckets; the old shared keys are gone.

### Apple Health toggle
- New **`healthKitEnabled`** toggle. Enabling re-requests authorisation and starts observing; disabling stops observing and ignores samples even if system-level read access is still granted. Replaces the sticky `healthKitEverDelivered` heuristic.
- `SharedDataManager.hasAnyDataSource` is now a clean `OR` of `healthKitEnabled || nightscoutEnabled || isMockModeEnabled`. No more recency heuristics in the disjunction.

### Settings UI
- `NightscoutSettingsView`: toggle moved above URL + token fields. New "Laatste gegevens" section with per-source `Glucose` and `Koolhydraten` rows (value + relative time). The old bottom "Laatste update" row is removed — freshness is already conveyed by the per-source rows. Background-fetch errors still surface in a conditional Status section.
- `HealthKitSettingsView`: reshaped to match — explicit enable toggle on top, same "Laatste gegevens" section.
- `MockDataSettingsView`: per-metric clear (`clearDemoGlucose()` / `clearDemoCarbs()`) so toggling off one metric doesn't wipe the other.

### Readers
Every consumer now goes through `UnifiedDataReader` (or `SharedDataManager.currentGlucoseReading` / `currentCarbsReading` as thin wrappers on the App target): `HomeView`, `ShieldConfigurationExtension`, `ShieldActionExtension`, `DeviceActivityMonitorExtension`, `StatusWidget`, `WatchSessionManager`, `ShieldManager`, `ScreenshotHarness`, `WidgetNightscoutRefresh`.

### Docs + i18n
- `AGENTS.md` App Group schema table updated; new "Per-source storage + unified reads" and "Data Source State" sections.
- `.claude/skills/appstore-screenshots/SKILL.md` note updated for the new keys.
- New EN/NL strings for toggle labels, per-source latest-data headers, and empty-state placeholders.

### No migration
Per AGENTS.md's "Forward-only by default" rule, no migration is shipped — the app isn't on the App Store yet. No `schemaVersion`, no `runLaunchTimeMigrations`, no `currentGlucose` / `glucoseFetchedAt` / `lastCarb*` compat shims on `SharedDataManager`. Readers use `currentGlucoseReading?.mmol` / `?.sampleAt` directly.

## Test plan

- [x] `swift test --package-path iOS/SharedKit` — 29/29 pass, including new `UnifiedDataReaderTests` (demo override for glucose + carbs, freshest-wins, disabled sources ignored, per-source reads ignore toggles, nil defaults).
- [x] `xcodebuild` clean build across App + all extensions + Watch.
- [x] On-device smoke: HK-only configured, Nightscout-only configured, both enabled (glucose + carbs come from different sources per timestamp), Demo override, welcome state when all three toggles are off.
- [x] Settings: toggling HK off stops observing; toggling Nightscout off stops polling; both disables clear their own cache via `handleSourceDisabled`.
- [x] Nightscout settings screen screenshot — per-source timestamps visible, no duplicative "Laatste update" row.

Closes #83

Made with [Cursor](https://cursor.com)