### PR TITLE
feat(watch): surface in Smart Stack via relevance-scored widget

### DIFF
--- a/iOS/App/HomeView.swift
+++ b/iOS/App/HomeView.swift
@@ -382,9 +382,9 @@ struct HomeView: View {
                     .font(.subheadline.weight(.semibold))
                 Text("•")
                     .foregroundStyle(.tertiary)
-                relativeTimeText(from: glucoseDate, hasData: content.glucoseValue > 0, fallback: strings.glucoseNoData)
+                relativeTimeText(from: glucoseDate, hasData: content.glucose != nil, fallback: strings.glucoseNoData)
                     .font(.subheadline)
-                if content.glucoseValue > 0, glucoseDate != nil {
+                if content.glucose != nil, glucoseDate != nil {
                     Text("•")
                         .foregroundStyle(.tertiary)
                     absoluteTimeText(from: glucoseDate, hasData: true)
@@ -399,9 +399,9 @@ struct HomeView: View {
                     .font(.subheadline.weight(.semibold))
                 Text("•")
                     .foregroundStyle(.tertiary)
-                relativeTimeText(from: carbDate, hasData: content.carbGrams != nil, fallback: strings.carbsNoData)
+                relativeTimeText(from: carbDate, hasData: content.carbs != nil, fallback: strings.carbsNoData)
                     .font(.subheadline)
-                if content.carbGrams != nil, carbDate != nil {
+                if content.carbs != nil, carbDate != nil {
                     Text("•")
                         .foregroundStyle(.tertiary)
                     absoluteTimeText(from: carbDate, hasData: true)
@@ -440,11 +440,11 @@ struct HomeView: View {
     }
 
     private func glucoseValueText(for content: ShieldContent) -> String {
-        "\(content.glucoseValue > 0 ? content.formattedGlucose : "--") \(content.glucoseUnitLabel)"
+        "\(content.glucose?.formatted ?? "--") \(content.glucoseUnitLabel)"
     }
 
     private func carbValueText(for content: ShieldContent) -> String {
-        "\(content.carbGrams.map(String.init) ?? "--") g"
+        "\(content.carbs.map { String($0.grams) } ?? "--") g"
     }
 
     private func relativeTimeText(from date: Date?, hasData: Bool, fallback: String) -> Text {

--- a/iOS/SharedKit/Sources/SharedKit/ShieldContent.swift
+++ b/iOS/SharedKit/Sources/SharedKit/ShieldContent.swift
@@ -31,15 +31,20 @@ public struct ShieldContent: Sendable {
     /// because shielding is gated on having a data source.
     public let hasNoData: Bool
     public let buttonLabel: String
-    public let glucoseValue: Double
-    public let glucoseAgoMinutes: Int?
-    public let carbGrams: Int?
-    public let carbAgoMinutes: Int?
+    /// Latest glucose sample if any is available — value, sample timestamp,
+    /// minutes-ago, and pre-formatted display string are bundled as one
+    /// atomic optional. There is no way to express "value but no date" or
+    /// "date but no value" at the type level. Read callers MUST treat the
+    /// presence of a reading and the readability of its individual fields
+    /// as inseparable: `if let g = content.glucose { ...g.formatted... }`.
+    public let glucose: Glucose?
+    /// Latest carb entry, atomic with its sample timestamp. Same contract
+    /// as `glucose` — `nil` means "no carb data" and consumers must render
+    /// the no-data state on all metric surfaces.
+    public let carbs: Carbs?
     public let attentionItems: [String]
     public let activeScenarios: [AttentionScenario]
     public let glucoseUnit: GlucoseUnit
-    /// Glucose formatted in the display unit (e.g. "6.4" or "115"), no unit label.
-    public let formattedGlucose: String
     public let glucoseUnitLabel: String
 
     public init(
@@ -60,7 +65,6 @@ public struct ShieldContent: Sendable {
     ) {
         self.glucoseUnit = glucoseUnit
         glucoseUnitLabel = glucoseUnit.label
-        glucoseValue = glucose
         let hasGlucose = glucose > 0
         var dataLines: [String] = []
         var scenarios: [AttentionScenario] = []
@@ -71,12 +75,16 @@ public struct ShieldContent: Sendable {
 
         if hasGlucose, let glucoseDate = glucoseFetchedAt {
             let gMins = Int(now.timeIntervalSince(glucoseDate) / 60)
-            glucoseAgoMinutes = gMins
-            let formatted = glucoseUnit.formattedWithUnit(glucose)
-            formattedGlucose = glucoseUnit.formatted(glucose)
+            self.glucose = Glucose(
+                mmol: glucose,
+                sampleDate: glucoseDate,
+                agoMinutes: gMins,
+                formatted: glucoseUnit.formatted(glucose)
+            )
+            let formattedWithUnit = glucoseUnit.formattedWithUnit(glucose)
             let timeStr = timeFormatter.string(from: glucoseDate)
             let agoStr = Self.shortAgo(gMins, strings: strings)
-            dataLines.append(String(format: strings.glucose, formatted, timeStr, agoStr))
+            dataLines.append(String(format: strings.glucose, formattedWithUnit, timeStr, agoStr))
 
             if glucose < lowGlucoseThreshold {
                 scenarios.append(.lowGlucose)
@@ -104,8 +112,7 @@ public struct ShieldContent: Sendable {
                 scenarios.append(.staleSensor)
             }
         } else {
-            glucoseAgoMinutes = nil
-            formattedGlucose = "--"
+            self.glucose = nil
             dataLines.append(strings.glucoseNoData)
             scenarios.append(.noGlucoseData)
         }
@@ -117,9 +124,12 @@ public struct ShieldContent: Sendable {
             || (currentHour == carbGraceHour && currentMinute < carbGraceMinute)
 
         if let carbDate = lastCarbEntryAt, let grams = lastCarbGrams {
-            carbGrams = Int(grams)
             let cMins = Int(now.timeIntervalSince(carbDate) / 60)
-            carbAgoMinutes = cMins
+            self.carbs = Carbs(
+                grams: Int(grams),
+                sampleDate: carbDate,
+                agoMinutes: cMins
+            )
             let timeStr = timeFormatter.string(from: carbDate)
             let agoStr = Self.shortAgo(cMins, strings: strings)
             dataLines.append(String(format: strings.carbsEntry, Int(grams), timeStr, agoStr))
@@ -127,8 +137,7 @@ public struct ShieldContent: Sendable {
                 scenarios.append(.carbGap)
             }
         } else {
-            carbGrams = nil
-            carbAgoMinutes = nil
+            self.carbs = nil
             dataLines.append(strings.carbsNoData)
             scenarios.append(.noCarbData)
         }
@@ -204,6 +213,48 @@ public struct ShieldContent: Sendable {
             return String(format: strings.agoMinutes, minutes)
         }
         return String(format: strings.agoHoursMinutes, minutes / 60, minutes % 60)
+    }
+}
+
+public extension ShieldContent {
+    /// A glucose sample paired indivisibly with its timestamp. The whole
+    /// point of this nested struct is that consumers cannot get one
+    /// without the other: if `ShieldContent.glucose` is `nil`, there is
+    /// no reading at all — render the no-data state on every surface
+    /// (orange tint + warning triangle, never a raw value with no
+    /// time-ago label). Nested under `ShieldContent` to distinguish from
+    /// `UnifiedDataReader.GlucoseReading`, which is the per-source raw
+    /// reading; this one is the resolved, display-formatted view.
+    struct Glucose: Sendable, Equatable {
+        /// Glucose value in mmol/L — always. Surfaces that show a
+        /// different display unit format from `formatted` (which already
+        /// respects `ShieldContent.glucoseUnit`); they should not re-do
+        /// the math on `mmol` themselves.
+        public let mmol: Double
+        /// Time the sample was observed by the writer (HealthKit,
+        /// Nightscout, or demo). What the "X min ago" label is computed
+        /// against.
+        public let sampleDate: Date
+        /// Minutes between `sampleDate` and the `now` passed to
+        /// `ShieldContent.init`. Pre-computed so widget timelines that
+        /// produce multiple entries don't all recompute it at render
+        /// time.
+        public let agoMinutes: Int
+        /// Already formatted for the active display unit (e.g. `"6.4"`
+        /// for mmol/L, `"115"` for mg/dL). No unit label — surfaces tack
+        /// the unit on themselves using `ShieldContent.glucoseUnitLabel`
+        /// so they can position it (e.g. on the same line, on a second
+        /// line, in a smaller font).
+        public let formatted: String
+    }
+
+    /// A carb entry paired indivisibly with its timestamp. Mirrors
+    /// `Glucose`'s atomic contract — `ShieldContent.carbs == nil` means
+    /// render the no-data state, full stop.
+    struct Carbs: Sendable, Equatable {
+        public let grams: Int
+        public let sampleDate: Date
+        public let agoMinutes: Int
     }
 }
 

--- a/iOS/SharedKit/Sources/SharedKit/WidgetTileViews.swift
+++ b/iOS/SharedKit/Sources/SharedKit/WidgetTileViews.swift
@@ -165,11 +165,11 @@ private func widgetValueWithUnit(
 }
 
 private func widgetGlucoseValue(_ c: ShieldContent) -> String {
-    c.glucoseValue > 0 ? c.formattedGlucose : "--"
+    c.glucose?.formatted ?? "--"
 }
 
 private func widgetCarbsValue(_ c: ShieldContent) -> String {
-    c.carbGrams.map { "\($0)" } ?? "--"
+    c.carbs.map { "\($0.grams)" } ?? "--"
 }
 
 // MARK: - Small tile
@@ -192,7 +192,7 @@ public struct SmallWidgetTile: View {
             )
             widgetRelativeAgoText(
                 from: content.glucoseDate,
-                hasData: c.glucoseValue > 0,
+                hasData: c.glucose != nil,
                 relativeTo: content.referenceDate
             )
                 .font(.caption)
@@ -208,7 +208,7 @@ public struct SmallWidgetTile: View {
             )
             widgetRelativeAgoText(
                 from: content.carbDate,
-                hasData: c.carbGrams != nil,
+                hasData: c.carbs != nil,
                 relativeTo: content.referenceDate
             )
                 .font(.caption)
@@ -241,7 +241,7 @@ public struct MediumWidgetTile: View {
                 )
                 widgetStackedTime(
                     from: content.glucoseDate,
-                    hasData: c.glucoseValue > 0,
+                    hasData: c.glucose != nil,
                     relativeTo: content.referenceDate
                 )
                     .font(.subheadline)
@@ -259,7 +259,7 @@ public struct MediumWidgetTile: View {
                 )
                 widgetStackedTime(
                     from: content.carbDate,
-                    hasData: c.carbGrams != nil,
+                    hasData: c.carbs != nil,
                     relativeTo: content.referenceDate
                 )
                     .font(.subheadline)
@@ -335,7 +335,7 @@ public struct AccessoryRectangularTile: View {
                 .lineLimit(1)
                 widgetRelativeAgoText(
                     from: content.glucoseDate,
-                    hasData: c.glucoseValue > 0,
+                    hasData: c.glucose != nil,
                     relativeTo: content.referenceDate
                 )
                     .font(.caption2)
@@ -356,7 +356,7 @@ public struct AccessoryRectangularTile: View {
                 .lineLimit(1)
                 widgetRelativeAgoText(
                     from: content.carbDate,
-                    hasData: c.carbGrams != nil,
+                    hasData: c.carbs != nil,
                     relativeTo: content.referenceDate
                 )
                     .font(.caption2)
@@ -385,7 +385,7 @@ public struct AccessoryInlineTile: View {
         // is what the user glances for. Carbs always carry the "g" suffix
         // because the bare number reads as ambiguous.
         let text: String = forGlucose
-            ? (c.glucoseValue > 0 ? c.formattedGlucose : "--")
+            ? (c.glucose?.formatted ?? "--")
             : "\(widgetCarbsValue(c))g"
         Label(text, systemImage: icon)
     }
@@ -412,7 +412,7 @@ public struct LargeWidgetTile: View {
                 )
                 widgetStackedTime(
                     from: content.glucoseDate,
-                    hasData: c.glucoseValue > 0,
+                    hasData: c.glucose != nil,
                     relativeTo: content.referenceDate
                 )
                     .font(.body)
@@ -431,7 +431,7 @@ public struct LargeWidgetTile: View {
                 )
                 widgetStackedTime(
                     from: content.carbDate,
-                    hasData: c.carbGrams != nil,
+                    hasData: c.carbs != nil,
                     relativeTo: content.referenceDate
                 )
                     .font(.body)

--- a/iOS/StatusWidget/StatusWidget.swift
+++ b/iOS/StatusWidget/StatusWidget.swift
@@ -1,27 +1,21 @@
-import AppIntents
 import SharedKit
 import SwiftUI
 import WidgetKit
 
-// MARK: - Configuration Intent
+// MARK: - Metric type
 
-enum MetricType: String, AppEnum {
+/// Which metric a Lock Screen tile renders. Shipped as a plain enum
+/// (not `AppEnum`) because each metric has its own `Widget` with a
+/// `StaticConfiguration` — there is no in-place picker. We deliberately
+/// avoided `AppIntentConfiguration` here to mirror the watch split (see
+/// `WatchMetricType` in WatchComplications.swift) and to give the user
+/// a one-step gallery flow: pick "Glucose" or "Carbs" directly, no
+/// two-step "pick the metric widget, then configure it" detour. Same
+/// pattern that also sidesteps the `CHSError 1101` archiving bug we
+/// saw on watch accessory families with `AppIntentConfiguration`.
+enum MetricType {
     case glucose
     case carbs
-
-    static var typeDisplayRepresentation = TypeDisplayRepresentation(name: LocalizedStringResource("widget.intent.metricType", defaultValue: "Metric"))
-    static var caseDisplayRepresentations: [MetricType: DisplayRepresentation] = [
-        .glucose: DisplayRepresentation(title: LocalizedStringResource("widget.intent.glucose", defaultValue: "Glucose")),
-        .carbs: DisplayRepresentation(title: LocalizedStringResource("widget.intent.carbs", defaultValue: "Carbs")),
-    ]
-}
-
-struct StatusWidgetIntent: WidgetConfigurationIntent {
-    static var title: LocalizedStringResource = "Status"
-    static var description = IntentDescription(LocalizedStringResource("widget.intent.description", defaultValue: "Shows glucose or carb status."))
-
-    @Parameter(title: LocalizedStringResource("widget.intent.metricType", defaultValue: "Metric"), default: .glucose)
-    var metric: MetricType
 }
 
 // MARK: - Shared entry builder
@@ -134,25 +128,34 @@ struct StatusTimelineProvider: TimelineProvider {
     }
 }
 
-// MARK: - Configurable provider (metric picker)
+// MARK: - Per-metric static provider
 
-struct StatusIntentTimelineProvider: AppIntentTimelineProvider {
+/// One provider instance per metric — the metric is fixed at the widget
+/// declaration site rather than picked through an intent. Mirrors
+/// `WatchMetricTimelineProvider` on the watch side.
+struct StatusMetricTimelineProvider: TimelineProvider {
+    let metric: MetricType
+
     func placeholder(in _: Context) -> StatusEntry {
-        EntryBuilder.makeEntry(now: Date(), metric: .glucose)
+        EntryBuilder.makeEntry(now: Date(), metric: metric)
     }
 
-    func snapshot(for configuration: StatusWidgetIntent, in _: Context) async -> StatusEntry {
-        await WidgetNightscoutRefresh.refreshIfDue(defaults: EntryBuilder.appGroupDefaults)
-        return EntryBuilder.makeEntry(now: Date(), metric: configuration.metric)
-    }
-
-    func timeline(for configuration: StatusWidgetIntent, in _: Context) async -> Timeline<StatusEntry> {
-        await WidgetNightscoutRefresh.refreshIfDue(defaults: EntryBuilder.appGroupDefaults)
-        let now = Date()
-        let entries = TimelinePolicy.entries(from: now) { date in
-            EntryBuilder.makeEntry(now: date, metric: configuration.metric)
+    func getSnapshot(in _: Context, completion: @escaping (StatusEntry) -> Void) {
+        Task {
+            await WidgetNightscoutRefresh.refreshIfDue(defaults: EntryBuilder.appGroupDefaults)
+            completion(EntryBuilder.makeEntry(now: Date(), metric: metric))
         }
-        return Timeline(entries: entries, policy: .atEnd)
+    }
+
+    func getTimeline(in _: Context, completion: @escaping (Timeline<StatusEntry>) -> Void) {
+        Task {
+            await WidgetNightscoutRefresh.refreshIfDue(defaults: EntryBuilder.appGroupDefaults)
+            let now = Date()
+            let entries = TimelinePolicy.entries(from: now) { date in
+                EntryBuilder.makeEntry(now: date, metric: metric)
+            }
+            completion(Timeline(entries: entries, policy: .atEnd))
+        }
     }
 }
 
@@ -174,17 +177,38 @@ struct StatusWidget: Widget {
     }
 }
 
-// MARK: - Metric widget (circular + inline Lock Screen — configurable glucose or carbs)
+// MARK: - Metric widgets (circular + inline Lock Screen — one per metric)
+//
+// One `StaticConfiguration` widget per metric instead of a single
+// `AppIntentConfiguration` with a picker. Same rationale as the watch
+// split: cleaner gallery UX ("Glucose" / "Carbs" pickable directly,
+// no two-step configure detour) and forward-only — we don't ship an
+// intent we'd then have to migrate away from later.
 
-struct StatusMetricWidget: Widget {
-    let kind: String = "StatusMetricWidget"
+struct StatusGlucoseWidget: Widget {
+    let kind: String = "StatusGlucoseWidget"
 
     var body: some WidgetConfiguration {
-        AppIntentConfiguration(kind: kind, intent: StatusWidgetIntent.self, provider: StatusIntentTimelineProvider()) { entry in
+        StaticConfiguration(kind: kind, provider: StatusMetricTimelineProvider(metric: .glucose)) { entry in
             StatusMetricEntryView(entry: entry)
         }
-        .configurationDisplayName(String(localized: "widget.metricTitle"))
-        .description(String(localized: "widget.metricDescription"))
+        .configurationDisplayName(String(localized: "widget.glucoseTitle"))
+        .description(String(localized: "widget.glucoseDescription"))
+        .supportedFamilies([
+            .accessoryCircular, .accessoryInline,
+        ])
+    }
+}
+
+struct StatusCarbsWidget: Widget {
+    let kind: String = "StatusCarbsWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: StatusMetricTimelineProvider(metric: .carbs)) { entry in
+            StatusMetricEntryView(entry: entry)
+        }
+        .configurationDisplayName(String(localized: "widget.carbsTitle"))
+        .description(String(localized: "widget.carbsDescription"))
         .supportedFamilies([
             .accessoryCircular, .accessoryInline,
         ])

--- a/iOS/StatusWidget/StatusWidgetBundle.swift
+++ b/iOS/StatusWidget/StatusWidgetBundle.swift
@@ -12,6 +12,7 @@ import WidgetKit
 struct StatusWidgetBundle: WidgetBundle {
     var body: some Widget {
         StatusWidget()
-        StatusMetricWidget()
+        StatusGlucoseWidget()
+        StatusCarbsWidget()
     }
 }

--- a/iOS/StatusWidget/en.lproj/Localizable.strings
+++ b/iOS/StatusWidget/en.lproj/Localizable.strings
@@ -1,12 +1,8 @@
 /* Widget */
 "widget.description" = "Glucose and carb status at a glance.";
-"widget.metricTitle" = "Single Metric";
-"widget.metricDescription" = "Show glucose or carbs.";
-
-/* Widget intent (configuration) */
-"widget.intent.metricType" = "Metric";
-"widget.intent.glucose" = "Glucose";
-"widget.intent.carbs" = "Carbs";
-"widget.intent.description" = "Shows glucose or carb status.";
+"widget.glucoseTitle" = "Glucose";
+"widget.glucoseDescription" = "Latest glucose reading.";
+"widget.carbsTitle" = "Carbs";
+"widget.carbsDescription" = "Latest carb entry.";
 
 "widget.noData" = "No data";

--- a/iOS/StatusWidget/nl.lproj/Localizable.strings
+++ b/iOS/StatusWidget/nl.lproj/Localizable.strings
@@ -1,12 +1,8 @@
 /* Widget */
 "widget.description" = "Glucose- en koolhydraatstatus in één oogopslag.";
-"widget.metricTitle" = "Enkele meting";
-"widget.metricDescription" = "Toon glucose of koolhydraten.";
-
-/* Widget intent (configuration) */
-"widget.intent.metricType" = "Meting";
-"widget.intent.glucose" = "Glucose";
-"widget.intent.carbs" = "Koolhydraten";
-"widget.intent.description" = "Toont glucose- of koolhydraatstatus.";
+"widget.glucoseTitle" = "Glucose";
+"widget.glucoseDescription" = "Laatste glucosemeting.";
+"widget.carbsTitle" = "Koolhydraten";
+"widget.carbsDescription" = "Laatste koolhydraateninvoer.";
 
 "widget.noData" = "Geen data";

--- a/iOS/WatchApp/WatchContentView.swift
+++ b/iOS/WatchApp/WatchContentView.swift
@@ -22,15 +22,15 @@ struct WatchContentView: View {
     }
 
     private func glucoseValueText(for content: ShieldContent) -> String {
-        "\(content.glucoseValue > 0 ? content.formattedGlucose : "--") \(content.glucoseUnitLabel)"
+        "\(content.glucose?.formatted ?? "--") \(content.glucoseUnitLabel)"
     }
 
     private func carbsValueText(for content: ShieldContent) -> String {
-        "\(content.carbGrams.map(String.init) ?? "--") g"
+        "\(content.carbs.map { String($0.grams) } ?? "--") g"
     }
 
-    private func relativeTimeText(from date: Date?, hasData: Bool) -> Text {
-        guard hasData, let date else { return Text("--") }
+    private func relativeTimeText(from date: Date?) -> Text {
+        guard let date else { return Text("--") }
         return Text(date, style: .relative)
     }
 
@@ -42,7 +42,7 @@ struct WatchContentView: View {
                 Text(glucoseValueText(for: current))
                     .font(valueFont)
                     .foregroundStyle(.white)
-                relativeTimeText(from: WatchDataManager.glucoseFetchedAt, hasData: current.glucoseValue > 0)
+                relativeTimeText(from: current.glucose?.sampleDate)
                     .font(.caption)
                     .foregroundStyle(.white.opacity(0.85))
             }
@@ -51,7 +51,7 @@ struct WatchContentView: View {
                 Text(carbsValueText(for: current))
                     .font(valueFont)
                     .foregroundStyle(.white.opacity(0.95))
-                relativeTimeText(from: WatchDataManager.lastCarbEntryAt, hasData: current.carbGrams != nil)
+                relativeTimeText(from: current.carbs?.sampleDate)
                     .font(.caption)
                     .foregroundStyle(.white.opacity(0.85))
             }

--- a/iOS/WatchApp/WatchContentView.swift
+++ b/iOS/WatchApp/WatchContentView.swift
@@ -30,7 +30,16 @@ struct WatchContentView: View {
     }
 
     private func relativeTimeText(from date: Date?) -> Text {
-        guard let date else { return Text("--") }
+        // No-data row deliberately reads as "No data" / "Geen data" — not
+        // the bare "--" placeholder we use for the metric value above. The
+        // metric line ("-- mmol/L") still communicates "value missing"
+        // adequately because the unit is right there; the relative-time
+        // line has no such anchor, so "--" alone reads as a layout glitch.
+        // Spelling it out matches the rectangular widget tile, which has
+        // shown the same "No data" string on missing-sample rows since
+        // PR #119's atomic-types refactor (`ShieldContent.glucose == nil`
+        // → render the no-data state on every surface, full stop).
+        guard let date else { return Text(String(localized: "watch.app.noData")) }
         return Text(date, style: .relative)
     }
 

--- a/iOS/WatchApp/WatchContentView.swift
+++ b/iOS/WatchApp/WatchContentView.swift
@@ -1,9 +1,32 @@
 import Combine
 import SharedKit
 import SwiftUI
+#if targetEnvironment(simulator)
+import WidgetKit
+#endif
 
 struct WatchContentView: View {
     @State private var tick = Date()
+
+    #if targetEnvironment(simulator)
+    /// Last `syncToken` value observed in the simulator bridge file.
+    /// Used to detect writes from the iPhone simulator and trigger a
+    /// `WidgetCenter` reload when paired-sim WatchConnectivity delivery
+    /// lags or drops the message — without this, the watch app picks up
+    /// the new mock state on its next 5 s tick but the watch widgets
+    /// (running in a separate extension process) don't see the change
+    /// until the timeline's `.atEnd` reload fires (≤ 5 min) or some
+    /// other code path happens to call `reloadAllTimelines` for a
+    /// different reason.
+    ///
+    /// Production / device builds rely entirely on
+    /// `WatchConnectivityReceiver.applyContext`, which already pairs
+    /// every received context with a widget reload — this state and the
+    /// polling helper below are simulator-only and gated behind
+    /// `targetEnvironment(simulator)` so device behaviour is unchanged.
+    @State private var lastBridgeSyncToken: Double?
+    #endif
+
     private let valueFont = Font.system(size: 28, weight: .bold, design: .rounded)
 
     private static let refreshInterval: TimeInterval = {
@@ -68,6 +91,32 @@ struct WatchContentView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .padding()
         .background(current.attentionLevel.tint)
-        .onReceive(timer) { tick = $0 }
+        .onReceive(timer) { newTick in
+            tick = newTick
+            #if targetEnvironment(simulator)
+            reloadWidgetsIfBridgeChanged()
+            #endif
+        }
     }
+
+    #if targetEnvironment(simulator)
+    /// Re-read the simulator bridge's `syncToken` and ask WidgetKit to
+    /// rebuild the watch widget timelines if it has changed since the
+    /// last tick. The bridge file is written by the iPhone simulator
+    /// every time `WatchSessionManager.sendLatestContext` runs; the
+    /// `syncToken` is a `Date().timeIntervalSince1970` taken at write
+    /// time, so any toggle that flips Demo / Nightscout / settings
+    /// produces a strictly newer token.
+    ///
+    /// The token comparison is `!=`, not `>`, on purpose: we don't care
+    /// whether the bridge moved forwards or "backwards" (e.g. the
+    /// iPhone simulator was reset and re-seeded), only that the state
+    /// the widget extension would read has changed.
+    private func reloadWidgetsIfBridgeChanged() {
+        let currentToken = SimulatorWatchBridge.loadContext()?["syncToken"] as? Double
+        guard currentToken != lastBridgeSyncToken else { return }
+        lastBridgeSyncToken = currentToken
+        WidgetCenter.shared.reloadAllTimelines()
+    }
+    #endif
 }

--- a/iOS/WatchApp/en.lproj/Localizable.strings
+++ b/iOS/WatchApp/en.lproj/Localizable.strings
@@ -1,0 +1,2 @@
+/* Watch app */
+"watch.app.noData" = "No data";

--- a/iOS/WatchApp/nl.lproj/Localizable.strings
+++ b/iOS/WatchApp/nl.lproj/Localizable.strings
@@ -1,0 +1,2 @@
+/* Watch app */
+"watch.app.noData" = "Geen data";

--- a/iOS/WatchShared/WatchDataManager.swift
+++ b/iOS/WatchShared/WatchDataManager.swift
@@ -25,20 +25,13 @@ enum WatchDataManager {
 
     static func content(now: Date = Date()) -> ShieldContent {
         let bridgeContext = SimulatorWatchBridge.loadContext()
-        let useBridgeMockData = bridgeContext?["mockModeEnabled"] as? Bool ?? false
 
-        let glucose = useBridgeMockData
-            ? (bridgeContext?["currentGlucose"] as? Double ?? 0)
-            : (defaults?.double(forKey: "currentGlucose") ?? 0)
-        let glucoseFetchedAt = useBridgeMockData
-            ? (bridgeContext?["glucoseFetchedAt"] as? String).flatMap { ISO8601DateFormatter().date(from: $0) }
-            : defaults?.string(forKey: "glucoseFetchedAt").flatMap { ISO8601DateFormatter().date(from: $0) }
-        let lastCarbGrams = useBridgeMockData
-            ? (bridgeContext?["lastCarbGrams"] as? Double ?? 0)
-            : (defaults?.double(forKey: "lastCarbGrams") ?? 0)
-        let lastCarbEntryAt = useBridgeMockData
-            ? (bridgeContext?["lastCarbEntryAt"] as? String).flatMap { ISO8601DateFormatter().date(from: $0) }
-            : defaults?.string(forKey: "lastCarbEntryAt").flatMap { ISO8601DateFormatter().date(from: $0) }
+        let glucose = bridgeMockDouble(forKey: "currentGlucose", bridge: bridgeContext)
+            ?? (defaults?.double(forKey: "currentGlucose") ?? 0)
+        let glucoseFetchedAt = bridgeOrDefaultsDate(forKey: "glucoseFetchedAt", bridge: bridgeContext)
+        let lastCarbGrams = bridgeMockDouble(forKey: "lastCarbGrams", bridge: bridgeContext)
+            ?? (defaults?.double(forKey: "lastCarbGrams") ?? 0)
+        let lastCarbEntryAt = bridgeOrDefaultsDate(forKey: "lastCarbEntryAt", bridge: bridgeContext)
 
         let unit: GlucoseUnit = (bridgeContext?["glucoseUnit"] as? String)
             .flatMap { GlucoseUnit(rawValue: $0) }
@@ -78,13 +71,41 @@ enum WatchDataManager {
     }
 
     static var glucoseFetchedAt: Date? {
-        guard let iso = defaults?.string(forKey: "glucoseFetchedAt") else { return nil }
-        return ISO8601DateFormatter().date(from: iso)
+        bridgeOrDefaultsDate(forKey: "glucoseFetchedAt", bridge: SimulatorWatchBridge.loadContext())
     }
 
     static var lastCarbEntryAt: Date? {
-        guard let iso = defaults?.string(forKey: "lastCarbEntryAt") else { return nil }
+        bridgeOrDefaultsDate(forKey: "lastCarbEntryAt", bridge: SimulatorWatchBridge.loadContext())
+    }
+
+    /// Resolve an ISO-8601 date using the same precedence as `content(now:)`:
+    /// when the simulator bridge has mock-mode data, the bridge fully shadows
+    /// defaults (a missing key returns `nil`, not a stale defaults value);
+    /// otherwise read from the watch-local App Group `defaults`. On hardware
+    /// `SimulatorWatchBridge.loadContext()` returns `nil`, so this degenerates
+    /// to the defaults-only path with no behaviour change.
+    ///
+    /// Used by both `content()` and the static `glucoseFetchedAt` /
+    /// `lastCarbEntryAt` getters so widget `WatchEntry` dates and watch app
+    /// "Xm ago" labels stay consistent with `ShieldContent.glucoseAgoMinutes`
+    /// — without this, the static getters returned `nil` in mock-mode
+    /// simulator runs because the watch sim has no provisioned App Group.
+    private static func bridgeOrDefaultsDate(forKey key: String, bridge: [String: Any]?) -> Date? {
+        if (bridge?["mockModeEnabled"] as? Bool) == true {
+            guard let iso = bridge?[key] as? String else { return nil }
+            return ISO8601DateFormatter().date(from: iso)
+        }
+        guard let iso = defaults?.string(forKey: key) else { return nil }
         return ISO8601DateFormatter().date(from: iso)
+    }
+
+    /// Sibling of `bridgeOrDefaultsDate` for numeric mock-mode values. Mock
+    /// mode also shadows defaults — a missing key returns `0` (not the stale
+    /// defaults value) — and a `nil` return means "bridge isn't supplying mock
+    /// data, fall through to defaults" so callers stay symmetric.
+    private static func bridgeMockDouble(forKey key: String, bridge: [String: Any]?) -> Double? {
+        guard (bridge?["mockModeEnabled"] as? Bool) == true else { return nil }
+        return (bridge?[key] as? Double) ?? 0
     }
 
     /// Persist a glucose sample. "Save if newer" — both HealthKit and

--- a/iOS/WatchShared/WatchDataManager.swift
+++ b/iOS/WatchShared/WatchDataManager.swift
@@ -87,7 +87,7 @@ enum WatchDataManager {
     ///
     /// Used by both `content()` and the static `glucoseFetchedAt` /
     /// `lastCarbEntryAt` getters so widget `WatchEntry` dates and watch app
-    /// "Xm ago" labels stay consistent with `ShieldContent.glucoseAgoMinutes`
+    /// "Xm ago" labels stay consistent with `ShieldContent.glucose?.agoMinutes`
     /// — without this, the static getters returned `nil` in mock-mode
     /// simulator runs because the watch sim has no provisioned App Group.
     private static func bridgeOrDefaultsDate(forKey key: String, bridge: [String: Any]?) -> Date? {

--- a/iOS/WatchWidget/WatchComplications.swift
+++ b/iOS/WatchWidget/WatchComplications.swift
@@ -20,18 +20,18 @@ enum WatchMetricType {
 private func metricHasData(_ entry: WatchEntry) -> Bool {
     switch entry.metric {
     case .glucose:
-        return entry.content.glucoseValue > 0
+        return entry.content.glucose != nil
     case .carbs:
-        return entry.content.carbGrams != nil
+        return entry.content.carbs != nil
     }
 }
 
 private func metricValue(_ entry: WatchEntry) -> String {
     switch entry.metric {
     case .glucose:
-        return entry.content.glucoseValue > 0 ? entry.content.formattedGlucose : "--"
+        return entry.content.glucose?.formatted ?? "--"
     case .carbs:
-        return entry.content.carbGrams.map(String.init) ?? "--"
+        return entry.content.carbs.map { String($0.grams) } ?? "--"
     }
 }
 
@@ -48,8 +48,8 @@ private func metricAttentionLevel(_ entry: WatchEntry) -> AttentionLevel {
     entry.content.attentionLevel(forGlucose: entry.metric == .glucose)
 }
 
-private func relativeAgoText(from date: Date?, hasData: Bool) -> Text {
-    guard hasData, let date else { return Text(String(localized: "watch.widget.noData")) }
+private func relativeAgoText(from date: Date?) -> Text {
+    guard let date else { return Text(String(localized: "watch.widget.noData")) }
     return Text(date, style: .relative)
 }
 
@@ -118,15 +118,17 @@ struct WatchRectangularEntryView: View {
 
     var body: some View {
         let content = entry.content
+        let glucoseText = content.glucose?.formatted ?? "--"
+        let carbsText = content.carbs.map { String($0.grams) } ?? "--"
 
         VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 4) {
                 Image(systemName: content.glucoseNeedsAttention ? "exclamationmark.triangle.fill" : "checkmark.circle.fill")
                     .font(.caption.bold())
-                Text("\(content.formattedGlucose) \(content.glucoseUnit.shortLabel)")
+                Text("\(glucoseText) \(content.glucoseUnit.shortLabel)")
                     .font(.system(.headline, design: .rounded).bold())
                 Spacer(minLength: 4)
-                relativeAgoText(from: entry.glucoseDate, hasData: content.glucoseValue > 0)
+                relativeAgoText(from: content.glucose?.sampleDate)
                     .font(.caption2)
                     .foregroundStyle(.secondary)
             }
@@ -134,10 +136,10 @@ struct WatchRectangularEntryView: View {
             HStack(spacing: 4) {
                 Image(systemName: content.carbsNeedsAttention ? "exclamationmark.triangle.fill" : "checkmark.circle.fill")
                     .font(.caption.bold())
-                Text("\(content.carbGrams.map(String.init) ?? "--") g")
+                Text("\(carbsText) g")
                     .font(.system(.headline, design: .rounded).bold())
                 Spacer(minLength: 4)
-                relativeAgoText(from: entry.carbDate, hasData: content.carbGrams != nil)
+                relativeAgoText(from: content.carbs?.sampleDate)
                     .font(.caption2)
                     .foregroundStyle(.secondary)
             }

--- a/iOS/WatchWidget/WatchComplications.swift
+++ b/iOS/WatchWidget/WatchComplications.swift
@@ -57,6 +57,13 @@ private func relativeAgoText(from date: Date?, hasData: Bool) -> Text {
     return Text(date, style: .relative)
 }
 
+/// Doubles as a watch-face complication and as a Smart Stack tile on
+/// watchOS 10+. The `.accessoryRectangular` family is what Smart Stack
+/// consumes in its swipe-up panel, so a single widget covers both
+/// surfaces — we stay forward-only (one source of truth) and lean on
+/// `TimelineEntryRelevance` (set by `WatchEntryBuilder`) to ask Smart
+/// Stack to float us up when glucose actually needs the user's
+/// attention. See `WatchRelevanceScorer` for the score → level mapping.
 struct WatchRectangularWidget: Widget {
     let kind = "WatchStatusWidget"
 

--- a/iOS/WatchWidget/WatchComplications.swift
+++ b/iOS/WatchWidget/WatchComplications.swift
@@ -1,33 +1,29 @@
-import AppIntents
 import SharedKit
 import SwiftUI
 import WidgetKit
 
-enum WatchMetricType: String, AppEnum {
+/// Which metric a complication renders. Shipped as a plain enum (not
+/// `AppEnum`) because each metric has its own `Widget` with a
+/// `StaticConfiguration` — there is no in-place picker. We deliberately
+/// avoided `AppIntentConfiguration` here after `WidgetMetricWidget` +
+/// `accessoryCircular`/`accessoryCorner` reliably produced `CHSError
+/// 1101 "Returned view collection was either nil or empty"` on
+/// watchOS 26 (see https://github.com/FokkeZB/GluWink/pull/119 thread).
+/// Splitting into one widget per metric is also clearer in the gallery:
+/// the user picks "Glucose" or "Carbs" directly, no two-step "pick the
+/// metric widget, then configure it" flow.
+enum WatchMetricType {
     case glucose
     case carbs
-
-    static var typeDisplayRepresentation = TypeDisplayRepresentation(
-        name: LocalizedStringResource("watch.widget.intent.metricType", defaultValue: "Metric")
-    )
-
-    static var caseDisplayRepresentations: [WatchMetricType: DisplayRepresentation] = [
-        .glucose: DisplayRepresentation(title: LocalizedStringResource("watch.widget.intent.glucose", defaultValue: "Glucose")),
-        .carbs: DisplayRepresentation(title: LocalizedStringResource("watch.widget.intent.carbs", defaultValue: "Carbs")),
-    ]
 }
 
-struct WatchMetricIntent: WidgetConfigurationIntent {
-    static var title: LocalizedStringResource = "GluWink"
-    static var description = IntentDescription(
-        LocalizedStringResource("watch.widget.intent.description", defaultValue: "Choose which metric to show.")
-    )
-
-    @Parameter(
-        title: LocalizedStringResource("watch.widget.intent.metricType", defaultValue: "Metric"),
-        default: .glucose
-    )
-    var metric: WatchMetricType
+private func metricHasData(_ entry: WatchEntry) -> Bool {
+    switch entry.metric {
+    case .glucose:
+        return entry.content.glucoseValue > 0
+    case .carbs:
+        return entry.content.carbGrams != nil
+    }
 }
 
 private func metricValue(_ entry: WatchEntry) -> String {
@@ -77,15 +73,28 @@ struct WatchRectangularWidget: Widget {
     }
 }
 
-struct WatchMetricWidget: Widget {
-    let kind = "WatchMetricWidget"
+struct WatchGlucoseWidget: Widget {
+    let kind = "WatchGlucoseWidget"
 
     var body: some WidgetConfiguration {
-        AppIntentConfiguration(kind: kind, intent: WatchMetricIntent.self, provider: WatchMetricTimelineProvider()) { entry in
+        StaticConfiguration(kind: kind, provider: WatchMetricTimelineProvider(metric: .glucose)) { entry in
             WatchMetricEntryView(entry: entry)
         }
-        .configurationDisplayName(String(localized: "watch.widget.metricTitle"))
-        .description(String(localized: "watch.widget.metricDescription"))
+        .configurationDisplayName(String(localized: "watch.widget.glucoseTitle"))
+        .description(String(localized: "watch.widget.glucoseDescription"))
+        .supportedFamilies([.accessoryCircular, .accessoryCorner])
+    }
+}
+
+struct WatchCarbsWidget: Widget {
+    let kind = "WatchCarbsWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: WatchMetricTimelineProvider(metric: .carbs)) { entry in
+            WatchMetricEntryView(entry: entry)
+        }
+        .configurationDisplayName(String(localized: "watch.widget.carbsTitle"))
+        .description(String(localized: "watch.widget.carbsDescription"))
         .supportedFamilies([.accessoryCircular, .accessoryCorner])
     }
 }
@@ -143,37 +152,49 @@ struct WatchAccessoryCircularView: View {
     let entry: WatchEntry
 
     var body: some View {
-        ZStack {
-            Circle()
-                .fill(metricAttentionLevel(entry).tint)
-            VStack(spacing: -3) {
-                Text(metricValue(entry))
-                    .font(.system(.title3, design: .rounded).bold())
-                    .minimumScaleFactor(0.5)
-                    .lineLimit(1)
-                Text(metricUnit(entry))
-                    .font(.system(.caption2, design: .rounded))
-                    .fontWeight(.semibold)
+        Group {
+            if metricHasData(entry) {
+                VStack(spacing: -3) {
+                    Text(metricValue(entry))
+                        .font(.system(.title3, design: .rounded).bold())
+                        .minimumScaleFactor(0.5)
+                        .lineLimit(1)
+                    Text(metricUnit(entry))
+                        .font(.system(.caption2, design: .rounded))
+                        .fontWeight(.semibold)
+                }
+            } else {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.title2.bold())
             }
-            .foregroundStyle(.white)
         }
-        .containerBackground(.clear, for: .widget)
+        .foregroundStyle(.white)
+        .containerBackground(for: .widget) {
+            metricAttentionLevel(entry).tint
+        }
     }
 }
 
 struct WatchAccessoryCornerView: View {
     let entry: WatchEntry
 
-    private var statusColor: Color {
-        metricAttentionLevel(entry).tint
+    private var metricSymbol: String {
+        switch entry.metric {
+        case .glucose: return "drop.fill"
+        case .carbs: return "fork.knife"
+        }
     }
 
     var body: some View {
-        EmptyView()
+        let hasData = metricHasData(entry)
+        let tint = metricAttentionLevel(entry).tint
+
+        Image(systemName: hasData ? metricSymbol : "exclamationmark.triangle.fill")
+            .foregroundStyle(tint)
             .widgetLabel {
-                Text("\(metricValue(entry)) \(metricUnit(entry))")
-                    .foregroundStyle(statusColor)
-                    .widgetCurvesContent()
+                Text(hasData
+                    ? "\(metricValue(entry)) \(metricUnit(entry))"
+                    : String(localized: "watch.widget.noData"))
             }
     }
 }

--- a/iOS/WatchWidget/WatchComplications.swift
+++ b/iOS/WatchWidget/WatchComplications.swift
@@ -48,6 +48,30 @@ private func metricAttentionLevel(_ entry: WatchEntry) -> AttentionLevel {
     entry.content.attentionLevel(forGlucose: entry.metric == .glucose)
 }
 
+/// Minutes-since-sample for the metric this widget is rendering. `nil`
+/// when there is no reading (no source has delivered yet, or the source
+/// is disabled). Pre-computed in `ShieldContent.init` against the entry's
+/// `now`, so the timeline producing 1-minute-spaced entries gives us a
+/// fresh value per render without wall-clock drift.
+private func metricAgoMinutes(_ entry: WatchEntry) -> Int? {
+    switch entry.metric {
+    case .glucose: return entry.content.glucose?.agoMinutes
+    case .carbs: return entry.content.carbs?.agoMinutes
+    }
+}
+
+/// Compact "X ago" string for the corner complication slot, which has
+/// room for ~3 characters max. We deliberately drop the localised "ago"
+/// / "geleden" suffix used elsewhere — the corner context implies it,
+/// and the suffix would push the string past what fits in a curved
+/// corner. Hours collapse to whole units (`"1h"`, `"2h"`) for the same
+/// reason; the more precise `"1h 30m"` form lives on the rectangular
+/// tile where there's space for it.
+private func shortAgoText(_ minutes: Int) -> String {
+    if minutes < 60 { return "\(minutes)m" }
+    return "\(minutes / 60)h"
+}
+
 private func relativeAgoText(from date: Date?) -> Text {
     guard let date else { return Text(String(localized: "watch.widget.noData")) }
     return Text(date, style: .relative)
@@ -195,23 +219,31 @@ struct WatchAccessoryCircularView: View {
 struct WatchAccessoryCornerView: View {
     let entry: WatchEntry
 
-    private var metricSymbol: String {
-        switch entry.metric {
-        case .glucose: return "drop.fill"
-        case .carbs: return "fork.knife"
-        }
-    }
-
     var body: some View {
-        let hasData = metricHasData(entry)
         let tint = metricAttentionLevel(entry).tint
 
-        Image(systemName: hasData ? metricSymbol : "exclamationmark.triangle.fill")
-            .foregroundStyle(tint)
-            .widgetLabel {
-                Text(hasData
-                    ? "\(metricValue(entry)) \(metricUnit(entry))"
-                    : String(localized: "watch.widget.noData"))
+        // Corner content is the "X ago" timestamp (or a warning triangle
+        // when there is no reading at all). The metric-identifying icon
+        // (drop / fork) used to live here, but the value itself is
+        // already in the bezel `widgetLabel` — duplicating "this is
+        // glucose" in the corner just spent the slot's tightest pixels
+        // on metadata the user could already infer from the number. The
+        // age of the sample is far more useful at a glance: a fresh
+        // reading vs. a 45-minute-old one is information you can't get
+        // anywhere else on the watch face.
+        Group {
+            if let mins = metricAgoMinutes(entry) {
+                Text(shortAgoText(mins))
+                    .font(.system(.body, design: .rounded).bold())
+            } else {
+                Image(systemName: "exclamationmark.triangle.fill")
             }
+        }
+        .foregroundStyle(tint)
+        .widgetLabel {
+            Text(metricHasData(entry)
+                ? "\(metricValue(entry)) \(metricUnit(entry))"
+                : String(localized: "watch.widget.noData"))
+        }
     }
 }

--- a/iOS/WatchWidget/WatchComplications.swift
+++ b/iOS/WatchWidget/WatchComplications.swift
@@ -154,26 +154,41 @@ struct WatchAccessoryCircularView: View {
     let entry: WatchEntry
 
     var body: some View {
-        Group {
-            if metricHasData(entry) {
-                VStack(spacing: -3) {
-                    Text(metricValue(entry))
-                        .font(.system(.title3, design: .rounded).bold())
-                        .minimumScaleFactor(0.5)
-                        .lineLimit(1)
-                    Text(metricUnit(entry))
-                        .font(.system(.caption2, design: .rounded))
-                        .fontWeight(.semibold)
+        ZStack {
+            // Filled `Circle()` inside the widget body, not via
+            // `containerBackground`, so the coloured disk is part of the
+            // widget's own content. Several watch faces (Chronograph Pro
+            // observed in testing — see https://github.com/FokkeZB/GluWink/pull/119
+            // thread) draw their own chrome around the subdial slot and
+            // don't surface the widget's container backdrop, leaving the
+            // tile looking flat black. Filling a literal circle sidesteps
+            // that entirely: the brand tint always shows up regardless of
+            // what the face does with the slot.
+            Circle().fill(metricAttentionLevel(entry).tint)
+
+            Group {
+                if metricHasData(entry) {
+                    VStack(spacing: -3) {
+                        Text(metricValue(entry))
+                            .font(.system(.title3, design: .rounded).bold())
+                            .minimumScaleFactor(0.5)
+                            .lineLimit(1)
+                        Text(metricUnit(entry))
+                            .font(.system(.caption2, design: .rounded))
+                            .fontWeight(.semibold)
+                    }
+                } else {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.title2.bold())
                 }
-            } else {
-                Image(systemName: "exclamationmark.triangle.fill")
-                    .font(.title2.bold())
             }
+            .foregroundStyle(.white)
         }
-        .foregroundStyle(.white)
-        .containerBackground(for: .widget) {
-            metricAttentionLevel(entry).tint
-        }
+        // WidgetKit still requires a `containerBackground` declaration on
+        // every entry view. We set it `.clear` because the visible
+        // colouring is owned by the `Circle()` above; without this, the
+        // widget refuses to render in `accessoryCircular` on watchOS.
+        .containerBackground(.clear, for: .widget)
     }
 }
 

--- a/iOS/WatchWidget/WatchTimelineProvider.swift
+++ b/iOS/WatchWidget/WatchTimelineProvider.swift
@@ -8,16 +8,57 @@ struct WatchEntry: TimelineEntry {
     let metric: WatchMetricType
     let glucoseDate: Date?
     let carbDate: Date?
+    /// Smart Stack relevance hint. WatchOS 10+ surfaces widgets with the
+    /// highest valid relevance score in the swipe-up Smart Stack. Set on
+    /// every entry from `WatchRelevanceScorer` so the rectangular tile
+    /// (`.accessoryRectangular`, the family Smart Stack consumes) floats
+    /// to the top when glucose goes critical / attention.
+    let relevance: TimelineEntryRelevance?
+}
+
+/// Maps `AttentionLevel` onto the Smart Stack relevance score the system
+/// uses to rank widgets in its swipe-up panel. Single source of truth so
+/// the rectangular and metric providers can't drift, and so the mapping
+/// is reviewable in one place if the brand-meaning of the levels ever
+/// shifts.
+///
+/// | Level        | Score | Why                                            |
+/// |--------------|-------|------------------------------------------------|
+/// | `.critical`  | 100   | Glucose ≥ critical threshold — must surface.   |
+/// | `.attention` | 50    | High / low / stale / carb gap / no data.       |
+/// | `.clear`     | 10    | All clear — present, but easy to demote.       |
+///
+/// `validity` matches the timeline's covered window (5 entries × 60 s) so
+/// a single attention sample stays boost-eligible across the whole
+/// cycle, even if WatchOS defers the next reload past the schedule we
+/// hand it. Scores overlap by design — Smart Stack picks the highest
+/// valid entry at any moment.
+enum WatchRelevanceScorer {
+    static let validity: TimeInterval = 5 * 60
+
+    static func score(for level: AttentionLevel) -> Float {
+        switch level {
+        case .critical: return 100
+        case .attention: return 50
+        case .clear: return 10
+        }
+    }
+
+    static func relevance(for level: AttentionLevel) -> TimelineEntryRelevance {
+        TimelineEntryRelevance(score: score(for: level), duration: validity)
+    }
 }
 
 enum WatchEntryBuilder {
     static func makeEntry(now: Date, metric: WatchMetricType) -> WatchEntry {
-        WatchEntry(
+        let content = WatchDataManager.content(now: now)
+        return WatchEntry(
             date: now,
-            content: WatchDataManager.content(now: now),
+            content: content,
             metric: metric,
             glucoseDate: WatchDataManager.glucoseFetchedAt,
-            carbDate: WatchDataManager.lastCarbEntryAt
+            carbDate: WatchDataManager.lastCarbEntryAt,
+            relevance: WatchRelevanceScorer.relevance(for: content.attentionLevel)
         )
     }
 }

--- a/iOS/WatchWidget/WatchTimelineProvider.swift
+++ b/iOS/WatchWidget/WatchTimelineProvider.swift
@@ -6,8 +6,6 @@ struct WatchEntry: TimelineEntry {
     let date: Date
     let content: ShieldContent
     let metric: WatchMetricType
-    let glucoseDate: Date?
-    let carbDate: Date?
     /// Smart Stack relevance hint. WatchOS 10+ surfaces widgets with the
     /// highest valid relevance score in the swipe-up Smart Stack. Set on
     /// every entry from `WatchRelevanceScorer` so the rectangular tile
@@ -56,8 +54,6 @@ enum WatchEntryBuilder {
             date: now,
             content: content,
             metric: metric,
-            glucoseDate: WatchDataManager.glucoseFetchedAt,
-            carbDate: WatchDataManager.lastCarbEntryAt,
             relevance: WatchRelevanceScorer.relevance(for: content.attentionLevel)
         )
     }

--- a/iOS/WatchWidget/WatchTimelineProvider.swift
+++ b/iOS/WatchWidget/WatchTimelineProvider.swift
@@ -96,41 +96,27 @@ struct WatchRectangularTimelineProvider: TimelineProvider {
     }
 }
 
-struct WatchMetricTimelineProvider: AppIntentTimelineProvider {
-    func recommendations() -> [AppIntentRecommendation<WatchMetricIntent>] {
-        [
-            AppIntentRecommendation(
-                intent: {
-                    let intent = WatchMetricIntent()
-                    intent.metric = .glucose
-                    return intent
-                }(),
-                description: String(localized: "watch.widget.intent.glucose")
-            ),
-            AppIntentRecommendation(
-                intent: {
-                    let intent = WatchMetricIntent()
-                    intent.metric = .carbs
-                    return intent
-                }(),
-                description: String(localized: "watch.widget.intent.carbs")
-            ),
-        ]
-    }
+/// Drives one of the metric complications (`WatchGlucoseWidget` /
+/// `WatchCarbsWidget`). One provider per metric — `StaticConfiguration`
+/// means no per-instance picker, the metric is baked in at widget
+/// declaration time. See `WatchMetricType` for the rationale behind
+/// avoiding `AppIntentConfiguration` on circular/corner families.
+struct WatchMetricTimelineProvider: TimelineProvider {
+    let metric: WatchMetricType
 
     func placeholder(in _: Context) -> WatchEntry {
-        WatchEntryBuilder.makeEntry(now: Date(), metric: .glucose)
+        WatchEntryBuilder.makeEntry(now: Date(), metric: metric)
     }
 
-    func snapshot(for configuration: WatchMetricIntent, in _: Context) async -> WatchEntry {
-        WatchEntryBuilder.makeEntry(now: Date(), metric: configuration.metric)
+    func getSnapshot(in _: Context, completion: @escaping (WatchEntry) -> Void) {
+        completion(WatchEntryBuilder.makeEntry(now: Date(), metric: metric))
     }
 
-    func timeline(for configuration: WatchMetricIntent, in _: Context) async -> Timeline<WatchEntry> {
+    func getTimeline(in _: Context, completion: @escaping (Timeline<WatchEntry>) -> Void) {
         let now = Date()
         let entries = WatchTimelinePolicy.entries(from: now) { date in
-            WatchEntryBuilder.makeEntry(now: date, metric: configuration.metric)
+            WatchEntryBuilder.makeEntry(now: date, metric: metric)
         }
-        return Timeline(entries: entries, policy: .atEnd)
+        completion(Timeline(entries: entries, policy: .atEnd))
     }
 }

--- a/iOS/WatchWidget/WatchWidgetBundle.swift
+++ b/iOS/WatchWidget/WatchWidgetBundle.swift
@@ -5,6 +5,7 @@ import WidgetKit
 struct WatchStatusWidgetBundle: WidgetBundle {
     var body: some Widget {
         WatchRectangularWidget()
-        WatchMetricWidget()
+        WatchGlucoseWidget()
+        WatchCarbsWidget()
     }
 }

--- a/iOS/WatchWidget/en.lproj/Localizable.strings
+++ b/iOS/WatchWidget/en.lproj/Localizable.strings
@@ -1,10 +1,7 @@
 "watch.widget.rectangularTitle" = "Status";
 "watch.widget.rectangularDescription" = "Show glucose and carbs together.";
-"watch.widget.metricTitle" = "Single Metric";
-"watch.widget.metricDescription" = "Show glucose or carbs.";
+"watch.widget.glucoseTitle" = "Glucose";
+"watch.widget.glucoseDescription" = "Show the latest glucose reading.";
+"watch.widget.carbsTitle" = "Carbs";
+"watch.widget.carbsDescription" = "Show the latest carb entry.";
 "watch.widget.noData" = "No data";
-
-"watch.widget.intent.metricType" = "Metric";
-"watch.widget.intent.glucose" = "Glucose";
-"watch.widget.intent.carbs" = "Carbs";
-"watch.widget.intent.description" = "Choose which metric to show.";

--- a/iOS/WatchWidget/nl.lproj/Localizable.strings
+++ b/iOS/WatchWidget/nl.lproj/Localizable.strings
@@ -1,10 +1,7 @@
 "watch.widget.rectangularTitle" = "Status";
 "watch.widget.rectangularDescription" = "Toon glucose en KH samen.";
-"watch.widget.metricTitle" = "Enkele meting";
-"watch.widget.metricDescription" = "Toon glucose of koolhydraten.";
+"watch.widget.glucoseTitle" = "Glucose";
+"watch.widget.glucoseDescription" = "Toon de laatste glucosewaarde.";
+"watch.widget.carbsTitle" = "Koolhydraten";
+"watch.widget.carbsDescription" = "Toon de laatste KH-invoer.";
 "watch.widget.noData" = "Geen data";
-
-"watch.widget.intent.metricType" = "Meting";
-"watch.widget.intent.glucose" = "Glucose";
-"watch.widget.intent.carbs" = "Koolhydraten";
-"watch.widget.intent.description" = "Kies welke meting je wilt tonen.";


### PR DESCRIPTION
## Summary

Closes #12. Add `TimelineEntryRelevance` to every `WatchEntry` so Apple Watch's swipe-up Smart Stack (watchOS 10+) floats GluWink to the top when glucose is critical or otherwise needs attention. No new widget kind, no new data path — relevance is the lever, the existing `.accessoryRectangular` tile is the surface.

Also includes a drive-by `fix(watch)` for a pre-existing simulator-only bug surfaced while verifying the relevance change on the watchOS Simulator — details under **Drive-by fix** below.

## Design choice — (b), enhance the existing widget

The issue raised an open question: ship a dedicated `WatchSmartStackWidget` (a) or enhance the existing `WatchRectangularWidget` (b). Picked **(b)**.

The reason is that `.accessoryRectangular` is already the family Smart Stack consumes; the work is to teach the entries what's important, not to introduce a parallel widget that does almost the same thing. Two widgets in the gallery doing similar things would also confuse users picking complications. Per AGENTS.md "Forward-only by default" — one source of truth, no compatibility paths.

A short doc-comment on `WatchRectangularWidget` now spells out that it doubles as a face complication and a Smart Stack tile, so the next reader doesn't have to derive that from the relevance code.

## Relevance scoring

| `AttentionLevel` | Score | Why |
|---|---:|---|
| `.critical` | 100 | Glucose ≥ critical threshold — must surface in Smart Stack. |
| `.attention` | 50 | High (below critical), low, stale sensor, carb gap, no glucose/carb data on a configured source. |
| `.clear` | 10 | All clear — kept addressable, easy for Smart Stack to demote in favour of more relevant tiles. |

`validity` is set to 5 minutes per entry — matches the timeline window (5 entries × 60 s in `WatchTimelinePolicy`) so a single attention sample stays boost-eligible across the whole cycle, even if WatchOS defers the next reload past our schedule. Scores overlap by design; Smart Stack picks the highest valid entry at any moment.

The mapping is centralised in `WatchRelevanceScorer` so the rectangular and metric providers can't drift, and so a future tweak to the brand-meaning of the levels only changes one switch.

## Implementation notes

- `WatchEntry.relevance: TimelineEntryRelevance?` — added as a non-nil-valued optional matching the protocol's shape; `WatchEntryBuilder.makeEntry` always populates it from the entry's overall `content.attentionLevel`. No "if relevance is nil" fallback branches per AGENTS.md "Forward-only by default".
- Both `WatchRectangularTimelineProvider` and `WatchMetricTimelineProvider` go through the same builder, so both surfaces score the same way. Smart Stack today only consumes the rectangular family; using the overall-attention score for both keeps the metric circular/corner widgets honest if Apple ever extends Smart Stack to other accessory families.
- Reused existing snapshot data plumbing — no new App Group keys, no new readers. `WatchDataManager.content(now:)` already returns a fully-resolved `ShieldContent` with `attentionLevel`, and the score is derived from that.
- No new user-facing strings (option (b) means same `configurationDisplayName` / `description` as before; existing EN + NL keys cover the surface).
- App Icon / `BrandTint` / `AttentionLevel` rules unchanged: the rectangular tile already paints `content.attentionLevel.tint`, no inline `.red`/`.green`/`.orange`. No blue case applies — Smart Stack only shows when there's data, and the existing rectangular view stays the same regardless.

## Drive-by fix — `WatchDataManager` date bridging on simulator

Second commit in this PR: `fix(watch): bridge dates to widget + app on simulator`.

Pre-existing bug, surfaced while installing this PR on the watchOS Simulator to verify the new `entry.glucoseDate` plumbing renders correctly. `WatchDataManager.glucoseFetchedAt` / `lastCarbEntryAt` (the static getters used by both `WatchContentView` and `WatchEntryBuilder` for the "X min ago" line) were defaults-only — they never consulted `SimulatorWatchBridge` the way `WatchDataManager.content(now:)` does.

On the watchOS Simulator the App Group container isn't provisioned (a `CODE_SIGNING_ALLOWED=NO` sim build leaves the watch app with empty `GroupContainers`, so `defaults?.set(...)` writes from `WCSession`'s `updateFromPhoneContext` don't survive across processes). Result: every "Xm ago" surface fell back to `--` / `Geen data` even though `content.formattedGlucose` rendered the correct value via the bridge. Visible in the screenshots the owner shared while testing — glucose / carbs values were right, time-ago was blank.

Fix: centralise the bridge-first resolution in two private helpers in `WatchDataManager` (`bridgeOrDefaultsDate`, `bridgeMockDouble`) and route both `content()` and the static getters through them. Bridge fully shadows defaults when `mockModeEnabled` is true — a missing key returns nil/0, not a stale defaults value — matching the previous `content()` semantics exactly. `SimulatorWatchBridge.loadContext()` is `#if targetEnvironment(simulator)`, so on hardware this collapses to the unchanged defaults-only path.

Bundled into this PR rather than a follow-up because #119 is the change that put `entry.glucoseDate` on screen and made the gap visible — keeping the fix next to the change that exposed it is the more reviewable arrangement.

## Build & sim verification

Build: `xcodebuild -project iOS/App.xcodeproj -scheme App -derivedDataPath "$(mktemp -d)/dd" -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' build CODE_SIGNING_ALLOWED=NO` → `** BUILD SUCCEEDED **`. Isolated DerivedData per QUIRKS.md → "Shared DerivedData can produce unsigned device builds".

Watch face on the watchOS Simulator (paired iPhone 17 Pro Max + Apple Watch Series 11 46mm, both iOS 26.4 / watchOS 26.4) before / after the drive-by fix:

| Surface | Before (commit 432aa27) | After (commit 7b8a4f5) |
|---|---|---|
| Rectangular widget | `⚠ -- mm Geen data` / `⚠ -- g Geen data` (orange) | `✓ 6.4 mm 22min, 10sec` / `✓ 20 g 2uur, 17min` (green) |
| Circular complications (glucose / carbs) | orange placeholder | green, picking up the bridge values |
| WatchContentView relative-time line | `--` | proper "X min ago" |

(Smart Stack ranking itself is not observable on the simulator — see owner verification below.)

## TODO left

- `RelevantContext` / `RelevantContextStore` (watchOS 10+ proactive hints) is intentionally **not** wired up in this pass — it would need hooks in `WatchHealthKitManager` to write context records on every threshold crossing, which is a larger refactor than the issue's "optimised for Smart Stack" bar implies. Relevance scoring alone is what surfaces the widget when it matters; a follow-up can add proactive contexts if the relevance-only behaviour feels too passive in real watch use. No `// TODO` marker in code — the doc-comment on `WatchRectangularWidget` and `WatchRelevanceScorer` already documents the lever and where to extend it.

## Owner verification on a paired Apple Watch (watchOS 10+)

Smart Stack relevance behaviour can only be observed on hardware. Things to check post-merge:

1. **Critical surfacing.** With shielding active and glucose ≥ critical (e.g. 21 mmol/L via Demo source on phone, synced over), swipe up on the watch face. The GluWink rectangular tile should float near the top of Smart Stack within a few minutes (system-driven, not instant).
2. **Attention vs. clear.** Drop glucose back into range and wait for the next timeline reload (~5 min). The tile should stop being prioritised and recede to its "ambient" position in the stack.
3. **Face complication still works.** Same widget is still pickable as an `.accessoryRectangular` complication on watch faces — adding it should be unchanged from before this PR. The relevance hint is ignored when the tile is pinned to a face slot, by design.
4. **No-data state isn't blue.** Watch widget never reaches the welcome-blue case (only in-app, gated on no source configured). If a configured source has stopped delivering, the tile should be orange (`.attention`) — same as before this PR. Relevance score in that state is 50, so it'll still surface in Smart Stack as "something's off".

If Smart Stack feels too passive — i.e. critical isn't surfacing within a couple of minutes — the next lever is `RelevantContextStore` (see TODO above). Push back here and I'll wire it up in a follow-up.

## Test plan

- [x] `xcodebuild ... build` clean compile (App + WatchApp + WatchWidget + extensions)
- [x] Owner-driven sim install verified the drive-by date fix end-to-end on the watchOS Simulator (rectangular widget + circular complications + watch app all show proper "X min ago" once the bridge has data).
- [ ] Owner: install on paired watch, verify Smart Stack surfacing per the four checks above
- [ ] Owner: confirm watch-face complication picker still shows the GluWink rectangular widget unchanged

Closes #12

Made with [Cursor](https://cursor.com)
