### PR TITLE
build(ci): extend docs-check with htmlproofer and smoke checks

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,13 +1,21 @@
 # Build the marketing site exactly the way GitHub Pages will publish it
-# and fail the PR if Jekyll can't produce a clean static tree. Catches
-# Liquid syntax errors, missing _data references, broken includes, plugin
-# loading failures, and anything else that surfaces only in JEKYLL_ENV=
-# production but not in the live-reload dev server.
+# and fail the PR if Jekyll can't produce a clean static tree, htmlproofer
+# finds a broken link / missing image / missing alt, or the smoke greps in
+# docs/scripts/site-check.sh detect a regression in canonical / OG /
+# sitemap / robots invariants.
 #
-# Layer 1 of the site-check stack from #62. Future layers (htmlproofer
-# for asset/link validation, project-specific smoke greps for the
-# canonical/OG dedupe class of bug) land in the PR that fixes #51,
-# alongside the bugs they're meant to catch.
+# Three layers from #62, each catching a distinct class of regression:
+#
+#   1. Layer 1 — `bundle exec jekyll build` (Liquid syntax, missing
+#      _data refs, plugin loading failures, broken includes).
+#   2. Layer 2 — `htmlproofer _site` (broken internal links, missing
+#      images including og:image, missing alt, malformed HTML).
+#   3. Layer 3 — `docs/scripts/site-check.sh` (project-specific
+#      assertions: canonical dedupe, OG locale, sitemap shape, robots
+#      host).
+#
+# Mirrors `make docs-check` step-for-step so "passes locally" means
+# "passes CI".
 #
 # Triggered only on PRs and main pushes that actually touch the site or
 # this workflow, so docs-only churn doesn't burn minutes on every iOS PR.
@@ -45,14 +53,37 @@ jobs:
       # ruby-version isn't set, keeping CI in lock-step with the local
       # pin (mise.toml + docs/.ruby-version) without duplicating it here.
       # bundler-cache restores docs/vendor/bundle/ keyed on
-      # docs/Gemfile.lock — first run installs gems, every subsequent
-      # run is a cache hit.
+      # docs/Gemfile.lock — first run installs gems (including the
+      # html-proofer gem from the :test group), every subsequent run is
+      # a cache hit.
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
           working-directory: docs
 
-      - name: Build site (production)
+      - name: Build site (production) — Layer 1
         env:
           JEKYLL_ENV: production
         run: bundle exec jekyll build --strict_front_matter --trace
+
+      # Validate the static output Jekyll just produced. htmlproofer is a
+      # :test-group gem (see docs/Gemfile) so it isn't shipped to GitHub
+      # Pages — only this workflow and `make docs-check` install it.
+      # --disable-external keeps the check unflaky (external link
+      # validation belongs in a periodic cron, not a per-PR gate).
+      # --no-ignore-empty-alt is deliberately strict: if a contributor
+      # adds a decorative <img>, they're nudged to mark it
+      # aria-hidden="true" instead of relying on alt="" alone.
+      # htmlproofer's image check covers <img> and <source> only, not
+      # <meta property="og:image"> — that case is asserted by Layer 3
+      # below (see docs/scripts/site-check.sh).
+      - name: Validate _site/ — Layer 2 (htmlproofer)
+        run: bundle exec htmlproofer _site --disable-external --no-enforce-https --no-ignore-empty-alt
+
+      # Project-specific smoke greps over docs/_site/ — see the script's
+      # header for the full list of invariants. Resolves paths relative
+      # to its own location, so the working-directory above doesn't
+      # affect it.
+      - name: Smoke checks — Layer 3 (site-check.sh)
+        working-directory: ${{ github.workspace }}
+        run: bash docs/scripts/site-check.sh

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ venv-clean:
 
 # --- App Store listing (fastlane deliver) ---
 
-.PHONY: appstore-bootstrap appstore-sync appstore-push appstore-pull appstore-screenshots appstore-beta watchface-prepare watchface-capture docs-sync-screenshots docs-bootstrap docs-serve docs-clean docs-build docs-publish-check docs-audit docs-og-images
+.PHONY: appstore-bootstrap appstore-sync appstore-push appstore-pull appstore-screenshots appstore-beta watchface-prepare watchface-capture docs-sync-screenshots docs-bootstrap docs-serve docs-clean docs-build docs-publish-check docs-audit docs-check docs-og-images
 
 ## One-time: install fastlane into iOS/vendor/bundle (uses iOS/Gemfile)
 appstore-bootstrap:
@@ -218,6 +218,28 @@ docs-publish-check: docs-build
 ## and offer to fix it.
 docs-audit:
 	bash docs/scripts/lighthouse-audit.sh
+
+## Run the same gates GitHub Actions runs on every docs-touching PR
+## (.github/workflows/docs-check.yml). Three layers, each catching a
+## distinct class of regression — keep this target and the workflow
+## in lock-step so "passes locally" means "passes CI":
+##
+##   1. Production Jekyll build (Liquid errors, missing _data refs,
+##      plugin loading failures — anything that crashes the build).
+##   2. htmlproofer over docs/_site/ — broken internal links, missing
+##      images (including og:image), missing alt attributes, malformed
+##      HTML. External links are skipped (--disable-external) so the
+##      check stays unflaky; periodic external-link audits belong in
+##      a cron, not a per-PR gate.
+##   3. docs/scripts/site-check.sh — project-specific smoke greps that
+##      defend the canonical/OG/sitemap/robots invariants we don't
+##      want to regress. See the script's header for the full list.
+##
+## See #62 for the design and staged rollout.
+docs-check: docs-build
+	cd docs && $(RUN_RUBY) bundle exec htmlproofer _site \
+		--disable-external --no-enforce-https --no-ignore-empty-alt
+	bash docs/scripts/site-check.sh
 
 ## Regenerate docs/assets/og-{en,nl}.png — the per-locale Open Graph cards
 ## referenced by data.meta.og_image. Idempotent. Requires Python 3 with

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -12,3 +12,10 @@ end
 
 # webrick is no longer in Ruby's stdlib (since 3.0); jekyll serve needs it.
 gem "webrick", "~> 1.8"
+
+# Validate the built site (Layer 2 of `make docs-check` — see #62). Kept in
+# a :test group so production / GitHub Pages publishing never even touches
+# it; only `make docs-check` and the docs-check.yml workflow install it.
+group :test do
+  gem "html-proofer", "~> 5.0"
+end

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    Ascii85 (2.0.1)
     activesupport (8.1.3)
       base64
       bigdecimal
@@ -16,7 +17,15 @@ GEM
       uri (>= 0.13.1)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    afm (1.0.0)
+    async (2.39.0)
+      console (~> 1.29)
+      fiber-annotation
+      io-event (~> 1.11)
+      metrics (~> 0.12)
+      traces (~> 0.18)
     base64 (0.3.0)
+    benchmark (0.5.0)
     bigdecimal (4.1.2)
     coffee-script (2.4.1)
       coffee-script-source
@@ -26,6 +35,10 @@ GEM
     commonmarker (0.23.12)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
+    console (1.34.3)
+      fiber-annotation
+      fiber-local (~> 1.1)
+      json
     csv (3.3.5)
     dnsruby (1.73.1)
       base64 (>= 0.2)
@@ -54,6 +67,10 @@ GEM
     ffi (1.17.4-x86_64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
     ffi (1.17.4-x86_64-linux-musl)
+    fiber-annotation (0.2.0)
+    fiber-local (1.1.0)
+      fiber-storage
+    fiber-storage (1.0.1)
     forwardable-extended (2.6.0)
     gemoji (4.1.0)
     github-pages (232)
@@ -108,12 +125,24 @@ GEM
       octokit (>= 4, < 8)
       public_suffix (>= 3.0, < 6.0)
       typhoeus (~> 1.3)
+    hashery (2.1.2)
     html-pipeline (2.14.3)
       activesupport (>= 2)
       nokogiri (>= 1.4)
+    html-proofer (5.2.1)
+      addressable (~> 2.3)
+      async (~> 2.1)
+      benchmark (~> 0.5)
+      nokogiri (~> 1.13)
+      pdf-reader (~> 2.11)
+      rainbow (~> 3.0)
+      typhoeus (~> 1.3)
+      yell (~> 2.0)
+      zeitwerk (~> 2.5)
     http_parser.rb (0.8.1)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
+    io-event (1.15.1)
     jekyll (3.10.0)
       addressable (~> 2.4)
       colorator (~> 1.0)
@@ -236,6 +265,7 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.7.0)
     mercenary (0.3.6)
+    metrics (0.15.0)
     minima (2.5.1)
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
@@ -266,14 +296,22 @@ GEM
       sawyer (~> 0.9)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
+    pdf-reader (2.15.1)
+      Ascii85 (>= 1.0, < 3.0, != 2.0.0)
+      afm (>= 0.2.1, < 2)
+      hashery (~> 2.0)
+      ruby-rc4
+      ttfunk
     prism (1.9.0)
     public_suffix (5.1.1)
     racc (1.8.1)
+    rainbow (3.1.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
     rexml (3.4.4)
     rouge (3.30.0)
+    ruby-rc4 (0.1.5)
     rubyzip (2.4.1)
     safe_yaml (1.0.5)
     sass (3.7.4)
@@ -288,6 +326,8 @@ GEM
     simpleidn (0.2.3)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
+    traces (0.18.2)
+    ttfunk (1.7.0)
     typhoeus (1.6.0)
       ethon (>= 0.18.0)
     tzinfo (2.0.6)
@@ -295,6 +335,8 @@ GEM
     unicode-display_width (1.8.0)
     uri (1.1.1)
     webrick (1.9.2)
+    yell (2.2.2)
+    zeitwerk (2.7.5)
 
 PLATFORMS
   aarch64-linux-gnu
@@ -308,6 +350,7 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
+  html-proofer (~> 5.0)
   jekyll-sitemap
   webrick (~> 1.8)
 

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -4,7 +4,15 @@
 <header class="site-header" role="banner">
   <div class="wrap site-header__inner">
     <a class="brand" href="{{ home_url | relative_url }}" aria-label="GluWink home">
-      <img src="{{ '/assets/icons/iOS.png' | relative_url }}" alt="" width="60" height="60" decoding="async" fetchpriority="high">
+      {%- comment -%}
+        The icon is purely decorative — the wordmark `<span>` next to it
+        already carries "GluWink" as text, and the link itself has an
+        aria-label. `aria-hidden="true"` tells assistive tech (and
+        htmlproofer's image check) to skip it; the empty `alt=""` is the
+        HTML5 idiom for a decorative image so non-AT crawlers don't read
+        the filename.
+      {%- endcomment -%}
+      <img src="{{ '/assets/icons/iOS.png' | relative_url }}" alt="" aria-hidden="true" width="60" height="60" decoding="async" fetchpriority="high">
       <span class="brand__name">GluWink</span>
     </a>
     <nav class="nav" aria-label="primary">

--- a/docs/_includes/hero-carousel.html
+++ b/docs/_includes/hero-carousel.html
@@ -18,11 +18,13 @@
   tilted and overlapping the header's bottom border — one home for the
   brand mark, and the hero is free to compose phone + watch only.
 
-  Slide 1 of the phone carousel paints with a real `src` (LCP, preloaded
-  via head.html); slides 2–5 ship with `data-src` and are hydrated on
-  demand by the carousel JS. The watch's first slide also uses real `src`
-  (it's visible from page load, just not preloaded); watch slide 2 uses
-  `data-src` and is warmed during idle.
+  Slide 1 of the phone carousel paints with a real `src` and `loading="eager"`
+  + `fetchpriority="high"` (it's the LCP element, preloaded via head.html);
+  slides 2–5 ship with real `src` plus `loading="lazy"` so the browser defers
+  their fetch until they're about to scroll into view. Same shape for the
+  watch: slide 1 eager, slide 2 lazy. Native `loading="lazy"` replaces an
+  earlier `data-src` + JS-driven hydration scheme — the browser handles
+  deferred loading natively and htmlproofer can verify every reference exists.
 
   Each slide wraps its image in either a `.device-stage--iphone` (verbatim
   devices.css iPhone 14 Pro, phone slides) or a `.device-stage--watch`
@@ -53,7 +55,7 @@
       <li class="hero-carousel__slide" data-slide aria-hidden="true">
         <div class="device-stage--iphone">
           <div class="device device-iphone-14-pro">
-            <div class="device-frame"><img class="device-screen" data-src="{{ base | append: '02_orangeShield.png' | relative_url }}" alt="{{ data.screenshots.alt.orange }}" width="390" height="847" decoding="async"></div>
+            <div class="device-frame"><img class="device-screen" src="{{ base | append: '02_orangeShield.png' | relative_url }}" alt="{{ data.screenshots.alt.orange }}" width="390" height="847" loading="lazy" decoding="async"></div>
             <div class="device-stripe"></div>
             <div class="device-btns"></div>
             <div class="device-power"></div>
@@ -64,7 +66,7 @@
       <li class="hero-carousel__slide" data-slide aria-hidden="true">
         <div class="device-stage--iphone">
           <div class="device device-iphone-14-pro">
-            <div class="device-frame"><img class="device-screen" data-src="{{ base | append: '03_redShield.png' | relative_url }}" alt="{{ data.screenshots.alt.red }}" width="390" height="847" decoding="async"></div>
+            <div class="device-frame"><img class="device-screen" src="{{ base | append: '03_redShield.png' | relative_url }}" alt="{{ data.screenshots.alt.red }}" width="390" height="847" loading="lazy" decoding="async"></div>
             <div class="device-stripe"></div>
             <div class="device-btns"></div>
             <div class="device-power"></div>
@@ -75,7 +77,7 @@
       <li class="hero-carousel__slide" data-slide aria-hidden="true">
         <div class="device-stage--iphone">
           <div class="device device-iphone-14-pro">
-            <div class="device-frame"><img class="device-screen" data-src="{{ base | append: '04_widgets.png' | relative_url }}" alt="{{ data.screenshots.alt.widgets }}" width="390" height="847" decoding="async"></div>
+            <div class="device-frame"><img class="device-screen" src="{{ base | append: '04_widgets.png' | relative_url }}" alt="{{ data.screenshots.alt.widgets }}" width="390" height="847" loading="lazy" decoding="async"></div>
             <div class="device-stripe"></div>
             <div class="device-btns"></div>
             <div class="device-power"></div>
@@ -86,7 +88,7 @@
       <li class="hero-carousel__slide" data-slide aria-hidden="true">
         <div class="device-stage--iphone">
           <div class="device device-iphone-14-pro">
-            <div class="device-frame"><img class="device-screen" data-src="{{ base | append: '05_settings.png' | relative_url }}" alt="{{ data.screenshots.alt.settings }}" width="390" height="847" decoding="async"></div>
+            <div class="device-frame"><img class="device-screen" src="{{ base | append: '05_settings.png' | relative_url }}" alt="{{ data.screenshots.alt.settings }}" width="390" height="847" loading="lazy" decoding="async"></div>
             <div class="device-stripe"></div>
             <div class="device-btns"></div>
             <div class="device-power"></div>
@@ -125,7 +127,7 @@
         <div class="device-stage--watch">
           <div class="device device-apple-watch-s8">
             <div class="device-frame">
-              <img class="device-screen" data-src="{{ base | append: '07_watchApp.png' | relative_url }}" alt="{{ data.screenshots.alt.watchApp }}" width="268" height="324" decoding="async">
+              <img class="device-screen" src="{{ base | append: '07_watchApp.png' | relative_url }}" alt="{{ data.screenshots.alt.watchApp }}" width="268" height="324" loading="lazy" decoding="async">
             </div>
             <div class="device-stripe"></div>
             <div class="device-header"></div>

--- a/docs/assets/js/hero-carousel.js
+++ b/docs/assets/js/hero-carousel.js
@@ -3,6 +3,11 @@
 // - Pauses on hover, focus-within, and when the tab is hidden
 // - Manual control via dot buttons, ArrowLeft/ArrowRight when focused
 // - Honors prefers-reduced-motion (no auto-advance, no fade)
+//
+// Image loading is handled entirely by the browser: slide 1 ships with
+// `loading="eager"` + `fetchpriority="high"` (preloaded in head.html),
+// slides 2+ with `loading="lazy"`. The carousel's only job is the timing
+// and aria toggles below.
 (function () {
   'use strict';
 
@@ -19,23 +24,8 @@
     let index = 0;
     let timer = null;
 
-    // Hydrate a slide's <img data-src=...> into a real <img src=...> the
-    // first time we need it. Slides 2-4 ship without `src` so they don't
-    // compete with slide 1 (the LCP element) for initial bandwidth — see
-    // the comment in _includes/hero-carousel.html for the full rationale.
-    function hydrate(slide) {
-      const img = slide && slide.querySelector('img[data-src]');
-      if (!img) return;
-      img.src = img.dataset.src;
-      img.removeAttribute('data-src');
-    }
-
     function show(next) {
       index = ((next % slides.length) + slides.length) % slides.length;
-      // Make sure the slide we're about to show — and the one after it,
-      // so it's already decoded by the next tick — both have real sources.
-      hydrate(slides[index]);
-      hydrate(slides[(index + 1) % slides.length]);
       slides.forEach((slide, n) => {
         const active = n === index;
         slide.classList.toggle('is-active', active);
@@ -44,17 +34,6 @@
       dots.forEach((dot, n) => {
         dot.setAttribute('aria-current', n === index ? 'true' : 'false');
       });
-    }
-
-    // Once the page has finished loading the LCP-critical assets, warm
-    // up slide 2 in the background so it's ready before the first
-    // auto-advance fires (~5s later). Falls back gracefully on browsers
-    // without requestIdleCallback.
-    const warmNext = () => hydrate(slides[1]);
-    if (window.requestIdleCallback) {
-      window.requestIdleCallback(warmNext, { timeout: 2000 });
-    } else {
-      window.setTimeout(warmNext, 1500);
     }
 
     function start() {

--- a/docs/scripts/site-check.sh
+++ b/docs/scripts/site-check.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Project-specific smoke greps over the built marketing site (Layer 3 of
+# `make docs-check` — see #62). Asserts the structural decisions we want
+# to defend at PR time, on top of what htmlproofer already covers:
+#
+#   - Exactly one head-level <link rel="canonical"> per real page (six
+#     pages: /, /nl/, /privacy/, /nl/privacy/, /support/, /nl/support/).
+#     This is the regression class that prompted the workflow — see
+#     #51 / PR #114, where both a hand-rolled head.html block and
+#     jekyll-seo-tag were emitting canonicals on every page.
+#   - The 404 page does NOT self-canonicalise and does NOT publish an
+#     og:url. Title / description / og:image stay (cheap and useful for
+#     deep-link shares that 404), but it must not advertise itself as a
+#     real URL. The body's nav language switcher legitimately uses an
+#     <a hreflang="nl"> attribute as a navigational hint — the head-only
+#     scope below makes sure we catch a head-level <link hreflang> on
+#     /404.html without complaining about the nav.
+#   - og:locale matches the page locale (en_US on /, nl_NL on /nl/).
+#   - Every <meta property="og:image"> URL resolves to a real file in
+#     _site/. htmlproofer's image check covers <img> and <source> only,
+#     not og:image meta tags, so this layer owns it. The exact bug #62
+#     was filed against was every page emitting an og:image pointing at
+#     /assets/og-{en,nl}.png that didn't exist on disk.
+#   - sitemap.xml has exactly six <loc> entries (the same six real pages).
+#   - robots.txt points at the correct sitemap host.
+#
+# Runnable from any cwd; resolves paths relative to the repo root via
+# this script's own location. Exit 0 on success, non-zero on the first
+# violation (with a one-line FAIL: message naming the offending page).
+#
+# The build itself is not this script's job — `make docs-check` runs
+# `docs-build` first. If you're invoking site-check.sh directly, make
+# sure docs/_site/ is fresh.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+SITE="${REPO_ROOT}/docs/_site"
+
+if [[ ! -d "${SITE}" ]]; then
+  echo "FAIL: ${SITE} does not exist — run 'make docs-build' first" >&2
+  exit 1
+fi
+
+REAL_PAGES=(
+  "index.html"
+  "nl/index.html"
+  "privacy/index.html"
+  "nl/privacy/index.html"
+  "support/index.html"
+  "nl/support/index.html"
+)
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# 1. Exactly one canonical per real page.
+for p in "${REAL_PAGES[@]}"; do
+  file="${SITE}/${p}"
+  [[ -f "${file}" ]] || fail "${p} is missing from _site/"
+  count="$(grep -cE '<link[^>]+rel="canonical"' "${file}" || true)"
+  [[ "${count}" -eq 1 ]] \
+    || fail "${p} has ${count} <link rel=\"canonical\"> tags (want 1) — see #51"
+done
+
+# 2. /404.html does not self-canonical.
+count="$(grep -cE '<link[^>]+rel="canonical"' "${SITE}/404.html" || true)"
+[[ "${count}" -eq 0 ]] \
+  || fail "/404.html has ${count} <link rel=\"canonical\"> tags (want 0)"
+
+# 3. /404.html does not advertise an og:url.
+count="$(grep -cE '<meta[^>]+property="og:url"' "${SITE}/404.html" || true)"
+[[ "${count}" -eq 0 ]] \
+  || fail "/404.html has ${count} <meta property=\"og:url\"> tags (want 0)"
+
+# 4. /404.html has no head-level hreflang. <a hreflang="..."> in the
+# nav language switcher is fine — that's a navigational hint, not an
+# SEO claim — so we scope the check to <link rel="alternate" hreflang>.
+count="$(grep -cE '<link[^>]+hreflang=' "${SITE}/404.html" || true)"
+[[ "${count}" -eq 0 ]] \
+  || fail "/404.html has ${count} <link hreflang=...> tags (want 0)"
+
+# 5. og:locale matches page locale.
+grep -qE 'property="og:locale"[^>]+content="en_US"' "${SITE}/index.html" \
+  || fail "/index.html missing og:locale=en_US"
+grep -qE 'property="og:locale"[^>]+content="nl_NL"' "${SITE}/nl/index.html" \
+  || fail "/nl/index.html missing og:locale=nl_NL"
+
+# 6. Every og:image URL across the real pages + 404 resolves to a real
+# file in _site/. htmlproofer skips <meta property="og:image"> entirely
+# (its image check is scoped to <img> and <source>), so a missing
+# og-{en,nl}.png — the original symptom of #62 — would only surface
+# when someone tried to share the URL. We assert it here instead.
+og_pages=("${REAL_PAGES[@]}" "404.html")
+declare -a checked_paths=()
+for p in "${og_pages[@]}"; do
+  file="${SITE}/${p}"
+  [[ -f "${file}" ]] || continue
+  while IFS= read -r url; do
+    [[ -z "${url}" ]] && continue
+    # Strip the production hostname so we resolve the path inside _site/.
+    rel="${url#https://gluwink.app}"
+    rel="${rel#http://gluwink.app}"
+    [[ "${rel}" == /* ]] || fail "${p} og:image URL '${url}' is not site-rooted"
+    target="${SITE}${rel}"
+    [[ -f "${target}" ]] \
+      || fail "${p} og:image '${url}' does not resolve to a file in _site/"
+    checked_paths+=("${target}")
+  done < <(grep -oE '<meta[^>]+property="og:image"[^>]+content="[^"]+"' "${file}" \
+             | grep -oE 'content="[^"]+"' \
+             | sed -E 's/content="([^"]+)"/\1/')
+done
+[[ "${#checked_paths[@]}" -gt 0 ]] \
+  || fail "no og:image meta tags found across ${#og_pages[@]} pages — head.html may have regressed"
+
+# 7. sitemap has exactly the expected number of <loc> entries.
+expected_locs="${#REAL_PAGES[@]}"
+sitemap_locs="$(grep -c '<loc>' "${SITE}/sitemap.xml" || true)"
+[[ "${sitemap_locs}" -eq "${expected_locs}" ]] \
+  || fail "sitemap.xml has ${sitemap_locs} <loc> entries (want ${expected_locs})"
+
+# 8. robots.txt points at the production sitemap.
+grep -qE '^Sitemap: https://gluwink\.app/sitemap\.xml$' "${SITE}/robots.txt" \
+  || fail "robots.txt is missing 'Sitemap: https://gluwink.app/sitemap.xml'"
+
+echo "site-check.sh: all assertions passed (${#REAL_PAGES[@]} pages + 404 + ${#checked_paths[@]} og:image refs + sitemap + robots)"


### PR DESCRIPTION
## Summary

Extends #63's Layer 1 (Jekyll prod build) with Layer 2 (htmlproofer) and Layer 3 (project-specific smoke greps), plus a `make docs-check` target that mirrors the workflow step-for-step. Two small markup conventions are paved first so htmlproofer's defaults work without `--ignore-urls` exclusions.

## Layers shipped (extending #63's Layer 1)

- **Layer 2** — `html-proofer ~> 5.0` over the built `_site/`. Catches broken internal links, missing `<img>`/`<source>` references, missing `alt` attributes, malformed HTML. `:test`-group gem so it never ships to GitHub Pages.
- **Layer 3** — `docs/scripts/site-check.sh`, project-specific smoke greps. See the script header for the full list, but the marquee assertions are: exactly one head-level `<link rel="canonical">` per real page (the regression class from #51), zero canonical/og:url/head-level hreflang on `/404.html`, og:locale matches page locale, **every `<meta property="og:image">` URL resolves to a real file in `_site/`** (htmlproofer's image check covers `<img>`/`<source>` only — the original symptom of #62 was every page emitting an og:image that 404'd, and Layer 2 alone would not catch this), sitemap shape, robots.txt host.
- **`make docs-check`** runs Layer 1 → Layer 2 → Layer 3 end-to-end locally; the workflow runs the same three steps in CI.

## Convention fixes (precondition for Layer 2 to pass)

- **`refactor(docs): mark nav brand mark decorative for a11y tooling`** (`c6a141f`) — `docs/_includes/header.html`'s `<img src="iOS.png" alt="">` now also carries `aria-hidden="true"`. The wordmark `<span>GluWink</span>` and the wrapping `<a aria-label="GluWink home">` already announce the brand; the icon is decorative. `aria-hidden="true"` is what htmlproofer's `Image` check actually recognises (`role="presentation"` is NOT honored — verified against the gem source).
- **`refactor(docs): use native lazy-loading on hero carousel slides`** (`f01f2a8`) — slides 2–5 (and watch slide 2) migrated from `data-src` + JS-driven `hydrate()` to a real `src` + `loading="lazy"`. Slide 1 keeps `loading="eager"` + `fetchpriority="high"` (still preloaded via `head.html`'s `page.preload_hero` block) so the LCP timeline doesn't move. The carousel JS loses the `hydrate()` function and the requestIdleCallback warm-up entirely — comment block at the top of the file points at the markup-level convention so future readers know where image loading lives.

## Test plan

- [x] `cd docs && JEKYLL_ENV=production bundle exec jekyll build` clean (Layer 1).
- [x] `bundle exec htmlproofer _site --disable-external --no-enforce-https --no-ignore-empty-alt` clean (Layer 2).
- [x] `bash docs/scripts/site-check.sh` clean — \"all assertions passed (6 pages + 404 + 7 og:image refs + sitemap + robots)\".
- [x] `make docs-check` runs all three end-to-end and exits 0.
- [x] **Negative test L1** — injected `{% if data.unclosed %}` into `_includes/footer.html`; Layer 1 fails, restored cleanly.
- [x] **Negative test L3 (og:image)** — removed `docs/assets/og-en.png`; Layer 3 fails with `FAIL: index.html og:image '...og-en.png' does not resolve to a file in _site/`. Restored. (Layer 2 alone would NOT catch this — confirmed mid-implementation; that's why the og:image check is in the smoke greps.)
- [x] **Negative test L3 (canonical dedupe)** — re-added `jekyll-seo-tag` to `_config.yml` and `{%- seo title=false -%}` to `head.html`; Layer 3 fails with `FAIL: index.html has 2 <link rel="canonical"> tags (want 1) — see #51`. Restored.

## Deviations from the issue body / planning prompt

- **html-proofer 5.x flag drift.** #62's body listed `--check-html --check-img-http`; those are 4.x flags. The v5-equivalent is the default `--checks Links,Images,Scripts` (no opt-in needed) plus `--no-ignore-empty-alt`. Used the v5 invocation throughout.
- **Decorative icon convention.** The plan suggested `role="presentation"`. Switched to `aria-hidden="true"` because that's what htmlproofer actually checks for (verified in `html-proofer-5.2.1/lib/html_proofer/check/images.rb`). Functionally equivalent for the user; cleaner for the tool.
- **og:image existence check moved to Layer 3, not Layer 2.** Mid-implementation discovered htmlproofer's `Image` check is scoped to `<img>` and `<source>` elements only — `<meta property="og:image">` tags are skipped entirely. The original symptom of #62 (`/assets/og-{en,nl}.png` 404s) would NOT have been caught by Layer 2 alone, so Layer 3 owns the og:image existence assertion. Documented in the script's header and in the workflow comment.

## Out of scope

- Lighthouse on every PR (stays on-demand via `make docs-audit` / `site-audit` skill).
- External link checking (periodic cron, future).
- Visual regression testing (out of scope for a brochure site).

Closes #62

Made with [Cursor](https://cursor.com)