### PR TITLE
feat(shield): expand positive affirmations to 20 per locale

### DIFF
--- a/iOS/SharedKit/Sources/SharedKit/Resources/en.lproj/Localizable.strings
+++ b/iOS/SharedKit/Sources/SharedKit/Resources/en.lproj/Localizable.strings
@@ -6,9 +6,24 @@
 /* Positive titles (no attention needed) */
 "shield.positiveTitle.0" = "Looking good!";
 "shield.positiveTitle.1" = "Keep it up!";
-"shield.positiveTitle.2" = "Nice work!";
+"shield.positiveTitle.2" = "Nice work.";
 "shield.positiveTitle.3" = "All good!";
-"shield.positiveTitle.4" = "Well done!";
+"shield.positiveTitle.4" = "Well done.";
+"shield.positiveTitle.5" = "You've got this.";
+"shield.positiveTitle.6" = "Right on track.";
+"shield.positiveTitle.7" = "Smooth sailing.";
+"shield.positiveTitle.8" = "Solid check-in.";
+"shield.positiveTitle.9" = "Nicely done.";
+"shield.positiveTitle.10" = "On top of it.";
+"shield.positiveTitle.11" = "Steady wins.";
+"shield.positiveTitle.12" = "That's how it's done.";
+"shield.positiveTitle.13" = "Quietly crushing it.";
+"shield.positiveTitle.14" = "Way to stay on it.";
+"shield.positiveTitle.15" = "Proud of you.";
+"shield.positiveTitle.16" = "Doing the work.";
+"shield.positiveTitle.17" = "Good rhythm today.";
+"shield.positiveTitle.18" = "Easy does it.";
+"shield.positiveTitle.19" = "Just keep going.";
 
 /* Attention titles (action needed) */
 "shield.attentionTitle.0" = "Heads up!";

--- a/iOS/SharedKit/Sources/SharedKit/Resources/nl.lproj/Localizable.strings
+++ b/iOS/SharedKit/Sources/SharedKit/Resources/nl.lproj/Localizable.strings
@@ -6,9 +6,24 @@
 /* Positive titles (no attention needed) */
 "shield.positiveTitle.0" = "Goed bezig!";
 "shield.positiveTitle.1" = "Lekker bezig!";
-"shield.positiveTitle.2" = "Top!";
+"shield.positiveTitle.2" = "Top.";
 "shield.positiveTitle.3" = "Alles goed!";
-"shield.positiveTitle.4" = "Netjes!";
+"shield.positiveTitle.4" = "Netjes.";
+"shield.positiveTitle.5" = "Je doet het super.";
+"shield.positiveTitle.6" = "Helemaal op koers.";
+"shield.positiveTitle.7" = "Loopt lekker.";
+"shield.positiveTitle.8" = "Mooi afgevinkt.";
+"shield.positiveTitle.9" = "Mooi gedaan.";
+"shield.positiveTitle.10" = "Je hebt het in de hand.";
+"shield.positiveTitle.11" = "Rustig en sterk.";
+"shield.positiveTitle.12" = "Zo doen we dat.";
+"shield.positiveTitle.13" = "Knap hoor.";
+"shield.positiveTitle.14" = "Mooi volgehouden.";
+"shield.positiveTitle.15" = "Trots op je.";
+"shield.positiveTitle.16" = "Goed dat je het doet.";
+"shield.positiveTitle.17" = "Lekker ritme vandaag.";
+"shield.positiveTitle.18" = "Rustig aan, gaat goed.";
+"shield.positiveTitle.19" = "Gewoon lekker doorgaan.";
 
 /* Attention titles (action needed) */
 "shield.attentionTitle.0" = "Even opletten!";

--- a/iOS/SharedKit/Sources/SharedKit/ShieldContent.swift
+++ b/iOS/SharedKit/Sources/SharedKit/ShieldContent.swift
@@ -345,7 +345,7 @@ public extension ShieldContent {
         /// Load a numbered list of strings with a display-name fallback (for titles).
         private static func loadList(bundle: Bundle, prefix: String) -> [String] {
             var results: [String] = []
-            for i in 0..<20 {
+            for i in 0..<30 {
                 let key = "\(prefix).\(i)"
                 let value = bundle.localizedString(forKey: key, value: key, table: nil)
                 if value == key { break }


### PR DESCRIPTION
## Summary

The shield's positive title pool was 5 entries per locale, which repeats noticeably for a kid clearing the shield several times a day. Expand to **20 distinct affirmations** in both English and Dutch, keeping the existing random-pick-per-render behavior. NL is translated by *meaning and tone*, not literally — the Dutch list should feel native to a Dutch child.

- **EN positive titles:** 5 → 20
- **NL positive titles:** 5 → 20
- Tone is warm, age-appropriate, not preachy or cloying — mixing short praise, agency-affirming lines, proud-of-progress phrasing, and a few nods to the daily-grind reality of T1D. Brand voice from `AGENTS.md` → "Marketing Copy" applies.
- Bumped `ShieldContent.loadList` cap from `0..<20` to `0..<30` so future additions don't silently truncate when the list hits the cap exactly. (At 20 entries we were sitting on the boundary — adding a 21st would have failed silently.)

## Sample of new affirmations

**English** (selection):
- "You've got this."
- "Solid check-in."
- "Quietly crushing it."
- "Doing the work."
- "Easy does it."

**Nederlands** (selection):
- "Je hebt het in de hand."
- "Mooi afgevinkt."
- "Knap hoor."
- "Goed dat je het doet."
- "Rustig aan, gaat goed."

## Build verification

- Xcode MCP bridge was stale — reported to surface to the owner. Used the `xcodebuild` fallback per `AGENTS.md` → "When the bridge goes stale".
- `xcodebuild -project iOS/App.xcodeproj -scheme App -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build` (with isolated `-derivedDataPath`) → `** BUILD SUCCEEDED **`.

## Test plan

- [ ] Visually confirm a few random shield activations cycle through new titles in both EN and NL.
- [ ] If the owner has tone tweaks for any of the 40 entries, this is the place to call them out — easier to adjust now than after first wave of TestFlight feedback.

Closes #3

Made with [Cursor](https://cursor.com)