### PR TITLE
docs(community): add code of conduct, issue templates, security policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,100 @@
+name: Bug report
+description: Something isn't working the way it should.
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. The more concrete this is, the faster it gets fixed.
+
+        For security issues (shielding bypass, passphrase / Keychain handling, App Group data exposure, anything that could let a child circumvent the shield without the configured passphrase), please use the security policy in [`SECURITY.md`](../../SECURITY.md) instead — those go through GitHub's private vulnerability reporting, not this public form.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One or two sentences. What did you expect, and what happened instead?
+      placeholder: I expected X, but Y happened.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: A numbered list. Include taps, screens, and anything off-device (e.g. CGM app state, Health permissions).
+      placeholder: |
+        1. Open GluWink
+        2. Tap the gear icon and enter the passphrase
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      placeholder: The shield should re-arm after 30 minutes.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+      placeholder: The shield never re-arms.
+    validations:
+      required: true
+
+  - type: input
+    id: device
+    attributes:
+      label: Device + iOS version
+      description: e.g. "iPhone 15 Pro, iOS 18.2". Apple Watch model + watchOS version too if the bug is on the watch.
+      placeholder: iPhone 15 Pro, iOS 18.2
+    validations:
+      required: true
+
+  - type: input
+    id: app-version
+    attributes:
+      label: GluWink version
+      description: |
+        Visible in Settings → about the bottom of the screen. Format: `1.2.3 (45)` — `CFBundleShortVersionString` then build number in parens.
+      placeholder: 1.2.3 (45)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: data-source
+    attributes:
+      label: Data source
+      description: Which data source is configured?
+      options:
+        - Apple Health (HealthKit)
+        - Nightscout
+        - Demo / mock data
+        - Multiple sources enabled
+        - None / not configured yet
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs, screenshots, or recordings
+      description: |
+        Drag and drop screenshots / screen recordings into this field. For logs, Console.app on macOS with the iPhone connected over USB filtered by `subsystem:nl.fokkezb.GluWink` is the easiest path.
+      placeholder: (paste / drag here)
+
+  - type: checkboxes
+    id: confirm
+    attributes:
+      label: Confirmation
+      options:
+        - label: I have searched [existing issues](https://github.com/FokkeZB/GluWink/issues?q=is%3Aissue) and this is not a duplicate.
+          required: true
+        - label: This is not a security issue (those go through [`SECURITY.md`](../../SECURITY.md)).
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or discussion
+    url: https://github.com/FokkeZB/GluWink/discussions
+    about: For questions, ideas, or general discussion. The issue tracker is for tracked work (bugs and feature requests).

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,56 @@
+name: Feature request
+description: Suggest a new feature or an enhancement to an existing one.
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to suggest something. Smaller / sharper requests are easier to act on — if your idea spans several features, consider opening one issue per feature so each can be discussed and prioritised on its own.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What's the situation today that this would improve? Describe the user experience, not the implementation.
+      placeholder: When my child opens the shield with low glucose, they have to ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What you'd like to see. Mockups, screenshots, or rough text are all fine.
+      placeholder: Add a button that ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about and why you didn't pick them. Saying "none" is fine if you've only got one idea.
+      placeholder: I considered X, but it would mean ...
+
+  - type: dropdown
+    id: audience
+    attributes:
+      label: Who benefits?
+      description: GluWink supports two audiences with different constraints. Be honest about which one this helps — both is also a valid answer.
+      options:
+        - Children (parent-managed via Family Sharing)
+        - Adults (self-managing)
+        - Either / both
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: confirm
+    attributes:
+      label: Confirmation
+      options:
+        - label: I have searched [existing issues](https://github.com/FokkeZB/GluWink/issues?q=is%3Aissue) and [discussions](https://github.com/FokkeZB/GluWink/discussions) and this is not already on the table.
+          required: true
+        - label: I've read the [security model](../../AGENTS.md#security-design-philosophy) and this proposal does not weaken the passphrase gate or give the child a bypass route.
+          required: true

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -36,7 +36,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at `<MAINTAINER_EMAIL>` (placeholder — see the note in the PR; the maintainer will replace this before merge). All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at mail@fokkezb.nl. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at `<MAINTAINER_EMAIL>` (placeholder — see the note in the PR; the maintainer will replace this before merge). All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,51 @@
+# Security Policy
+
+GluWink shields all apps on a child's iPhone (or an adult's, with deliberate friction) until the user acknowledges their diabetes status. Anything that lets a child bypass the shield without the configured passphrase is a security issue. We take those seriously.
+
+## Supported versions
+
+Only the **latest TestFlight or App Store release** is supported. GluWink is a single-maintainer open-source project — there's no LTS, no backports, no parallel branches. If you're on an older build, please update before reporting.
+
+## Reporting a vulnerability
+
+**Please report privately.** Do not file a public issue.
+
+The primary channel is GitHub's [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability):
+
+> Go to the repository's **Security** tab → **Report a vulnerability**.
+
+That opens a private advisory only the maintainer and you can see, with a structured template for the details. If you can't use that flow, fall back to the maintainer email at `<MAINTAINER_EMAIL>` (placeholder — see the note in the PR; the maintainer will replace this before merge).
+
+When you report, please include:
+
+- A clear description of the issue and what an attacker can do with it.
+- Reproduction steps (on-device steps, sample data, scripts — whatever you have).
+- Affected GluWink version (`CFBundleShortVersionString` + build number, visible in Settings).
+- iOS version, device model, and any relevant configuration (Family Sharing setup, data source, etc.).
+
+## Disclosure timeline
+
+- **Acknowledgement** within **7 days** of the report.
+- **Fix or status update** within **30 days**. If a fix takes longer (third-party dependency, App Review queue, etc.), we'll keep you in the loop in the same advisory thread.
+- **Public disclosure** is coordinated with the reporter. We'd prefer to ship a fix in TestFlight / the App Store before the advisory goes public, but we won't sit on a confirmed issue indefinitely.
+
+## In scope
+
+- **Shielding bypass** — any path that removes or sidesteps the shield without the configured passphrase, including misuse of `ManagedSettings`, `DeviceActivity`, App Group state, or the shield extensions.
+- **Passphrase / Keychain handling** — weak hashing, salt reuse, plaintext storage, key-extraction routes, brute-force amplification.
+- **App Group data exposure** — anything that lets another app on the device read or tamper with GluWink's `group.nl.fokkezb.GluWink` container.
+- **Shield extensions** (`ShieldConfig`, `ShieldAction`, `DeviceActivityMonitor`) — re-arm bypasses, dismiss-without-check-in paths, state corruption from extension input.
+- **Critical-glucose contract** — anything that lets the shield be dismissed at or above the user-configured critical threshold (per the [check-in rules in `AGENTS.md`](AGENTS.md#check-in-rules-hard-coded), this is supposed to be a hard "no").
+- **Data integrity from external sources** — Nightscout response handling, HealthKit sample validation, anything that can be poisoned to spoof a "safe" reading.
+
+## Out of scope
+
+- **Feature requests, UX gripes, missing translations.** Those go in the regular [issue tracker](https://github.com/FokkeZB/GluWink/issues) or [Discussions](https://github.com/FokkeZB/GluWink/discussions).
+- **Generic Apple platform issues** (HealthKit returning stale samples on a specific iOS build, FamilyControls UI bugs, etc.) — please file those with Apple via Feedback Assistant.
+- **Adults deleting the app from their own device.** This is by design — the adult mode is deliberate friction, not absolute prevention. See [`AGENTS.md` → "For adults"](AGENTS.md#for-adults-self-managing).
+- **Children defeating the shield by powering off the device, factory-resetting, asking the parent for the passphrase, etc.** Out-of-band attacks the app cannot defend against.
+- **Issues in the `docs/` marketing site** that don't expose user data or affect the iOS app's security posture.
+
+## Out-of-scope licence note
+
+The `LICENSE` shows up as `Other` on GitHub because [PolyForm Noncommercial 1.0](https://polyformproject.org/licenses/noncommercial/1.0.0/) isn't in GitHub's SPDX list. That's deliberate — noncommercial is the point. Not a security issue.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ The primary channel is GitHub's [private vulnerability reporting](https://docs.g
 
 > Go to the repository's **Security** tab → **Report a vulnerability**.
 
-That opens a private advisory only the maintainer and you can see, with a structured template for the details. If you can't use that flow, fall back to the maintainer email at `<MAINTAINER_EMAIL>` (placeholder — see the note in the PR; the maintainer will replace this before merge).
+That opens a private advisory only the maintainer and you can see, with a structured template for the details. If you can't use that flow, fall back to the maintainer email at mail@fokkezb.nl.
 
 When you report, please include:
 


### PR DESCRIPTION
## Summary

Closes the three gaps GitHub's [community profile checklist](https://github.com/FokkeZB/GluWink/community) flagged on the public repo: no code of conduct, no issue templates, no security policy. None were release-blocking, but they're cheap to add and they unlock structured bug reports, a published vulnerability disclosure path, and a clearer signal to drive-by visitors that the project has community norms.

## What's added

- **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1 verbatim (de-facto standard, GitHub auto-detects it). Hugo TOML frontmatter from the upstream source stripped so it renders cleanly on github.com. Contact: `mail@fokkezb.nl`.
- **`.github/ISSUE_TEMPLATE/`** — three YAML form templates (modern form schema, not legacy markdown):
  - `bug_report.yml` — pre-applies `bug` label; fields for summary, repro steps, expected vs actual, device + iOS version, GluWink version (`CFBundleShortVersionString` + build number per AGENTS.md neutrality), data source dropdown (HealthKit / Nightscout / Demo / etc.), logs/screenshots. Steers security-sensitive reports at `SECURITY.md` instead.
  - `feature_request.yml` — pre-applies `enhancement`; fields for problem statement, proposed solution, alternatives considered, and a "who benefits" dropdown (Children / Adults / Either) that mirrors the two audiences in `AGENTS.md`. Includes a checkbox confirming the proposal doesn't weaken the passphrase gate.
  - `config.yml` — `blank_issues_enabled: false` so the tracker stays for tracked work, plus a contact link to GitHub Discussions (verified enabled via `gh api repos/FokkeZB/GluWink --jq '.has_discussions' → true`).
- **`SECURITY.md`** at repo root (more discoverable than `.github/SECURITY.md`; GitHub finds both):
  - Supported version policy: latest TestFlight / App Store release only (single-maintainer, no LTS).
  - Primary reporting channel: GitHub's [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability), with `mail@fokkezb.nl` as a fallback.
  - In scope: shielding bypass, passphrase / Keychain handling, App Group data exposure, shield extensions, the critical-glucose no-disarm contract per `AGENTS.md`, data integrity from Nightscout / HealthKit.
  - Out of scope: feature requests, generic Apple platform issues, the deliberate "adult deletes the app" friction-not-prevention case per `AGENTS.md` → "For adults".
  - Timeline: ack within 7 days, fix or status update within 30.

## After merging — owner action required

**Enable Private Vulnerability Reporting** in repo settings:
- `Settings → Code security and analysis → Private vulnerability reporting → Enable`.
- This makes the "Security tab → Report a vulnerability" link in `SECURITY.md` actually open an advisory form. Currently the link will work but the form may be greyed out until this toggle is on.
- Can't be done from CLI / API; web UI only.

## Acceptance

Per the issue body's acceptance criteria — verified post-merge once GitHub re-indexes the community profile (the cache lags by a few minutes):

\`\`\`bash
gh api repos/FokkeZB/GluWink/community/profile --jq '.files | to_entries | map(select(.value == null)) | length'
# expect: 0
\`\`\`

The community profile page should show green ticks for code of conduct, issue templates, and security policy. License will keep showing as `Other` — that's expected (PolyForm Noncommercial 1.0 isn't in GitHub's SPDX list, and that's deliberate per `LICENSE`).

## Verification done

- `ruby -ryaml` parses all three `.yml` form templates without errors.
- File layout matches what GitHub's community detector looks for (`CODE_OF_CONDUCT.md` and `SECURITY.md` at repo root, templates under `.github/ISSUE_TEMPLATE/`).
- No Swift / Xcode changes — skipped the build verification step per AGENTS.md (markdown / YAML only).

## Notes for reviewers

- Two commits — initial bundle, then a follow-up that substitutes `mail@fokkezb.nl` for the placeholder (the address is already exposed in 154 prior git-history commits, so no privacy gain in placeholding).
- Did not touch `.github/pull_request_template.md` — already present, working, out of scope.
- English only — no NL counterpart, per AGENTS.md "English is the project's base language".

Closes #118