### PR TITLE
feat: add EasyView (Medtrum) as a fourth data source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ docs/.jekyll-cache/
 docs/.jekyll-metadata
 docs/vendor/bundle/
 docs/.bundle/
+

--- a/iOS/App/App.swift
+++ b/iOS/App/App.swift
@@ -47,6 +47,19 @@ struct MainApp: App {
                 NightscoutManager.shared.handleBackgroundRefresh(refreshTask)
             }
         }
+
+        BGTaskScheduler.shared.register(
+            forTaskWithIdentifier: EasyViewManager.backgroundTaskIdentifier,
+            using: nil
+        ) { task in
+            guard let refreshTask = task as? BGAppRefreshTask else {
+                task.setTaskCompleted(success: false)
+                return
+            }
+            Task { @MainActor in
+                EasyViewManager.shared.handleBackgroundRefresh(refreshTask)
+            }
+        }
     }
 
     var body: some Scene {
@@ -89,6 +102,13 @@ struct MainApp: App {
                         NightscoutManager.shared.startPolling()
                         await NightscoutManager.shared.fetchAll()
                         NightscoutManager.shared.scheduleBackgroundRefresh()
+                    }
+
+                    // EasyView: only poll when the user has enabled the integration.
+                    if data.easyViewEnabled {
+                        EasyViewManager.shared.startPolling()
+                        await EasyViewManager.shared.fetchAll()
+                        EasyViewManager.shared.scheduleBackgroundRefresh()
                     }
 
                     // Shielding requires at least one live data source to
@@ -134,6 +154,9 @@ struct MainApp: App {
                             if SharedDataManager.shared.nightscoutEnabled {
                                 await NightscoutManager.shared.fetchAll()
                             }
+                            if SharedDataManager.shared.easyViewEnabled {
+                                await EasyViewManager.shared.fetchAll()
+                            }
                             // Always reconcile on foreground — staleness and
                             // carb-grace transitions cross thresholds on
                             // wall-clock time alone, with no fetch event to
@@ -144,6 +167,9 @@ struct MainApp: App {
                     } else if scenePhase == .background {
                         if SharedDataManager.shared.nightscoutEnabled {
                             NightscoutManager.shared.scheduleBackgroundRefresh()
+                        }
+                        if SharedDataManager.shared.easyViewEnabled {
+                            EasyViewManager.shared.scheduleBackgroundRefresh()
                         }
                     }
                 }
@@ -180,6 +206,7 @@ struct MainApp: App {
 
         SharedDataManager.shared.wipeAllForFreshInstall()
         KeychainManager.shared.removePassphrase()
+        KeychainManager.shared.easyViewPassword = nil
         ShieldManager.shared.removeShields()
         ActivityScheduler.shared.stopMonitoring()
 

--- a/iOS/App/EasyViewManager.swift
+++ b/iOS/App/EasyViewManager.swift
@@ -29,21 +29,18 @@ final class EasyViewManager {
     // MARK: - Config
 
     /// Build a client from current user configuration. Returns nil when
-    /// EasyView is disabled, missing required fields, or there is no session.
+    /// EasyView is disabled or there is no session cookie yet.
     private func currentClient() -> EasyViewClient? {
         let data = SharedDataManager.shared
         guard data.easyViewEnabled,
-              let urlString = data.easyViewBaseURL,
-              let session = data.easyViewSession,
-              let client = EasyViewClient(baseURLString: urlString, sessionCookie: session)
+              let session = data.easyViewSession
         else { return nil }
-        return client
+        return EasyViewClient(sessionCookie: session)
     }
 
     var isConfigured: Bool {
         let data = SharedDataManager.shared
-        guard let urlString = data.easyViewBaseURL, !urlString.isEmpty,
-              let username = data.easyViewUsername, !username.isEmpty,
+        guard let username = data.easyViewUsername, !username.isEmpty,
               KeychainManager.shared.easyViewPassword?.isEmpty == false
         else { return false }
         return true
@@ -151,8 +148,7 @@ final class EasyViewManager {
     @discardableResult
     func reLogin() async -> Bool {
         let data = SharedDataManager.shared
-        guard let urlString = data.easyViewBaseURL,
-              let username = data.easyViewUsername,
+        guard let username = data.easyViewUsername,
               let password = KeychainManager.shared.easyViewPassword
         else {
             logger.error("EasyView re-login failed — missing credentials")
@@ -161,7 +157,6 @@ final class EasyViewManager {
         }
         do {
             let result = try await EasyViewClient.login(
-                baseURLString: urlString,
                 username: username,
                 password: password
             )
@@ -186,19 +181,15 @@ final class EasyViewManager {
     /// Login + fetch one glucose sample. Used by the Settings UI to verify credentials.
     /// On success also writes the session + patientUID to the App Group.
     func testConnection(
-        baseURL: String,
         username: String,
         password: String
     ) async throws -> TestResult {
         let loginResult = try await EasyViewClient.login(
-            baseURLString: baseURL,
             username: username,
             password: password
         )
 
-        guard let client = EasyViewClient(baseURLString: baseURL, sessionCookie: loginResult.sessionCookie) else {
-            throw EasyViewClient.ClientError.invalidBaseURL
-        }
+        let client = EasyViewClient(sessionCookie: loginResult.sessionCookie)
 
         // For monitor accounts, fetch connections and use the first one
         // (the Settings view will offer a picker if more are found).

--- a/iOS/App/EasyViewManager.swift
+++ b/iOS/App/EasyViewManager.swift
@@ -1,0 +1,256 @@
+import BackgroundTasks
+import Foundation
+import os
+import SharedKit
+import WidgetKit
+
+/// Coordinates EasyView (Medtrum) polling on iOS. Mirrors `NightscoutManager` in shape:
+/// a singleton that keeps the App Group keys up to date via `SharedDataManager`,
+/// reloads widgets, and refreshes shields/app icon.
+///
+/// On session expiry (`.sessionExpired` from `EasyViewClient`) the manager
+/// re-logs in using the password from Keychain, stores the new session cookie in
+/// the App Group, then retries the fetch once. If re-login also fails, the error
+/// is surfaced in `SharedDataManager.easyViewLastError`.
+@MainActor
+final class EasyViewManager {
+    static let shared = EasyViewManager()
+
+    static let backgroundTaskIdentifier = "\(Constants.bundlePrefix).easyview.refresh"
+    static let pollInterval: TimeInterval = 5 * 60
+
+    private let logger = Logger(subsystem: Constants.bundlePrefix, category: "EasyViewManager")
+
+    private var pollTimer: Timer?
+    private var inFlight = false
+
+    private init() {}
+
+    // MARK: - Config
+
+    /// Build a client from current user configuration. Returns nil when
+    /// EasyView is disabled, missing required fields, or there is no session.
+    private func currentClient() -> EasyViewClient? {
+        let data = SharedDataManager.shared
+        guard data.easyViewEnabled,
+              let urlString = data.easyViewBaseURL,
+              let session = data.easyViewSession,
+              let client = EasyViewClient(baseURLString: urlString, sessionCookie: session)
+        else { return nil }
+        return client
+    }
+
+    var isConfigured: Bool {
+        let data = SharedDataManager.shared
+        guard let urlString = data.easyViewBaseURL, !urlString.isEmpty,
+              let username = data.easyViewUsername, !username.isEmpty,
+              KeychainManager.shared.easyViewPassword?.isEmpty == false
+        else { return false }
+        return true
+    }
+
+    // MARK: - Polling lifecycle
+
+    func startPolling() {
+        stopPolling()
+        guard isConfigured else { return }
+        let timer = Timer(timeInterval: Self.pollInterval, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                await self?.fetchAll()
+            }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        pollTimer = timer
+        logger.info("EasyView polling started (\(Int(Self.pollInterval))s)")
+    }
+
+    func stopPolling() {
+        pollTimer?.invalidate()
+        pollTimer = nil
+    }
+
+    func configurationDidChange() {
+        if isConfigured {
+            startPolling()
+            Task { await fetchAll() }
+        } else {
+            stopPolling()
+        }
+    }
+
+    // MARK: - Fetching
+
+    func fetchAll() async {
+        guard isConfigured else { return }
+        guard !SharedDataManager.shared.isMockModeEnabled else {
+            logger.info("Mock mode active — skipping EasyView fetch")
+            return
+        }
+        guard !inFlight else { return }
+        inFlight = true
+        defer { inFlight = false }
+
+        // If we have no session yet, try to get one first.
+        if SharedDataManager.shared.easyViewSession == nil {
+            guard await reLogin() else { return }
+        }
+
+        await performFetch(retryOnExpiry: true)
+    }
+
+    /// Internal fetch pass. When `retryOnExpiry` is true and the session is
+    /// expired, re-login once and retry. This keeps `fetchAll` readable while
+    /// avoiding unbounded recursion.
+    private func performFetch(retryOnExpiry: Bool) async {
+        guard let client = currentClient() else { return }
+        let data = SharedDataManager.shared
+
+        guard let patientUID = data.easyViewPatientUID else {
+            logger.warning("EasyView patientUID not set — skipping fetch")
+            data.easyViewLastError = "Patient not selected"
+            return
+        }
+
+        do {
+            // Fetch glucose and carbs concurrently.
+            async let glucoseTask = client.fetchLatestGlucose(patientUID: patientUID)
+            async let carbsTask = client.fetchLatestCarbs(patientUID: patientUID)
+
+            let glucose = try await glucoseTask
+            let carbs = try await carbsTask
+
+            if let glucose {
+                data.saveEasyViewGlucose(mmol: glucose.mmol, at: glucose.date)
+                logger.info("EasyView glucose: \(String(format: "%.1f", glucose.mmol)) mmol/L at \(glucose.date)")
+            }
+            if let carbs {
+                data.saveEasyViewCarbs(grams: carbs.grams, at: carbs.date)
+                logger.info("EasyView carbs: \(String(format: "%.0f", carbs.grams))g at \(carbs.date)")
+            }
+            data.easyViewLastError = nil
+        } catch EasyViewClient.ClientError.sessionExpired where retryOnExpiry {
+            logger.info("EasyView session expired — re-logging in")
+            guard await reLogin() else { return }
+            await performFetch(retryOnExpiry: false)
+            return
+        } catch {
+            logger.error("EasyView fetch failed: \(error.localizedDescription)")
+            data.easyViewLastError = error.localizedDescription
+        }
+
+        data.easyViewLastFetchedAt = Date()
+        data.refreshAttentionBadge()
+        ShieldManager.shared.reevaluateShields()
+        WidgetCenter.shared.reloadAllTimelines()
+        WatchSessionManager.shared.sendLatestContext()
+        scheduleBackgroundRefresh()
+    }
+
+    /// Re-login using stored credentials. Writes the new session to the App
+    /// Group on success. Returns true when the session was refreshed.
+    @discardableResult
+    func reLogin() async -> Bool {
+        let data = SharedDataManager.shared
+        guard let urlString = data.easyViewBaseURL,
+              let username = data.easyViewUsername,
+              let password = KeychainManager.shared.easyViewPassword
+        else {
+            logger.error("EasyView re-login failed — missing credentials")
+            data.easyViewLastError = "Missing credentials"
+            return false
+        }
+        do {
+            let result = try await EasyViewClient.login(
+                baseURLString: urlString,
+                username: username,
+                password: password
+            )
+            data.easyViewSession = result.sessionCookie
+            data.flush()
+            logger.info("EasyView re-login succeeded (userType=\(result.userType))")
+            return true
+        } catch {
+            logger.error("EasyView re-login failed: \(error.localizedDescription)")
+            data.easyViewLastError = error.localizedDescription
+            return false
+        }
+    }
+
+    // MARK: - Connection test (settings UI)
+
+    struct TestResult {
+        let glucose: EasyViewClient.GlucoseSample?
+        let carbs: EasyViewClient.CarbEntry?
+    }
+
+    /// Login + fetch one glucose sample. Used by the Settings UI to verify credentials.
+    /// On success also writes the session + patientUID to the App Group.
+    func testConnection(
+        baseURL: String,
+        username: String,
+        password: String
+    ) async throws -> TestResult {
+        let loginResult = try await EasyViewClient.login(
+            baseURLString: baseURL,
+            username: username,
+            password: password
+        )
+
+        guard let client = EasyViewClient(baseURLString: baseURL, sessionCookie: loginResult.sessionCookie) else {
+            throw EasyViewClient.ClientError.invalidBaseURL
+        }
+
+        // For monitor accounts, fetch connections and use the first one
+        // (the Settings view will offer a picker if more are found).
+        let patientUID: Int
+        if loginResult.isPatient {
+            patientUID = loginResult.uid
+        } else {
+            let connections = try await client.fetchConnections()
+            guard let first = connections.first else {
+                throw EasyViewClient.ClientError.decoding("No monitored patients found")
+            }
+            patientUID = first.uid
+        }
+
+        let glucose = try await client.fetchLatestGlucose(patientUID: patientUID)
+
+        // Persist on success.
+        let data = SharedDataManager.shared
+        data.easyViewSession = loginResult.sessionCookie
+        data.easyViewPatientUID = patientUID
+        data.flush()
+
+        return TestResult(glucose: glucose, carbs: nil)
+    }
+
+    // MARK: - Background refresh
+
+    func scheduleBackgroundRefresh() {
+        guard isConfigured else { return }
+        let request = BGAppRefreshTaskRequest(identifier: Self.backgroundTaskIdentifier)
+        request.earliestBeginDate = Date(timeIntervalSinceNow: Self.pollInterval)
+        do {
+            try BGTaskScheduler.shared.submit(request)
+        } catch {
+            logger.error("Failed to schedule EasyView background refresh: \(error.localizedDescription)")
+        }
+    }
+
+    func handleBackgroundRefresh(_ task: BGAppRefreshTask) {
+        logger.info("EasyView background refresh task started")
+        scheduleBackgroundRefresh()
+
+        let work = Task { @MainActor in
+            await fetchAll()
+            logger.info("EasyView background refresh task completed")
+            task.setTaskCompleted(success: true)
+        }
+
+        task.expirationHandler = {
+            self.logger.warning("EasyView background refresh task expired")
+            work.cancel()
+            task.setTaskCompleted(success: false)
+        }
+    }
+}

--- a/iOS/App/EasyViewManager.swift
+++ b/iOS/App/EasyViewManager.swift
@@ -191,17 +191,17 @@ final class EasyViewManager {
 
         let client = EasyViewClient(sessionCookie: loginResult.sessionCookie)
 
-        // For monitor accounts, fetch connections and use the first one
-        // (the Settings view will offer a picker if more are found).
+        // Resolve the patient UID. For patient accounts use the login uid
+        // directly. For monitor accounts try fetchConnections; fall back to
+        // the login uid if that call fails or returns nothing (e.g. the
+        // account has dual roles, or the endpoint is temporarily unreachable).
         let patientUID: Int
         if loginResult.isPatient {
             patientUID = loginResult.uid
         } else {
-            let connections = try await client.fetchConnections()
-            guard let first = connections.first else {
-                throw EasyViewClient.ClientError.decoding("No monitored patients found")
-            }
-            patientUID = first.uid
+            let connections = (try? await client.fetchConnections()) ?? []
+            patientUID = connections.first?.uid ?? loginResult.uid
+            logger.info("EasyView monitor account: resolved patientUID=\(patientUID) via \(connections.isEmpty ? "login uid fallback" : "connections")")
         }
 
         let glucose = try await client.fetchLatestGlucose(patientUID: patientUID)

--- a/iOS/App/EasyViewManager.swift
+++ b/iOS/App/EasyViewManager.swift
@@ -4,7 +4,7 @@ import os
 import SharedKit
 import WidgetKit
 
-/// Coordinates EasyView (Medtrum) polling on iOS. Mirrors `NightscoutManager` in shape:
+/// Coordinates EasyView polling on iOS. Mirrors `NightscoutManager` in shape:
 /// a singleton that keeps the App Group keys up to date via `SharedDataManager`,
 /// reloads widgets, and refreshes shields/app icon.
 ///

--- a/iOS/App/Info.plist
+++ b/iOS/App/Info.plist
@@ -7,6 +7,7 @@
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>$(BUNDLE_PREFIX).nightscout.refresh</string>
+		<string>$(BUNDLE_PREFIX).easyview.refresh</string>
 	</array>
 	<key>BundlePrefix</key>
 	<string>$(BUNDLE_PREFIX)</string>

--- a/iOS/App/KeychainManager.swift
+++ b/iOS/App/KeychainManager.swift
@@ -47,7 +47,55 @@ final class KeychainManager {
         }
     }
 
-    // MARK: - Private
+    // MARK: - EasyView password
+
+    /// The user's EasyView login password. Stored in Keychain so it never
+    /// leaves the main app. The session cookie is stored in the App Group
+    /// (accessible to widget + watch) and re-acquired from this password on
+    /// expiry.
+    var easyViewPassword: String? {
+        get { readString(account: "easyview-password") }
+        set { writeOrDelete(string: newValue, account: "easyview-password") }
+    }
+
+    // MARK: - Private helpers
+
+    private func readString(account: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess, let data = result as? Data else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    private func writeOrDelete(string: String?, account: String) {
+        let deleteQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        SecItemDelete(deleteQuery as CFDictionary)
+        guard let string, !string.isEmpty, let data = string.data(using: .utf8) else { return }
+        let addQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
+        ]
+        let status = SecItemAdd(addQuery as CFDictionary, nil)
+        if status != errSecSuccess {
+            logger.error("Keychain write failed for '\(account)': \(status)")
+        }
+    }
+
+    // MARK: - Passphrase private
 
     private static func hash(_ passphrase: String, salt: Data) -> Data {
         let input = salt + Data(passphrase.utf8)

--- a/iOS/App/SettingsView.swift
+++ b/iOS/App/SettingsView.swift
@@ -1132,7 +1132,6 @@ struct NightscoutSettingsView: View {
 
 struct EasyViewSettingsView: View {
     @State private var enabled: Bool
-    @State private var baseURL: String
     @State private var username: String
     @State private var password: String
     @State private var lastError: String?
@@ -1149,7 +1148,6 @@ struct EasyViewSettingsView: View {
     init() {
         let data = SharedDataManager.shared
         _enabled = State(initialValue: data.easyViewEnabled)
-        _baseURL = State(initialValue: data.easyViewBaseURL ?? "")
         _username = State(initialValue: data.easyViewUsername ?? "")
         _password = State(initialValue: KeychainManager.shared.easyViewPassword ?? "")
         _lastError = State(initialValue: data.easyViewLastError)
@@ -1158,8 +1156,7 @@ struct EasyViewSettingsView: View {
     }
 
     private var hasCredentials: Bool {
-        !baseURL.trimmingCharacters(in: .whitespaces).isEmpty
-            && !username.trimmingCharacters(in: .whitespaces).isEmpty
+        !username.trimmingCharacters(in: .whitespaces).isEmpty
             && !password.trimmingCharacters(in: .whitespaces).isEmpty
     }
 
@@ -1198,15 +1195,6 @@ struct EasyViewSettingsView: View {
             }
 
             Section {
-                TextField(
-                    String(localized: "settings.easyViewURLPlaceholder"),
-                    text: $baseURL
-                )
-                .textContentType(.URL)
-                .keyboardType(.URL)
-                .autocorrectionDisabled()
-                .textInputAutocapitalization(.never)
-
                 TextField(
                     String(localized: "settings.easyViewUsernamePlaceholder"),
                     text: $username
@@ -1332,17 +1320,14 @@ struct EasyViewSettingsView: View {
 
     private func persistFields() {
         let data = SharedDataManager.shared
-        let trimmedURL = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedUsername = username.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedPassword = password.trimmingCharacters(in: .whitespacesAndNewlines)
-        let urlChanged = data.easyViewBaseURL != (trimmedURL.isEmpty ? nil : trimmedURL)
         let usernameChanged = data.easyViewUsername != (trimmedUsername.isEmpty ? nil : trimmedUsername)
         let passwordChanged = KeychainManager.shared.easyViewPassword != (trimmedPassword.isEmpty ? nil : trimmedPassword)
-        data.easyViewBaseURL = trimmedURL.isEmpty ? nil : trimmedURL
         data.easyViewUsername = trimmedUsername.isEmpty ? nil : trimmedUsername
         KeychainManager.shared.easyViewPassword = trimmedPassword.isEmpty ? nil : trimmedPassword
         data.flush()
-        if urlChanged || usernameChanged || passwordChanged {
+        if usernameChanged || passwordChanged {
             EasyViewManager.shared.configurationDidChange()
             WatchSessionManager.shared.sendLatestContext()
         }
@@ -1358,12 +1343,10 @@ struct EasyViewSettingsView: View {
         testResult = nil
         defer { isTesting = false }
 
-        let trimmedURL = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedUsername = username.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedPassword = password.trimmingCharacters(in: .whitespacesAndNewlines)
         do {
             let result = try await EasyViewManager.shared.testConnection(
-                baseURL: trimmedURL,
                 username: trimmedUsername,
                 password: trimmedPassword
             )

--- a/iOS/App/SettingsView.swift
+++ b/iOS/App/SettingsView.swift
@@ -28,6 +28,7 @@ struct SettingsView: View {
     @State private var glucoseUnit: GlucoseUnit
     @State private var nightscoutEnabled: Bool
     @State private var healthKitEnabled: Bool
+    @State private var easyViewEnabled: Bool
 
     init() {
         let data = SharedDataManager.shared
@@ -37,6 +38,7 @@ struct SettingsView: View {
         _glucoseUnit = State(initialValue: data.glucoseUnit)
         _nightscoutEnabled = State(initialValue: data.nightscoutEnabled)
         _healthKitEnabled = State(initialValue: data.healthKitEnabled)
+        _easyViewEnabled = State(initialValue: data.easyViewEnabled)
     }
 
     var body: some View {
@@ -148,6 +150,19 @@ struct SettingsView: View {
                     }
 
                     NavigationLink {
+                        EasyViewSettingsView()
+                    } label: {
+                        HStack {
+                            Label(String(localized: "settings.easyView"), systemImage: "waveform.path.ecg")
+                            Spacer()
+                            Text(easyViewEnabled
+                                ? String(localized: "settings.statusOn")
+                                : String(localized: "settings.statusOff"))
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+
+                    NavigationLink {
                         MockDataSettingsView()
                     } label: {
                         HStack {
@@ -180,6 +195,7 @@ struct SettingsView: View {
                 demoEnabled = data.isMockModeEnabled
                 nightscoutEnabled = data.nightscoutEnabled
                 healthKitEnabled = data.healthKitEnabled
+                easyViewEnabled = data.easyViewEnabled
             }
             .navigationTitle(String(localized: "settings.title"))
             .navigationBarTitleDisplayMode(.inline)
@@ -1107,6 +1123,284 @@ struct NightscoutSettingsView: View {
         // Kick HK so users running HK-as-fallback see their data
         // immediately instead of waiting for the next observer fire.
         Task { await HealthKitManager.shared.refreshIfAuthorized() }
+        WatchSessionManager.shared.sendLatestContext()
+        WidgetCenter.shared.reloadAllTimelines()
+    }
+}
+
+// MARK: - EasyView
+
+struct EasyViewSettingsView: View {
+    @State private var enabled: Bool
+    @State private var baseURL: String
+    @State private var username: String
+    @State private var password: String
+    @State private var lastError: String?
+    @State private var latestGlucose: GlucoseReading?
+    @State private var latestCarbs: CarbsReading?
+    @State private var isTesting = false
+    @State private var testResult: TestResult?
+
+    enum TestResult: Equatable {
+        case success(mmol: Double)
+        case failure(String)
+    }
+
+    init() {
+        let data = SharedDataManager.shared
+        _enabled = State(initialValue: data.easyViewEnabled)
+        _baseURL = State(initialValue: data.easyViewBaseURL ?? "")
+        _username = State(initialValue: data.easyViewUsername ?? "")
+        _password = State(initialValue: KeychainManager.shared.easyViewPassword ?? "")
+        _lastError = State(initialValue: data.easyViewLastError)
+        _latestGlucose = State(initialValue: data.glucoseReading(source: .easyView))
+        _latestCarbs = State(initialValue: data.carbsReading(source: .easyView))
+    }
+
+    private var hasCredentials: Bool {
+        !baseURL.trimmingCharacters(in: .whitespaces).isEmpty
+            && !username.trimmingCharacters(in: .whitespaces).isEmpty
+            && !password.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    var body: some View {
+        List {
+            Section {
+                HStack {
+                    Toggle(String(localized: "settings.easyViewEnabled"), isOn: Binding(
+                        get: { enabled && hasCredentials },
+                        set: { newValue in
+                            if newValue {
+                                Task { await enableWithVerification() }
+                            } else {
+                                disable()
+                            }
+                        }
+                    ))
+                    .disabled(!hasCredentials || isTesting)
+                    if isTesting {
+                        ProgressView()
+                    }
+                }
+            } footer: {
+                if !hasCredentials {
+                    Text("settings.easyViewRequiresCredentials", tableName: "Localizable")
+                } else if isTesting {
+                    Text("settings.easyViewVerifying", tableName: "Localizable")
+                } else {
+                    Text("settings.easyViewFooter", tableName: "Localizable")
+                }
+            }
+            .onChange(of: hasCredentials) { _, newValue in
+                if !newValue, enabled {
+                    disable()
+                }
+            }
+
+            Section {
+                TextField(
+                    String(localized: "settings.easyViewURLPlaceholder"),
+                    text: $baseURL
+                )
+                .textContentType(.URL)
+                .keyboardType(.URL)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+
+                TextField(
+                    String(localized: "settings.easyViewUsernamePlaceholder"),
+                    text: $username
+                )
+                .textContentType(.emailAddress)
+                .keyboardType(.emailAddress)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+
+                SecureField(
+                    String(localized: "settings.easyViewPasswordPlaceholder"),
+                    text: $password
+                )
+                .textContentType(.password)
+            } header: {
+                Text("settings.easyViewConfigHeader", tableName: "Localizable")
+            } footer: {
+                Text("settings.easyViewConfigFooter", tableName: "Localizable")
+            }
+
+            Section {
+                Button {
+                    Task { await runConnectionTest() }
+                } label: {
+                    HStack {
+                        Label(String(localized: "settings.easyViewTest"), systemImage: "network")
+                        Spacer()
+                        if isTesting {
+                            ProgressView()
+                        }
+                    }
+                }
+                .disabled(isTesting || !hasCredentials)
+
+                if let testResult {
+                    switch testResult {
+                    case let .success(mmol):
+                        VStack(alignment: .leading, spacing: 2) {
+                            Label(String(localized: "settings.easyViewTestSuccess"), systemImage: "checkmark.circle.fill")
+                                .foregroundStyle(BrandTint.green)
+                            let unit = SharedDataManager.shared.glucoseUnit
+                            Text(String(localized: "settings.easyViewTestGlucose \(unit.formattedWithUnit(mmol))"))
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    case let .failure(message):
+                        Label(message, systemImage: "exclamationmark.triangle.fill")
+                            .foregroundStyle(BrandTint.red)
+                    }
+                }
+            }
+
+            Section {
+                latestSampleRow(
+                    label: String(localized: "settings.easyViewLatestGlucose"),
+                    value: latestGlucose.map { SharedDataManager.shared.glucoseUnit.formattedWithUnit($0.mmol) },
+                    at: latestGlucose?.sampleAt,
+                    emptyMessage: String(localized: "settings.easyViewNoGlucoseYet")
+                )
+                latestSampleRow(
+                    label: String(localized: "settings.easyViewLatestCarbs"),
+                    value: latestCarbs.map { "\(Int($0.grams)) g" },
+                    at: latestCarbs?.sampleAt,
+                    emptyMessage: String(localized: "settings.easyViewNoCarbsYet")
+                )
+            } header: {
+                Text("settings.easyViewLatestHeader", tableName: "Localizable")
+            }
+
+            if let lastError {
+                Section {
+                    Label(lastError, systemImage: "exclamationmark.triangle")
+                        .foregroundStyle(BrandTint.orange)
+                        .font(.caption)
+                } header: {
+                    Text("settings.easyViewStatusHeader", tableName: "Localizable")
+                }
+            }
+        }
+        .navigationTitle(String(localized: "settings.easyView"))
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            while !Task.isCancelled {
+                refreshStatusFields()
+                try? await Task.sleep(nanoseconds: 5_000_000_000)
+            }
+        }
+        .onDisappear {
+            persistFields()
+        }
+    }
+
+    private func refreshStatusFields() {
+        let data = SharedDataManager.shared
+        lastError = data.easyViewLastError
+        latestGlucose = data.glucoseReading(source: .easyView)
+        latestCarbs = data.carbsReading(source: .easyView)
+    }
+
+    @ViewBuilder
+    private func latestSampleRow(label: String, value: String?, at: Date?, emptyMessage: String) -> some View {
+        if let value, let at {
+            HStack(alignment: .firstTextBaseline) {
+                Text(label)
+                Spacer()
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text(value)
+                        .monospacedDigit()
+                    Text(at, style: .relative)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        } else {
+            HStack {
+                Text(label)
+                Spacer()
+                Text(emptyMessage)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func persistFields() {
+        let data = SharedDataManager.shared
+        let trimmedURL = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedUsername = username.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedPassword = password.trimmingCharacters(in: .whitespacesAndNewlines)
+        let urlChanged = data.easyViewBaseURL != (trimmedURL.isEmpty ? nil : trimmedURL)
+        let usernameChanged = data.easyViewUsername != (trimmedUsername.isEmpty ? nil : trimmedUsername)
+        let passwordChanged = KeychainManager.shared.easyViewPassword != (trimmedPassword.isEmpty ? nil : trimmedPassword)
+        data.easyViewBaseURL = trimmedURL.isEmpty ? nil : trimmedURL
+        data.easyViewUsername = trimmedUsername.isEmpty ? nil : trimmedUsername
+        KeychainManager.shared.easyViewPassword = trimmedPassword.isEmpty ? nil : trimmedPassword
+        data.flush()
+        if urlChanged || usernameChanged || passwordChanged {
+            EasyViewManager.shared.configurationDidChange()
+            WatchSessionManager.shared.sendLatestContext()
+        }
+    }
+
+    private func runConnectionTest() async {
+        _ = await verifyConnection()
+    }
+
+    private func verifyConnection() async -> Bool {
+        persistFields()
+        isTesting = true
+        testResult = nil
+        defer { isTesting = false }
+
+        let trimmedURL = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedUsername = username.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedPassword = password.trimmingCharacters(in: .whitespacesAndNewlines)
+        do {
+            let result = try await EasyViewManager.shared.testConnection(
+                baseURL: trimmedURL,
+                username: trimmedUsername,
+                password: trimmedPassword
+            )
+            let mmol = result.glucose?.mmol ?? 0
+            testResult = .success(mmol: mmol)
+            return true
+        } catch {
+            testResult = .failure(error.localizedDescription)
+            return false
+        }
+    }
+
+    private func enableWithVerification() async {
+        guard await verifyConnection() else { return }
+        enabled = true
+        SharedDataManager.shared.easyViewEnabled = true
+        SharedDataManager.shared.flush()
+        EasyViewManager.shared.startPolling()
+        await EasyViewManager.shared.fetchAll()
+        WatchSessionManager.shared.sendLatestContext()
+        refreshStatusFields()
+    }
+
+    private func disable() {
+        enabled = false
+        let data = SharedDataManager.shared
+        data.easyViewEnabled = false
+        data.flush()
+        EasyViewManager.shared.configurationDidChange()
+        data.handleSourceDisabled(.easyView)
+        latestGlucose = nil
+        latestCarbs = nil
+        ShieldManager.shared.disableIfNoDataSource()
+        Task {
+            await HealthKitManager.shared.refreshIfAuthorized()
+            if data.nightscoutEnabled { await NightscoutManager.shared.fetchAll() }
+        }
         WatchSessionManager.shared.sendLatestContext()
         WidgetCenter.shared.reloadAllTimelines()
     }

--- a/iOS/App/SetupChecklistCard.swift
+++ b/iOS/App/SetupChecklistCard.swift
@@ -44,6 +44,7 @@ struct SetupChecklistCard: View {
     /// the user turns HealthKit off again without waiting for samples
     /// to age out.
     @State private var healthKitEnabled: Bool
+    @State private var easyViewEnabled: Bool
     @State private var showHideConfirmation = false
 
     init(refreshToken: Binding<Int>) {
@@ -57,6 +58,7 @@ struct SetupChecklistCard: View {
         _nightscoutEnabled = State(initialValue: data.nightscoutEnabled)
         _isMockModeEnabled = State(initialValue: data.isMockModeEnabled)
         _healthKitEnabled = State(initialValue: data.healthKitEnabled)
+        _easyViewEnabled = State(initialValue: data.easyViewEnabled)
     }
 
     var body: some View {
@@ -132,7 +134,7 @@ struct SetupChecklistCard: View {
     /// changes. Reading the manager directly here would skip re-render
     /// because the body wouldn't observe those flags.
     private var hasAnyDataSource: Bool {
-        nightscoutEnabled || isMockModeEnabled || healthKitEnabled
+        nightscoutEnabled || isMockModeEnabled || healthKitEnabled || easyViewEnabled
     }
 
     /// The shielding row stays visible until shielding is actually enabled —
@@ -169,7 +171,7 @@ struct SetupChecklistCard: View {
                 kind: .dataSources,
                 titleKey: "setup.checklist.dataSources",
                 footerKey: "setup.checklist.dataSourcesFooter",
-                rows: [.healthKit, .nightscout, .demo]
+                rows: [.healthKit, .nightscout, .easyView, .demo]
             )]
         }
 
@@ -305,6 +307,7 @@ struct SetupChecklistCard: View {
         switch row {
         case .healthKit: presentedSheet = .healthKit
         case .nightscout: presentedSheet = .nightscout
+        case .easyView: presentedSheet = .easyView
         case .demo: presentedSheet = .demo
         case .shielding: presentedSheet = .shielding
         case .passphrase: presentedSheet = .passphrase
@@ -327,6 +330,7 @@ struct SetupChecklistCard: View {
         nightscoutEnabled = data.nightscoutEnabled
         isMockModeEnabled = data.isMockModeEnabled
         healthKitEnabled = data.healthKitEnabled
+        easyViewEnabled = data.easyViewEnabled
         Task {
             let settings = await UNUserNotificationCenter.current().notificationSettings()
             await MainActor.run { notificationStatus = settings.authorizationStatus }
@@ -378,6 +382,11 @@ struct SetupChecklistCard: View {
                 NightscoutSettingsView()
                     .toolbar { dismissToolbar }
             }
+        case .easyView:
+            NavigationStack {
+                EasyViewSettingsView()
+                    .toolbar { dismissToolbar }
+            }
         case .demo:
             NavigationStack {
                 MockDataSettingsView()
@@ -408,6 +417,7 @@ struct SetupChecklistCard: View {
 private enum ChecklistRow: String, Hashable {
     case healthKit
     case nightscout
+    case easyView
     case demo
     case shielding
     case passphrase
@@ -417,6 +427,7 @@ private enum ChecklistRow: String, Hashable {
         switch self {
         case .healthKit: return "heart.text.square"
         case .nightscout: return "cloud"
+        case .easyView: return "waveform.path.ecg"
         case .demo: return "flask"
         case .shielding: return "shield.lefthalf.filled"
         case .passphrase: return "lock"
@@ -428,6 +439,7 @@ private enum ChecklistRow: String, Hashable {
         switch self {
         case .healthKit: return "setup.checklist.connectHealthKit"
         case .nightscout: return "setup.checklist.connectNightscout"
+        case .easyView: return "setup.checklist.connectEasyView"
         case .demo: return "setup.checklist.tryDemo"
         case .shielding: return "setup.checklist.enableShielding"
         case .passphrase: return "setup.checklist.setPassphrase"
@@ -439,6 +451,7 @@ private enum ChecklistRow: String, Hashable {
         switch self {
         case .healthKit: return "setup.checklist.connectHealthKit.subtitle"
         case .nightscout: return "setup.checklist.connectNightscout.subtitle"
+        case .easyView: return "setup.checklist.connectEasyView.subtitle"
         case .demo: return "setup.checklist.tryDemo.subtitle"
         case .shielding: return "setup.checklist.enableShielding.subtitle"
         case .passphrase: return "setup.checklist.setPassphrase.subtitle"
@@ -466,6 +479,6 @@ private struct ChecklistGroup: Identifiable {
 }
 
 private enum ChecklistSheet: String, Identifiable {
-    case healthKit, nightscout, demo, shielding, passphrase
+    case healthKit, nightscout, easyView, demo, shielding, passphrase
     var id: String { rawValue }
 }

--- a/iOS/App/SharedDataManager.swift
+++ b/iOS/App/SharedDataManager.swift
@@ -460,7 +460,7 @@ final class SharedDataManager {
             DataSourceKeys.easyViewEnabled,
             "nightscoutBaseURL", "nightscoutToken",
             "nightscoutLastFetchedAt", "nightscoutLastError",
-            "easyViewBaseURL", "easyViewUsername", "easyViewSession",
+            "easyViewUsername", "easyViewSession",
             "easyViewPatientUID", "easyViewLastFetchedAt", "easyViewLastError",
             "setupTipsHidden",
         ]
@@ -541,21 +541,6 @@ final class SharedDataManager {
     var easyViewEnabled: Bool {
         get { defaults?.bool(forKey: DataSourceKeys.easyViewEnabled) ?? false }
         set { defaults?.set(newValue, forKey: DataSourceKeys.easyViewEnabled) }
-    }
-
-    var easyViewBaseURL: String? {
-        get {
-            guard let value = defaults?.string(forKey: "easyViewBaseURL"),
-                  !value.isEmpty else { return nil }
-            return value
-        }
-        set {
-            if let value = newValue, !value.isEmpty {
-                defaults?.set(value, forKey: "easyViewBaseURL")
-            } else {
-                defaults?.removeObject(forKey: "easyViewBaseURL")
-            }
-        }
     }
 
     var easyViewUsername: String? {

--- a/iOS/App/SharedDataManager.swift
+++ b/iOS/App/SharedDataManager.swift
@@ -65,6 +65,10 @@ final class SharedDataManager {
         saveGlucose(source: .nightscout, mmol: mmol, at: date, force: force)
     }
 
+    func saveEasyViewGlucose(mmol: Double, at date: Date, force: Bool = false) {
+        saveGlucose(source: .easyView, mmol: mmol, at: date, force: force)
+    }
+
     func saveDemoGlucose(mmol: Double, at date: Date, force: Bool = true) {
         saveGlucose(source: .demo, mmol: mmol, at: date, force: force)
     }
@@ -75,6 +79,10 @@ final class SharedDataManager {
 
     func saveNightscoutCarbs(grams: Double, at date: Date, force: Bool = false) {
         saveCarbs(source: .nightscout, grams: grams, at: date, force: force)
+    }
+
+    func saveEasyViewCarbs(grams: Double, at date: Date, force: Bool = false) {
+        saveCarbs(source: .easyView, grams: grams, at: date, force: force)
     }
 
     func saveDemoCarbs(grams: Double, at date: Date, force: Bool = true) {
@@ -90,6 +98,7 @@ final class SharedDataManager {
     ///   masquerading as real data.
     func clearHealthKitData() { clearSource(.healthKit) }
     func clearNightscoutData() { clearSource(.nightscout) }
+    func clearEasyViewData() { clearSource(.easyView) }
     func clearDemoData() { clearSource(.demo) }
 
     /// Targeted per-metric clears — used by the Demo Settings panel
@@ -224,7 +233,7 @@ final class SharedDataManager {
     /// per-source toggles in place this is now a simple `OR` of the
     /// three enabled flags — no recency heuristic needed.
     var hasAnyDataSource: Bool {
-        healthKitEnabled || nightscoutEnabled || isMockModeEnabled
+        healthKitEnabled || nightscoutEnabled || easyViewEnabled || isMockModeEnabled
     }
 
     /// Call after a data-source toggle flips off. Clears the disabled
@@ -448,8 +457,11 @@ final class SharedDataManager {
             DataSourceKeys.mockModeEnabled,
             DataSourceKeys.nightscoutEnabled,
             DataSourceKeys.healthKitEnabled,
+            DataSourceKeys.easyViewEnabled,
             "nightscoutBaseURL", "nightscoutToken",
             "nightscoutLastFetchedAt", "nightscoutLastError",
+            "easyViewBaseURL", "easyViewUsername", "easyViewSession",
+            "easyViewPatientUID", "easyViewLastFetchedAt", "easyViewLastError",
             "setupTipsHidden",
         ]
         for key in settingsKeys {
@@ -520,6 +532,96 @@ final class SharedDataManager {
                 defaults?.set(error, forKey: "nightscoutLastError")
             } else {
                 defaults?.removeObject(forKey: "nightscoutLastError")
+            }
+        }
+    }
+
+    // MARK: - EasyView
+
+    var easyViewEnabled: Bool {
+        get { defaults?.bool(forKey: DataSourceKeys.easyViewEnabled) ?? false }
+        set { defaults?.set(newValue, forKey: DataSourceKeys.easyViewEnabled) }
+    }
+
+    var easyViewBaseURL: String? {
+        get {
+            guard let value = defaults?.string(forKey: "easyViewBaseURL"),
+                  !value.isEmpty else { return nil }
+            return value
+        }
+        set {
+            if let value = newValue, !value.isEmpty {
+                defaults?.set(value, forKey: "easyViewBaseURL")
+            } else {
+                defaults?.removeObject(forKey: "easyViewBaseURL")
+            }
+        }
+    }
+
+    var easyViewUsername: String? {
+        get {
+            guard let value = defaults?.string(forKey: "easyViewUsername"),
+                  !value.isEmpty else { return nil }
+            return value
+        }
+        set {
+            if let value = newValue, !value.isEmpty {
+                defaults?.set(value, forKey: "easyViewUsername")
+            } else {
+                defaults?.removeObject(forKey: "easyViewUsername")
+            }
+        }
+    }
+
+    /// Cookie string `"userid=N; session=…"`. Stored in App Group so the
+    /// widget and watch can poll without needing a shared Keychain group.
+    var easyViewSession: String? {
+        get {
+            guard let value = defaults?.string(forKey: "easyViewSession"),
+                  !value.isEmpty else { return nil }
+            return value
+        }
+        set {
+            if let value = newValue, !value.isEmpty {
+                defaults?.set(value, forKey: "easyViewSession")
+            } else {
+                defaults?.removeObject(forKey: "easyViewSession")
+            }
+        }
+    }
+
+    var easyViewPatientUID: Int? {
+        get { defaults?.object(forKey: "easyViewPatientUID") as? Int }
+        set {
+            if let uid = newValue {
+                defaults?.set(uid, forKey: "easyViewPatientUID")
+            } else {
+                defaults?.removeObject(forKey: "easyViewPatientUID")
+            }
+        }
+    }
+
+    var easyViewLastFetchedAt: Date? {
+        get {
+            guard let iso = defaults?.string(forKey: "easyViewLastFetchedAt") else { return nil }
+            return ISO8601DateFormatter().date(from: iso)
+        }
+        set {
+            if let date = newValue {
+                defaults?.set(date.ISO8601Format(), forKey: "easyViewLastFetchedAt")
+            } else {
+                defaults?.removeObject(forKey: "easyViewLastFetchedAt")
+            }
+        }
+    }
+
+    var easyViewLastError: String? {
+        get { defaults?.string(forKey: "easyViewLastError") }
+        set {
+            if let error = newValue {
+                defaults?.set(error, forKey: "easyViewLastError")
+            } else {
+                defaults?.removeObject(forKey: "easyViewLastError")
             }
         }
     }

--- a/iOS/App/WatchSessionManager.swift
+++ b/iOS/App/WatchSessionManager.swift
@@ -82,6 +82,11 @@ final class WatchSessionManager: NSObject, WCSessionDelegate {
         if let url = data.nightscoutBaseURL { context["nightscoutBaseURL"] = url }
         if let token = data.nightscoutToken { context["nightscoutToken"] = token }
 
+        context["easyViewEnabled"] = data.easyViewEnabled
+        if let url = data.easyViewBaseURL { context["easyViewBaseURL"] = url }
+        if let session = data.easyViewSession { context["easyViewSession"] = session }
+        if let uid = data.easyViewPatientUID { context["easyViewPatientUID"] = uid }
+
         if data.isMockModeEnabled {
             if let glucoseReading = data.currentGlucoseReading {
                 context["currentGlucose"] = glucoseReading.mmol

--- a/iOS/App/WatchSessionManager.swift
+++ b/iOS/App/WatchSessionManager.swift
@@ -83,7 +83,6 @@ final class WatchSessionManager: NSObject, WCSessionDelegate {
         if let token = data.nightscoutToken { context["nightscoutToken"] = token }
 
         context["easyViewEnabled"] = data.easyViewEnabled
-        if let url = data.easyViewBaseURL { context["easyViewBaseURL"] = url }
         if let session = data.easyViewSession { context["easyViewSession"] = session }
         if let uid = data.easyViewPatientUID { context["easyViewPatientUID"] = uid }
 

--- a/iOS/App/en.lproj/Localizable.strings
+++ b/iOS/App/en.lproj/Localizable.strings
@@ -167,11 +167,10 @@
 "settings.easyView" = "EasyView";
 "settings.easyViewEnabled" = "Enable EasyView";
 "settings.easyViewFooter" = "Fetch glucose and carb data from the EasyView cloud service. Works for both patients and caregivers monitoring a patient. When multiple sources are enabled, the most recent data wins.";
-"settings.easyViewRequiresCredentials" = "Provide your EasyView URL, username, and password above before enabling.";
+"settings.easyViewRequiresCredentials" = "Provide your EasyView username and password above before enabling.";
 "settings.easyViewVerifying" = "Verifying connection…";
 "settings.easyViewConfigHeader" = "Credentials";
-"settings.easyViewConfigFooter" = "Enter the base URL of your EasyView site (e.g. https://your-easyview-server.com), your account username, and your password.";
-"settings.easyViewURLPlaceholder" = "https://your-easyview-server.com";
+"settings.easyViewConfigFooter" = "Enter your EasyView account username and password.";
 "settings.easyViewUsernamePlaceholder" = "Username or email";
 "settings.easyViewPasswordPlaceholder" = "Password";
 "settings.easyViewTest" = "Test Connection";

--- a/iOS/App/en.lproj/Localizable.strings
+++ b/iOS/App/en.lproj/Localizable.strings
@@ -163,6 +163,31 @@
 "settings.nightscoutNoGlucoseYet" = "No data yet";
 "settings.nightscoutNoCarbsYet" = "No data yet";
 
+/* EasyView */
+"settings.easyView" = "EasyView (Medtrum)";
+"settings.easyViewEnabled" = "Enable EasyView";
+"settings.easyViewFooter" = "Fetch glucose and carb data from the EasyView cloud service (Medtrum). Works for both patients and caregivers monitoring a patient. When multiple sources are enabled, the most recent data wins.";
+"settings.easyViewRequiresCredentials" = "Provide your EasyView URL, username, and password above before enabling.";
+"settings.easyViewVerifying" = "Verifying connection…";
+"settings.easyViewConfigHeader" = "Credentials";
+"settings.easyViewConfigFooter" = "Enter the base URL of your EasyView site (e.g. https://your-easyview-server.com), your account username, and your password.";
+"settings.easyViewURLPlaceholder" = "https://your-easyview-server.com";
+"settings.easyViewUsernamePlaceholder" = "Username or email";
+"settings.easyViewPasswordPlaceholder" = "Password";
+"settings.easyViewTest" = "Test Connection";
+"settings.easyViewTestSuccess" = "Connected";
+"settings.easyViewTestGlucose %@" = "Latest glucose: %@";
+"settings.easyViewStatusHeader" = "Status";
+"settings.easyViewLatestHeader" = "Latest data";
+"settings.easyViewLatestGlucose" = "Glucose";
+"settings.easyViewLatestCarbs" = "Carbs";
+"settings.easyViewNoGlucoseYet" = "No data yet";
+"settings.easyViewNoCarbsYet" = "No data yet";
+
+/* Setup Checklist — EasyView */
+"setup.checklist.connectEasyView" = "Connect EasyView";
+"setup.checklist.connectEasyView.subtitle" = "For Medtrum CGM systems using the EasyView cloud.";
+
 /* Check-In Flow */
 "checkin.disarmButton" = "All Done";
 "checkin.disarmCountdown %lld" = "Wait (%llds)";

--- a/iOS/App/en.lproj/Localizable.strings
+++ b/iOS/App/en.lproj/Localizable.strings
@@ -164,9 +164,9 @@
 "settings.nightscoutNoCarbsYet" = "No data yet";
 
 /* EasyView */
-"settings.easyView" = "EasyView (Medtrum)";
+"settings.easyView" = "EasyView";
 "settings.easyViewEnabled" = "Enable EasyView";
-"settings.easyViewFooter" = "Fetch glucose and carb data from the EasyView cloud service (Medtrum). Works for both patients and caregivers monitoring a patient. When multiple sources are enabled, the most recent data wins.";
+"settings.easyViewFooter" = "Fetch glucose and carb data from the EasyView cloud service. Works for both patients and caregivers monitoring a patient. When multiple sources are enabled, the most recent data wins.";
 "settings.easyViewRequiresCredentials" = "Provide your EasyView URL, username, and password above before enabling.";
 "settings.easyViewVerifying" = "Verifying connection…";
 "settings.easyViewConfigHeader" = "Credentials";
@@ -186,7 +186,7 @@
 
 /* Setup Checklist — EasyView */
 "setup.checklist.connectEasyView" = "Connect EasyView";
-"setup.checklist.connectEasyView.subtitle" = "For Medtrum CGM systems using the EasyView cloud.";
+"setup.checklist.connectEasyView.subtitle" = "For CGM systems using the EasyView cloud.";
 
 /* Check-In Flow */
 "checkin.disarmButton" = "All Done";

--- a/iOS/App/nl.lproj/Localizable.strings
+++ b/iOS/App/nl.lproj/Localizable.strings
@@ -167,11 +167,10 @@
 "settings.easyView" = "EasyView";
 "settings.easyViewEnabled" = "EasyView inschakelen";
 "settings.easyViewFooter" = "Haal glucose- en koolhydraatgegevens op van de EasyView-clouddienst. Werkt voor patiënten én verzorgers die een patiënt volgen. Zijn meerdere bronnen actief, dan wint de nieuwste waarde.";
-"settings.easyViewRequiresCredentials" = "Vul hierboven eerst een EasyView-URL, gebruikersnaam en wachtwoord in voordat je dit kunt inschakelen.";
+"settings.easyViewRequiresCredentials" = "Vul hierboven eerst een gebruikersnaam en wachtwoord in voordat je dit kunt inschakelen.";
 "settings.easyViewVerifying" = "Verbinding controleren…";
 "settings.easyViewConfigHeader" = "Inloggegevens";
-"settings.easyViewConfigFooter" = "Vul de basis-URL van je EasyView-site in (bijv. https://jouw-easyview-server.com), je gebruikersnaam en je wachtwoord.";
-"settings.easyViewURLPlaceholder" = "https://jouw-easyview-server.com";
+"settings.easyViewConfigFooter" = "Vul je EasyView-gebruikersnaam en wachtwoord in.";
 "settings.easyViewUsernamePlaceholder" = "Gebruikersnaam of e-mailadres";
 "settings.easyViewPasswordPlaceholder" = "Wachtwoord";
 "settings.easyViewTest" = "Verbinding testen";

--- a/iOS/App/nl.lproj/Localizable.strings
+++ b/iOS/App/nl.lproj/Localizable.strings
@@ -164,9 +164,9 @@
 "settings.nightscoutNoCarbsYet" = "Nog geen gegevens";
 
 /* EasyView */
-"settings.easyView" = "EasyView (Medtrum)";
+"settings.easyView" = "EasyView";
 "settings.easyViewEnabled" = "EasyView inschakelen";
-"settings.easyViewFooter" = "Haal glucose- en koolhydraatgegevens op van de EasyView-clouddienst (Medtrum). Werkt voor patiënten én verzorgers die een patiënt volgen. Zijn meerdere bronnen actief, dan wint de nieuwste waarde.";
+"settings.easyViewFooter" = "Haal glucose- en koolhydraatgegevens op van de EasyView-clouddienst. Werkt voor patiënten én verzorgers die een patiënt volgen. Zijn meerdere bronnen actief, dan wint de nieuwste waarde.";
 "settings.easyViewRequiresCredentials" = "Vul hierboven eerst een EasyView-URL, gebruikersnaam en wachtwoord in voordat je dit kunt inschakelen.";
 "settings.easyViewVerifying" = "Verbinding controleren…";
 "settings.easyViewConfigHeader" = "Inloggegevens";
@@ -186,7 +186,7 @@
 
 /* Configuratielijst — EasyView */
 "setup.checklist.connectEasyView" = "EasyView koppelen";
-"setup.checklist.connectEasyView.subtitle" = "Voor Medtrum-CGM-systemen die de EasyView-cloud gebruiken.";
+"setup.checklist.connectEasyView.subtitle" = "Voor CGM-systemen die de EasyView-cloud gebruiken.";
 
 /* Inchecken */
 "checkin.disarmButton" = "Klaar";

--- a/iOS/App/nl.lproj/Localizable.strings
+++ b/iOS/App/nl.lproj/Localizable.strings
@@ -163,6 +163,31 @@
 "settings.nightscoutNoGlucoseYet" = "Nog geen gegevens";
 "settings.nightscoutNoCarbsYet" = "Nog geen gegevens";
 
+/* EasyView */
+"settings.easyView" = "EasyView (Medtrum)";
+"settings.easyViewEnabled" = "EasyView inschakelen";
+"settings.easyViewFooter" = "Haal glucose- en koolhydraatgegevens op van de EasyView-clouddienst (Medtrum). Werkt voor patiënten én verzorgers die een patiënt volgen. Zijn meerdere bronnen actief, dan wint de nieuwste waarde.";
+"settings.easyViewRequiresCredentials" = "Vul hierboven eerst een EasyView-URL, gebruikersnaam en wachtwoord in voordat je dit kunt inschakelen.";
+"settings.easyViewVerifying" = "Verbinding controleren…";
+"settings.easyViewConfigHeader" = "Inloggegevens";
+"settings.easyViewConfigFooter" = "Vul de basis-URL van je EasyView-site in (bijv. https://jouw-easyview-server.com), je gebruikersnaam en je wachtwoord.";
+"settings.easyViewURLPlaceholder" = "https://jouw-easyview-server.com";
+"settings.easyViewUsernamePlaceholder" = "Gebruikersnaam of e-mailadres";
+"settings.easyViewPasswordPlaceholder" = "Wachtwoord";
+"settings.easyViewTest" = "Verbinding testen";
+"settings.easyViewTestSuccess" = "Verbonden";
+"settings.easyViewTestGlucose %@" = "Laatste glucose: %@";
+"settings.easyViewStatusHeader" = "Status";
+"settings.easyViewLatestHeader" = "Laatste gegevens";
+"settings.easyViewLatestGlucose" = "Glucose";
+"settings.easyViewLatestCarbs" = "Koolhydraten";
+"settings.easyViewNoGlucoseYet" = "Nog geen gegevens";
+"settings.easyViewNoCarbsYet" = "Nog geen gegevens";
+
+/* Configuratielijst — EasyView */
+"setup.checklist.connectEasyView" = "EasyView koppelen";
+"setup.checklist.connectEasyView.subtitle" = "Voor Medtrum-CGM-systemen die de EasyView-cloud gebruiken.";
+
 /* Inchecken */
 "checkin.disarmButton" = "Klaar";
 "checkin.disarmCountdown %lld" = "Wacht (%llds)";

--- a/iOS/SharedKit/Sources/SharedKit/EasyViewClient.swift
+++ b/iOS/SharedKit/Sources/SharedKit/EasyViewClient.swift
@@ -21,10 +21,14 @@ import Foundation
 ///   pick one. The chosen patient's `uid` becomes `patientUID`.
 public struct EasyViewClient: Sendable {
 
+    // MARK: - Constants
+
+    /// The single known EasyView cloud endpoint.
+    public static let baseURL = URL(string: "https://easyview.medtrum.eu/v3/")!
+
     // MARK: - Error
 
     public enum ClientError: Error, LocalizedError, Sendable {
-        case invalidBaseURL
         case invalidResponse
         case http(status: Int)
         case sessionExpired
@@ -32,7 +36,6 @@ public struct EasyViewClient: Sendable {
 
         public var errorDescription: String? {
             switch self {
-            case .invalidBaseURL: return "Invalid EasyView URL"
             case .invalidResponse: return "Invalid response from EasyView"
             case let .http(status): return "HTTP \(status)"
             case .sessionExpired: return "Session expired (re-login required)"
@@ -77,7 +80,6 @@ public struct EasyViewClient: Sendable {
 
     // MARK: - Instance state
 
-    public let baseURL: URL
     /// Cookie string sent with every authenticated request.
     /// Format: `"userid=<N>; session=<signed-token>"`.
     public let sessionCookie: String
@@ -87,28 +89,13 @@ public struct EasyViewClient: Sendable {
     // MARK: - Init
 
     public init(
-        baseURL: URL,
         sessionCookie: String,
         urlSession: URLSession = .shared,
         requestTimeout: TimeInterval = 15
     ) {
-        self.baseURL = baseURL
         self.sessionCookie = sessionCookie
         self.urlSession = urlSession
         self.requestTimeout = requestTimeout
-    }
-
-    public init?(
-        baseURLString: String,
-        sessionCookie: String,
-        urlSession: URLSession = .shared,
-        requestTimeout: TimeInterval = 15
-    ) {
-        let trimmed = baseURLString.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard var components = URLComponents(string: trimmed) else { return nil }
-        if components.scheme == nil { components.scheme = "https" }
-        guard let url = components.url, url.host?.isEmpty == false else { return nil }
-        self.init(baseURL: url, sessionCookie: sessionCookie, urlSession: urlSession, requestTimeout: requestTimeout)
     }
 
     // MARK: - Login (static — no session needed)
@@ -120,26 +107,16 @@ public struct EasyViewClient: Sendable {
     /// Throws `ClientError.sessionExpired` on 401, other `ClientError` cases on
     /// network or parse failures.
     public static func login(
-        baseURLString: String,
         username: String,
         password: String,
         urlSession: URLSession = .shared,
         requestTimeout: TimeInterval = 15
     ) async throws -> LoginResult {
-        let trimmed = baseURLString.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard var components = URLComponents(string: trimmed) else { throw ClientError.invalidBaseURL }
-        if components.scheme == nil { components.scheme = "https" }
-        guard let baseURL = components.url, baseURL.host?.isEmpty == false else {
-            throw ClientError.invalidBaseURL
-        }
-
-        guard var urlComponents = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
-            throw ClientError.invalidBaseURL
-        }
+        var urlComponents = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)!
         var basePath = urlComponents.path
         if basePath.hasSuffix("/") { basePath.removeLast() }
         urlComponents.path = basePath + "/api/v2.0/login"
-        guard let url = urlComponents.url else { throw ClientError.invalidBaseURL }
+        let url = urlComponents.url!
 
         let body = try JSONSerialization.data(withJSONObject: [
             "user_name": username,
@@ -206,7 +183,7 @@ public struct EasyViewClient: Sendable {
     /// Returns an empty array (rather than throwing) when the endpoint returns
     /// `error: 14` (patient account — callers should use `loginResult.uid`).
     public func fetchConnections() async throws -> [Connection] {
-        let request = try makeRequest(path: "/api/v2.1/monitor/connections", query: [
+        let request = makeRequest(path: "/api/v2.1/monitor/connections", query: [
             URLQueryItem(name: "per_page", value: "9999"),
         ])
         do {
@@ -283,7 +260,7 @@ public struct EasyViewClient: Sendable {
         let start = now - windowHours * 3600
         let param = encodeEventsParam(start: start, end: now)
 
-        let request = try makeRequest(path: "/api/v2.0/events/\(patientUID)", query: [
+        let request = makeRequest(path: "/api/v2.0/events/\(patientUID)", query: [
             URLQueryItem(name: "param", value: param),
             URLQueryItem(name: "per_page", value: "9999"),
             URLQueryItem(name: "page", value: "1"),
@@ -309,17 +286,14 @@ public struct EasyViewClient: Sendable {
 
     // MARK: - Private: request plumbing
 
-    private func makeRequest(path: String, query: [URLQueryItem]) throws -> URLRequest {
-        guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
-            throw ClientError.invalidBaseURL
-        }
+    private func makeRequest(path: String, query: [URLQueryItem]) -> URLRequest {
+        var components = URLComponents(url: Self.baseURL, resolvingAgainstBaseURL: false)!
         var basePath = components.path
         if basePath.hasSuffix("/") { basePath.removeLast() }
         components.path = basePath + path
         components.queryItems = query.isEmpty ? nil : query
 
-        guard let url = components.url else { throw ClientError.invalidBaseURL }
-        var request = URLRequest(url: url)
+        var request = URLRequest(url: components.url!)
         request.httpMethod = "GET"
         request.timeoutInterval = requestTimeout
         request.setValue("application/json, text/plain, */*", forHTTPHeaderField: "Accept")

--- a/iOS/SharedKit/Sources/SharedKit/EasyViewClient.swift
+++ b/iOS/SharedKit/Sources/SharedKit/EasyViewClient.swift
@@ -1,0 +1,339 @@
+import Foundation
+
+/// Shared HTTP client for the EasyView REST API (Medtrum cloud companion).
+///
+/// EasyView uses cookie-based session auth: callers must first call the static
+/// `login` method to obtain a session cookie string, then pass it to the
+/// instance initialiser. Every subsequent request sends the cookie in the
+/// `Cookie` request header.
+///
+/// Platform-specific managers (`EasyViewManager` on iOS,
+/// `WatchEasyViewManager` on watchOS) handle session persistence and lifecycle;
+/// this type only deals with request construction and JSON parsing so the
+/// logic stays identical across platforms.
+///
+/// ## Account modes
+///
+/// - **Patient** (`user_type == "P"`): the logged-in user IS the patient.
+///   `patientUID` equals the `uid` returned from `login`.
+/// - **Monitor** (`user_type == "M"`): the logged-in user is a caregiver.
+///   Call `fetchConnections()` to list monitored patients and let the user
+///   pick one. The chosen patient's `uid` becomes `patientUID`.
+public struct EasyViewClient: Sendable {
+
+    // MARK: - Error
+
+    public enum ClientError: Error, LocalizedError, Sendable {
+        case invalidBaseURL
+        case invalidResponse
+        case http(status: Int)
+        case sessionExpired
+        case decoding(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidBaseURL: return "Invalid EasyView URL"
+            case .invalidResponse: return "Invalid response from EasyView"
+            case let .http(status): return "HTTP \(status)"
+            case .sessionExpired: return "Session expired (re-login required)"
+            case let .decoding(message): return "Parse error: \(message)"
+            }
+        }
+    }
+
+    // MARK: - Output types (shared with NightscoutClient consumers)
+
+    public struct GlucoseSample: Sendable {
+        /// Blood glucose value in mmol/L.
+        public let mmol: Double
+        /// Timestamp the sample was recorded.
+        public let date: Date
+    }
+
+    public struct CarbEntry: Sendable {
+        public let grams: Double
+        public let date: Date
+    }
+
+    /// A patient connection returned by `fetchConnections()`.
+    public struct Connection: Sendable {
+        public let uid: Int
+        public let realName: String
+    }
+
+    /// Result of a successful `login` call.
+    public struct LoginResult: Sendable {
+        /// Cookie string to pass to the `EasyViewClient` initialiser.
+        /// Format: `"userid=<N>; session=<signed-token>"`.
+        public let sessionCookie: String
+        /// The uid of the logged-in account.
+        public let uid: Int
+        /// `"P"` for patient, `"M"` for monitor/caregiver.
+        public let userType: String
+
+        /// Whether this account is a patient (owns their own data).
+        public var isPatient: Bool { userType == "P" }
+    }
+
+    // MARK: - Instance state
+
+    public let baseURL: URL
+    /// Cookie string sent with every authenticated request.
+    /// Format: `"userid=<N>; session=<signed-token>"`.
+    public let sessionCookie: String
+    private let urlSession: URLSession
+    private let requestTimeout: TimeInterval
+
+    // MARK: - Init
+
+    public init(
+        baseURL: URL,
+        sessionCookie: String,
+        urlSession: URLSession = .shared,
+        requestTimeout: TimeInterval = 15
+    ) {
+        self.baseURL = baseURL
+        self.sessionCookie = sessionCookie
+        self.urlSession = urlSession
+        self.requestTimeout = requestTimeout
+    }
+
+    public init?(
+        baseURLString: String,
+        sessionCookie: String,
+        urlSession: URLSession = .shared,
+        requestTimeout: TimeInterval = 15
+    ) {
+        let trimmed = baseURLString.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard var components = URLComponents(string: trimmed) else { return nil }
+        if components.scheme == nil { components.scheme = "https" }
+        guard let url = components.url, url.host?.isEmpty == false else { return nil }
+        self.init(baseURL: url, sessionCookie: sessionCookie, urlSession: urlSession, requestTimeout: requestTimeout)
+    }
+
+    // MARK: - Login (static — no session needed)
+
+    /// Authenticate with username + password. Returns a `LoginResult` whose
+    /// `sessionCookie` should be stored (App Group UserDefaults) and passed to
+    /// subsequent `EasyViewClient` instances.
+    ///
+    /// Throws `ClientError.sessionExpired` on 401, other `ClientError` cases on
+    /// network or parse failures.
+    public static func login(
+        baseURLString: String,
+        username: String,
+        password: String,
+        urlSession: URLSession = .shared,
+        requestTimeout: TimeInterval = 15
+    ) async throws -> LoginResult {
+        let trimmed = baseURLString.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard var components = URLComponents(string: trimmed) else { throw ClientError.invalidBaseURL }
+        if components.scheme == nil { components.scheme = "https" }
+        guard let baseURL = components.url, baseURL.host?.isEmpty == false else {
+            throw ClientError.invalidBaseURL
+        }
+
+        guard var urlComponents = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
+            throw ClientError.invalidBaseURL
+        }
+        var basePath = urlComponents.path
+        if basePath.hasSuffix("/") { basePath.removeLast() }
+        urlComponents.path = basePath + "/api/v2.0/login"
+        guard let url = urlComponents.url else { throw ClientError.invalidBaseURL }
+
+        let body = try JSONSerialization.data(withJSONObject: [
+            "user_name": username,
+            "user_type": "P",
+            "password": password,
+        ])
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = requestTimeout
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json, text/plain, */*", forHTTPHeaderField: "Accept")
+        request.httpBody = body
+
+        let (data, response) = try await urlSession.data(for: request)
+        guard let http = response as? HTTPURLResponse else { throw ClientError.invalidResponse }
+
+        switch http.statusCode {
+        case 200...299: break
+        case 401, 403: throw ClientError.sessionExpired
+        default: throw ClientError.http(status: http.statusCode)
+        }
+
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw ClientError.decoding("login response not an object")
+        }
+        guard let uid = json["uid"] as? Int else {
+            throw ClientError.decoding("missing uid in login response")
+        }
+        let userType = json["user_type"] as? String ?? "P"
+
+        // Extract cookies from Set-Cookie headers. The session cookie
+        // is a signed Flask token; the userid is the numeric account id.
+        var cookieParts: [String] = []
+        let headerFields = http.allHeaderFields as? [String: String] ?? [:]
+        // `HTTPURLResponse.allHeaderFields` combines all headers into a dict
+        // (losing duplicate Set-Cookie entries on case-insensitive keys).
+        // We parse the response cookies via HTTPCookieStorage patterns:
+        let cookies = HTTPCookie.cookies(
+            withResponseHeaderFields: headerFields,
+            for: url
+        )
+        for cookie in cookies where cookie.name == "session" || cookie.name == "userid" {
+            cookieParts.append("\(cookie.name)=\(cookie.value)")
+        }
+
+        // Ensure userid is present even if it arrived in the body rather
+        // than a Set-Cookie header (observed: some EasyView deployments
+        // surface only a `session` cookie; userid comes from the JSON body).
+        if !cookieParts.contains(where: { $0.hasPrefix("userid=") }) {
+            cookieParts.insert("userid=\(uid)", at: 0)
+        }
+
+        if cookieParts.isEmpty {
+            throw ClientError.decoding("no session cookie in login response")
+        }
+        let sessionCookie = cookieParts.joined(separator: "; ")
+        return LoginResult(sessionCookie: sessionCookie, uid: uid, userType: userType)
+    }
+
+    // MARK: - Connections (monitor accounts only)
+
+    /// Fetch the list of patients this monitor account can observe.
+    /// Returns an empty array (rather than throwing) when the endpoint returns
+    /// `error: 14` (patient account — callers should use `loginResult.uid`).
+    public func fetchConnections() async throws -> [Connection] {
+        let request = try makeRequest(path: "/api/v2.1/monitor/connections", query: [
+            URLQueryItem(name: "per_page", value: "9999"),
+        ])
+        do {
+            let data = try await perform(request)
+            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let dataObj = json["data"] as? [String: Any],
+                  let items = dataObj["items"] as? [[String: Any]]
+            else {
+                return []
+            }
+            return items.compactMap { item in
+                guard let uid = item["uid"] as? Int else { return nil }
+                let name = item["real_name"] as? String ?? ""
+                return Connection(uid: uid, realName: name)
+            }
+        } catch ClientError.http(let status) where status == 403 {
+            // Patient accounts get 403 on this endpoint — not an error.
+            return []
+        }
+    }
+
+    // MARK: - Glucose
+
+    /// Fetch the most recent BG event from the last `windowHours` hours.
+    /// Returns nil when there are no events in the window.
+    public func fetchLatestGlucose(patientUID: Int, windowHours: Double = 3) async throws -> GlucoseSample? {
+        let items = try await fetchEvents(patientUID: patientUID, windowHours: windowHours)
+        let bgEvents = items.filter { event in
+            guard event.count > 2 else { return false }
+            return (event[2] as? String) == "BG"
+        }
+        .sorted { a, b in
+            (a[1] as? Double ?? 0) > (b[1] as? Double ?? 0)
+        }
+
+        guard let latest = bgEvents.first,
+              let ts = latest[1] as? Double,
+              let dataDict = latest[3] as? [String: Any],
+              let mgdl = dataDict["value"] as? Double
+        else { return nil }
+
+        return GlucoseSample(mmol: mgdl / 18.018, date: Date(timeIntervalSince1970: ts))
+    }
+
+    // MARK: - Carbs
+
+    /// Fetch the most recent CARB event from the last `windowHours` hours.
+    /// Returns nil when there are no carb events in the window.
+    public func fetchLatestCarbs(patientUID: Int, windowHours: Double = 4) async throws -> CarbEntry? {
+        let items = try await fetchEvents(patientUID: patientUID, windowHours: windowHours)
+        let carbEvents = items.filter { event in
+            guard event.count > 2 else { return false }
+            return (event[2] as? String) == "CARB"
+        }
+        .sorted { a, b in
+            (a[1] as? Double ?? 0) > (b[1] as? Double ?? 0)
+        }
+
+        guard let latest = carbEvents.first,
+              let ts = latest[1] as? Double,
+              let dataDict = latest[3] as? [String: Any],
+              let grams = dataDict["value"] as? Double
+        else { return nil }
+
+        return CarbEntry(grams: grams, date: Date(timeIntervalSince1970: ts))
+    }
+
+    // MARK: - Private: events
+
+    /// Fetch raw events for `patientUID` over the last `windowHours` hours.
+    /// Each event is an array: `[id, timestamp, type, data, source, record_id]`.
+    private func fetchEvents(patientUID: Int, windowHours: Double) async throws -> [[Any]] {
+        let now = Date().timeIntervalSince1970
+        let start = now - windowHours * 3600
+        let param = encodeEventsParam(start: start, end: now)
+
+        let request = try makeRequest(path: "/api/v2.0/events/\(patientUID)", query: [
+            URLQueryItem(name: "param", value: param),
+            URLQueryItem(name: "per_page", value: "9999"),
+            URLQueryItem(name: "page", value: "1"),
+        ])
+        let data = try await perform(request)
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let dataObj = json["data"] as? [String: Any],
+              let items = dataObj["items"] as? [[Any]]
+        else { return [] }
+        return items
+    }
+
+    /// Encode the base64 JSON `param` expected by the events endpoint.
+    private func encodeEventsParam(start: Double, end: Double) -> String {
+        let obj: [String: Any] = [
+            "order": [["time", "desc"]],
+            "st": Int(start),
+            "et": Int(end),
+        ]
+        let jsonData = (try? JSONSerialization.data(withJSONObject: obj, options: [.sortedKeys])) ?? Data()
+        return jsonData.base64EncodedString()
+    }
+
+    // MARK: - Private: request plumbing
+
+    private func makeRequest(path: String, query: [URLQueryItem]) throws -> URLRequest {
+        guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
+            throw ClientError.invalidBaseURL
+        }
+        var basePath = components.path
+        if basePath.hasSuffix("/") { basePath.removeLast() }
+        components.path = basePath + path
+        components.queryItems = query.isEmpty ? nil : query
+
+        guard let url = components.url else { throw ClientError.invalidBaseURL }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = requestTimeout
+        request.setValue("application/json, text/plain, */*", forHTTPHeaderField: "Accept")
+        request.setValue(sessionCookie, forHTTPHeaderField: "Cookie")
+        return request
+    }
+
+    private func perform(_ request: URLRequest) async throws -> Data {
+        let (data, response) = try await urlSession.data(for: request)
+        guard let http = response as? HTTPURLResponse else { throw ClientError.invalidResponse }
+        switch http.statusCode {
+        case 200...299: return data
+        case 401, 403: throw ClientError.sessionExpired
+        default: throw ClientError.http(status: http.statusCode)
+        }
+    }
+}

--- a/iOS/SharedKit/Sources/SharedKit/EasyViewClient.swift
+++ b/iOS/SharedKit/Sources/SharedKit/EasyViewClient.swift
@@ -24,7 +24,7 @@ public struct EasyViewClient: Sendable {
     // MARK: - Constants
 
     /// The single known EasyView cloud endpoint.
-    public static let baseURL = URL(string: "https://easyview.medtrum.eu/v3/")!
+    public static let baseURL = URL(string: "https://easyview.medtrum.eu/")!
 
     // MARK: - Error
 

--- a/iOS/SharedKit/Sources/SharedKit/EasyViewClient.swift
+++ b/iOS/SharedKit/Sources/SharedKit/EasyViewClient.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Shared HTTP client for the EasyView REST API (Medtrum cloud companion).
+/// Shared HTTP client for the EasyView REST API.
 ///
 /// EasyView uses cookie-based session auth: callers must first call the static
 /// `login` method to obtain a session cookie string, then pass it to the

--- a/iOS/SharedKit/Sources/SharedKit/UnifiedDataReader.swift
+++ b/iOS/SharedKit/Sources/SharedKit/UnifiedDataReader.swift
@@ -10,6 +10,7 @@ import Foundation
 public enum DataSource: String, Sendable, CaseIterable {
     case healthKit
     case nightscout
+    case easyView
     case demo
 }
 
@@ -34,8 +35,14 @@ public enum DataSourceKeys {
     public static let demoCarbs = "demoCarbs"
     public static let demoCarbsSampleAt = "demoCarbsSampleAt"
 
+    public static let easyViewGlucose = "easyViewGlucose"
+    public static let easyViewGlucoseSampleAt = "easyViewGlucoseSampleAt"
+    public static let easyViewCarbs = "easyViewCarbs"
+    public static let easyViewCarbsSampleAt = "easyViewCarbsSampleAt"
+
     public static let healthKitEnabled = "healthKitEnabled"
     public static let nightscoutEnabled = "nightscoutEnabled"
+    public static let easyViewEnabled = "easyViewEnabled"
     public static let mockModeEnabled = "mockModeEnabled"
 }
 
@@ -106,6 +113,10 @@ public enum UnifiedDataReader {
            let reading = glucoseReading(source: .nightscout, from: defaults) {
             candidates.append(reading)
         }
+        if defaults.bool(forKey: DataSourceKeys.easyViewEnabled),
+           let reading = glucoseReading(source: .easyView, from: defaults) {
+            candidates.append(reading)
+        }
         return candidates.max(by: { $0.sampleAt < $1.sampleAt })
     }
 
@@ -125,6 +136,10 @@ public enum UnifiedDataReader {
         }
         if defaults.bool(forKey: DataSourceKeys.nightscoutEnabled),
            let reading = carbsReading(source: .nightscout, from: defaults) {
+            candidates.append(reading)
+        }
+        if defaults.bool(forKey: DataSourceKeys.easyViewEnabled),
+           let reading = carbsReading(source: .easyView, from: defaults) {
             candidates.append(reading)
         }
         return candidates.max(by: { $0.sampleAt < $1.sampleAt })
@@ -151,6 +166,7 @@ public enum UnifiedDataReader {
         switch source {
         case .healthKit: return DataSourceKeys.healthKitGlucose
         case .nightscout: return DataSourceKeys.nightscoutGlucose
+        case .easyView: return DataSourceKeys.easyViewGlucose
         case .demo: return DataSourceKeys.demoGlucose
         }
     }
@@ -159,6 +175,7 @@ public enum UnifiedDataReader {
         switch source {
         case .healthKit: return DataSourceKeys.healthKitGlucoseSampleAt
         case .nightscout: return DataSourceKeys.nightscoutGlucoseSampleAt
+        case .easyView: return DataSourceKeys.easyViewGlucoseSampleAt
         case .demo: return DataSourceKeys.demoGlucoseSampleAt
         }
     }
@@ -167,6 +184,7 @@ public enum UnifiedDataReader {
         switch source {
         case .healthKit: return DataSourceKeys.healthKitCarbs
         case .nightscout: return DataSourceKeys.nightscoutCarbs
+        case .easyView: return DataSourceKeys.easyViewCarbs
         case .demo: return DataSourceKeys.demoCarbs
         }
     }
@@ -175,6 +193,7 @@ public enum UnifiedDataReader {
         switch source {
         case .healthKit: return DataSourceKeys.healthKitCarbsSampleAt
         case .nightscout: return DataSourceKeys.nightscoutCarbsSampleAt
+        case .easyView: return DataSourceKeys.easyViewCarbsSampleAt
         case .demo: return DataSourceKeys.demoCarbsSampleAt
         }
     }

--- a/iOS/SharedKit/Sources/SharedKit/WidgetEasyViewRefresh.swift
+++ b/iOS/SharedKit/Sources/SharedKit/WidgetEasyViewRefresh.swift
@@ -1,0 +1,122 @@
+import Foundation
+import os
+
+/// Fetches the latest EasyView glucose + carbs from inside a WidgetKit
+/// timeline call and writes the result into the App Group `UserDefaults` that
+/// the widgets already read from.
+///
+/// Mirrors `WidgetNightscoutRefresh` for EasyView. Key difference: if the
+/// session cookie has expired, this type does **not** attempt re-login because
+/// the widget extension has no access to the Keychain password. Instead it
+/// logs the error and serves stale cached values. The main app re-authenticates
+/// on its next foreground activation, at which point the new session propagates
+/// to the App Group.
+///
+/// Widget extensions DO have network access (unlike Shield / Action /
+/// DeviceActivityMonitor — see QUIRKS.md), so fetching here is safe.
+public enum WidgetEasyViewRefresh {
+    public static let throttleInterval: TimeInterval = 60
+    public static let requestTimeout: TimeInterval = 5
+
+    private static let logger = Logger(subsystem: "SharedKit", category: "WidgetEasyViewRefresh")
+
+    /// If EasyView is enabled and the throttle window has elapsed, fetch
+    /// the latest glucose + carbs and persist them to the App Group with
+    /// "save if newer" semantics. Always returns; never throws.
+    ///
+    /// - Parameter defaults: the App Group `UserDefaults` the widget reads from.
+    public static func refreshIfDue(defaults: UserDefaults?) async {
+        guard let defaults else { return }
+        guard defaults.bool(forKey: DataSourceKeys.easyViewEnabled) else { return }
+        guard !defaults.bool(forKey: DataSourceKeys.mockModeEnabled) else { return }
+
+        guard let urlString = defaults.string(forKey: "easyViewBaseURL"),
+              !urlString.isEmpty,
+              let sessionCookie = defaults.string(forKey: "easyViewSession"),
+              !sessionCookie.isEmpty,
+              let patientUID = defaults.object(forKey: "easyViewPatientUID") as? Int
+        else { return }
+
+        if let lastIso = defaults.string(forKey: "easyViewLastFetchedAt"),
+           let last = ISO8601DateFormatter().date(from: lastIso),
+           Date().timeIntervalSince(last) < throttleInterval {
+            return
+        }
+
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = requestTimeout
+        config.timeoutIntervalForResource = requestTimeout
+        config.waitsForConnectivity = false
+        let session = URLSession(configuration: config)
+
+        guard let client = EasyViewClient(
+            baseURLString: urlString,
+            sessionCookie: sessionCookie,
+            urlSession: session,
+            requestTimeout: requestTimeout
+        ) else { return }
+
+        async let glucoseTask: EasyViewClient.GlucoseSample? = {
+            do {
+                return try await client.fetchLatestGlucose(patientUID: patientUID)
+            } catch EasyViewClient.ClientError.sessionExpired {
+                logger.warning("Widget EasyView session expired — serving stale cached values")
+                return nil
+            } catch {
+                logger.error("Widget EasyView glucose fetch failed: \(error.localizedDescription, privacy: .public)")
+                return nil
+            }
+        }()
+
+        async let carbsTask: EasyViewClient.CarbEntry? = {
+            do {
+                return try await client.fetchLatestCarbs(patientUID: patientUID)
+            } catch EasyViewClient.ClientError.sessionExpired {
+                return nil
+            } catch {
+                logger.error("Widget EasyView carbs fetch failed: \(error.localizedDescription, privacy: .public)")
+                return nil
+            }
+        }()
+
+        let glucose = await glucoseTask
+        let carbs = await carbsTask
+
+        if let glucose {
+            saveIfNewer(
+                defaults: defaults,
+                valueKey: UnifiedDataReader.glucoseValueKey(for: .easyView),
+                dateKey: UnifiedDataReader.glucoseDateKey(for: .easyView),
+                value: glucose.mmol,
+                date: glucose.date
+            )
+        }
+        if let carbs {
+            saveIfNewer(
+                defaults: defaults,
+                valueKey: UnifiedDataReader.carbsValueKey(for: .easyView),
+                dateKey: UnifiedDataReader.carbsDateKey(for: .easyView),
+                value: carbs.grams,
+                date: carbs.date
+            )
+        }
+
+        defaults.set(Date().ISO8601Format(), forKey: "easyViewLastFetchedAt")
+    }
+
+    private static func saveIfNewer(
+        defaults: UserDefaults,
+        valueKey: String,
+        dateKey: String,
+        value: Double,
+        date: Date
+    ) {
+        if let existingIso = defaults.string(forKey: dateKey),
+           let existing = ISO8601DateFormatter().date(from: existingIso),
+           date <= existing {
+            return
+        }
+        defaults.set(value, forKey: valueKey)
+        defaults.set(date.ISO8601Format(), forKey: dateKey)
+    }
+}

--- a/iOS/SharedKit/Sources/SharedKit/WidgetEasyViewRefresh.swift
+++ b/iOS/SharedKit/Sources/SharedKit/WidgetEasyViewRefresh.swift
@@ -30,9 +30,7 @@ public enum WidgetEasyViewRefresh {
         guard defaults.bool(forKey: DataSourceKeys.easyViewEnabled) else { return }
         guard !defaults.bool(forKey: DataSourceKeys.mockModeEnabled) else { return }
 
-        guard let urlString = defaults.string(forKey: "easyViewBaseURL"),
-              !urlString.isEmpty,
-              let sessionCookie = defaults.string(forKey: "easyViewSession"),
+        guard let sessionCookie = defaults.string(forKey: "easyViewSession"),
               !sessionCookie.isEmpty,
               let patientUID = defaults.object(forKey: "easyViewPatientUID") as? Int
         else { return }
@@ -49,12 +47,11 @@ public enum WidgetEasyViewRefresh {
         config.waitsForConnectivity = false
         let session = URLSession(configuration: config)
 
-        guard let client = EasyViewClient(
-            baseURLString: urlString,
+        let client = EasyViewClient(
             sessionCookie: sessionCookie,
             urlSession: session,
             requestTimeout: requestTimeout
-        ) else { return }
+        )
 
         async let glucoseTask: EasyViewClient.GlucoseSample? = {
             do {

--- a/iOS/StatusWidget/StatusWidget.swift
+++ b/iOS/StatusWidget/StatusWidget.swift
@@ -112,6 +112,7 @@ struct StatusTimelineProvider: TimelineProvider {
     func getSnapshot(in _: Context, completion: @escaping (StatusEntry) -> Void) {
         Task {
             await WidgetNightscoutRefresh.refreshIfDue(defaults: EntryBuilder.appGroupDefaults)
+            await WidgetEasyViewRefresh.refreshIfDue(defaults: EntryBuilder.appGroupDefaults)
             completion(EntryBuilder.makeEntry(now: Date(), metric: .glucose))
         }
     }
@@ -119,6 +120,7 @@ struct StatusTimelineProvider: TimelineProvider {
     func getTimeline(in _: Context, completion: @escaping (Timeline<StatusEntry>) -> Void) {
         Task {
             await WidgetNightscoutRefresh.refreshIfDue(defaults: EntryBuilder.appGroupDefaults)
+            await WidgetEasyViewRefresh.refreshIfDue(defaults: EntryBuilder.appGroupDefaults)
             let now = Date()
             let entries = TimelinePolicy.entries(from: now) { date in
                 EntryBuilder.makeEntry(now: date, metric: .glucose)
@@ -143,6 +145,7 @@ struct StatusMetricTimelineProvider: TimelineProvider {
     func getSnapshot(in _: Context, completion: @escaping (StatusEntry) -> Void) {
         Task {
             await WidgetNightscoutRefresh.refreshIfDue(defaults: EntryBuilder.appGroupDefaults)
+            await WidgetEasyViewRefresh.refreshIfDue(defaults: EntryBuilder.appGroupDefaults)
             completion(EntryBuilder.makeEntry(now: Date(), metric: metric))
         }
     }
@@ -150,6 +153,7 @@ struct StatusMetricTimelineProvider: TimelineProvider {
     func getTimeline(in _: Context, completion: @escaping (Timeline<StatusEntry>) -> Void) {
         Task {
             await WidgetNightscoutRefresh.refreshIfDue(defaults: EntryBuilder.appGroupDefaults)
+            await WidgetEasyViewRefresh.refreshIfDue(defaults: EntryBuilder.appGroupDefaults)
             let now = Date()
             let entries = TimelinePolicy.entries(from: now) { date in
                 EntryBuilder.makeEntry(now: date, metric: metric)

--- a/iOS/WatchApp/WatchApp.swift
+++ b/iOS/WatchApp/WatchApp.swift
@@ -48,6 +48,10 @@ struct CompanionWatchApp: App {
                     WatchNightscoutManager.shared.startPolling()
                     await WatchNightscoutManager.shared.fetchAll()
                     WatchNightscoutManager.shared.scheduleBackgroundRefresh()
+
+                    WatchEasyViewManager.shared.startPolling()
+                    await WatchEasyViewManager.shared.fetchAll()
+                    WatchEasyViewManager.shared.scheduleBackgroundRefresh()
                 }
                 .onChange(of: scenePhase) {
                     #if targetEnvironment(simulator)
@@ -58,9 +62,11 @@ struct CompanionWatchApp: App {
                             await WatchHealthKitManager.shared.fetchLatestGlucose()
                             await WatchHealthKitManager.shared.fetchLatestCarbs()
                             await WatchNightscoutManager.shared.fetchAll()
+                            await WatchEasyViewManager.shared.fetchAll()
                         }
                     } else if scenePhase == .background {
                         WatchNightscoutManager.shared.scheduleBackgroundRefresh()
+                        WatchEasyViewManager.shared.scheduleBackgroundRefresh()
                     }
                 }
         }
@@ -68,6 +74,13 @@ struct CompanionWatchApp: App {
             await WatchNightscoutManager.shared.fetchAll()
             await MainActor.run {
                 WatchNightscoutManager.shared.scheduleBackgroundRefresh()
+                WidgetCenter.shared.reloadAllTimelines()
+            }
+        }
+        .backgroundTask(.appRefresh("easyview")) {
+            await WatchEasyViewManager.shared.fetchAll()
+            await MainActor.run {
+                WatchEasyViewManager.shared.scheduleBackgroundRefresh()
                 WidgetCenter.shared.reloadAllTimelines()
             }
         }

--- a/iOS/WatchApp/WatchConnectivityReceiver.swift
+++ b/iOS/WatchApp/WatchConnectivityReceiver.swift
@@ -48,6 +48,7 @@ final class WatchConnectivityReceiver: NSObject, WCSessionDelegate {
                 await WatchHealthKitManager.shared.fetchLatestCarbs()
                 await MainActor.run {
                     WatchNightscoutManager.shared.configurationDidChange()
+                    WatchEasyViewManager.shared.configurationDidChange()
                 }
             }
         }

--- a/iOS/WatchApp/WatchEasyViewManager.swift
+++ b/iOS/WatchApp/WatchEasyViewManager.swift
@@ -1,0 +1,125 @@
+import Foundation
+import os
+import SharedKit
+import WidgetKit
+#if canImport(WatchKit)
+import WatchKit
+#endif
+
+/// Watch-side EasyView poller. Mirrors `WatchNightscoutManager`: keeps the
+/// watch App Group glucose/carb keys up to date so complications stay fresh
+/// even when the paired phone is unreachable.
+///
+/// Config (base URL, session cookie, patient UID) is synced from the phone via
+/// `WatchConnectivity` and stored in the watch-local App Group by
+/// `WatchDataManager.updateFromPhoneContext`. The session cookie lives in the
+/// App Group (not Keychain) specifically so both the widget and the watch can
+/// access it without a shared Keychain access group.
+///
+/// On session expiry the watch cannot re-login (no Keychain password).
+/// It logs the error and serves stale cached values; the next phone
+/// foreground pass will refresh the session and push it via WatchConnectivity.
+@MainActor
+final class WatchEasyViewManager {
+    static let shared = WatchEasyViewManager()
+
+    static let pollInterval: TimeInterval = 5 * 60
+
+    private let logger = Logger(subsystem: Constants.bundlePrefix, category: "WatchEasyViewManager")
+    private var pollTimer: Timer?
+    private var inFlight = false
+
+    private init() {}
+
+    private func currentClient() -> EasyViewClient? {
+        guard WatchDataManager.easyViewEnabled,
+              let urlString = WatchDataManager.easyViewBaseURL,
+              let session = WatchDataManager.easyViewSession,
+              let client = EasyViewClient(baseURLString: urlString, sessionCookie: session)
+        else { return nil }
+        return client
+    }
+
+    var isConfigured: Bool { currentClient() != nil }
+
+    func startPolling() {
+        stopPolling()
+        guard isConfigured else { return }
+        let timer = Timer(timeInterval: Self.pollInterval, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                await self?.fetchAll()
+            }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        pollTimer = timer
+        logger.info("Watch EasyView polling started")
+    }
+
+    func stopPolling() {
+        pollTimer?.invalidate()
+        pollTimer = nil
+    }
+
+    func configurationDidChange() {
+        if isConfigured {
+            startPolling()
+            Task { await fetchAll() }
+        } else {
+            stopPolling()
+        }
+    }
+
+    func fetchAll() async {
+        guard let client = currentClient() else { return }
+        guard !WatchDataManager.isMockModeEnabled else {
+            logger.info("Watch mock mode active — skipping EasyView fetch")
+            return
+        }
+        guard !inFlight else { return }
+        inFlight = true
+        defer { inFlight = false }
+
+        guard let patientUID = WatchDataManager.easyViewPatientUID else {
+            logger.warning("Watch EasyView patientUID not set — skipping fetch")
+            return
+        }
+
+        do {
+            if let sample = try await client.fetchLatestGlucose(patientUID: patientUID) {
+                WatchDataManager.storeGlucose(mmol: sample.mmol, at: sample.date)
+                logger.info("Watch EasyView glucose: \(String(format: "%.1f", sample.mmol)) mmol/L")
+            }
+        } catch EasyViewClient.ClientError.sessionExpired {
+            logger.warning("Watch EasyView session expired — phone will refresh on next foreground")
+        } catch {
+            logger.error("Watch EasyView glucose fetch failed: \(error.localizedDescription)")
+        }
+
+        do {
+            if let entry = try await client.fetchLatestCarbs(patientUID: patientUID) {
+                WatchDataManager.storeCarbs(grams: entry.grams, at: entry.date)
+                logger.info("Watch EasyView carbs: \(String(format: "%.0f", entry.grams))g")
+            }
+        } catch EasyViewClient.ClientError.sessionExpired {
+            // Already logged above.
+        } catch {
+            logger.error("Watch EasyView carbs fetch failed: \(error.localizedDescription)")
+        }
+
+        WidgetCenter.shared.reloadAllTimelines()
+    }
+
+    func scheduleBackgroundRefresh() {
+        guard isConfigured else { return }
+        #if canImport(WatchKit) && !os(iOS)
+        WKExtension.shared().scheduleBackgroundRefresh(
+            withPreferredDate: Date(timeIntervalSinceNow: Self.pollInterval),
+            userInfo: nil
+        ) { [weak self] error in
+            if let error {
+                self?.logger.error("Watch EasyView background schedule failed: \(error.localizedDescription)")
+            }
+        }
+        #endif
+    }
+}

--- a/iOS/WatchApp/WatchEasyViewManager.swift
+++ b/iOS/WatchApp/WatchEasyViewManager.swift
@@ -33,11 +33,9 @@ final class WatchEasyViewManager {
 
     private func currentClient() -> EasyViewClient? {
         guard WatchDataManager.easyViewEnabled,
-              let urlString = WatchDataManager.easyViewBaseURL,
-              let session = WatchDataManager.easyViewSession,
-              let client = EasyViewClient(baseURLString: urlString, sessionCookie: session)
+              let session = WatchDataManager.easyViewSession
         else { return nil }
-        return client
+        return EasyViewClient(sessionCookie: session)
     }
 
     var isConfigured: Bool { currentClient() != nil }

--- a/iOS/WatchShared/WatchDataManager.swift
+++ b/iOS/WatchShared/WatchDataManager.swift
@@ -129,12 +129,6 @@ enum WatchDataManager {
         defaults?.bool(forKey: "easyViewEnabled") ?? false
     }
 
-    static var easyViewBaseURL: String? {
-        guard let value = defaults?.string(forKey: "easyViewBaseURL"),
-              !value.isEmpty else { return nil }
-        return value
-    }
-
     static var easyViewSession: String? {
         guard let value = defaults?.string(forKey: "easyViewSession"),
               !value.isEmpty else { return nil }
@@ -200,12 +194,6 @@ enum WatchDataManager {
 
         let easyViewEnabled = context["easyViewEnabled"] as? Bool ?? false
         defaults?.set(easyViewEnabled, forKey: "easyViewEnabled")
-
-        if let url = context["easyViewBaseURL"] as? String, !url.isEmpty {
-            defaults?.set(url, forKey: "easyViewBaseURL")
-        } else {
-            defaults?.removeObject(forKey: "easyViewBaseURL")
-        }
 
         if let session = context["easyViewSession"] as? String, !session.isEmpty {
             defaults?.set(session, forKey: "easyViewSession")

--- a/iOS/WatchShared/WatchDataManager.swift
+++ b/iOS/WatchShared/WatchDataManager.swift
@@ -123,6 +123,28 @@ enum WatchDataManager {
         defaults?.set(date.ISO8601Format(), forKey: "lastCarbEntryAt")
     }
 
+    // MARK: - EasyView config (synced from phone)
+
+    static var easyViewEnabled: Bool {
+        defaults?.bool(forKey: "easyViewEnabled") ?? false
+    }
+
+    static var easyViewBaseURL: String? {
+        guard let value = defaults?.string(forKey: "easyViewBaseURL"),
+              !value.isEmpty else { return nil }
+        return value
+    }
+
+    static var easyViewSession: String? {
+        guard let value = defaults?.string(forKey: "easyViewSession"),
+              !value.isEmpty else { return nil }
+        return value
+    }
+
+    static var easyViewPatientUID: Int? {
+        defaults?.object(forKey: "easyViewPatientUID") as? Int
+    }
+
     // MARK: - Nightscout config (synced from phone)
 
     static var nightscoutEnabled: Bool {
@@ -174,6 +196,27 @@ enum WatchDataManager {
             defaults?.set(token, forKey: "nightscoutToken")
         } else {
             defaults?.removeObject(forKey: "nightscoutToken")
+        }
+
+        let easyViewEnabled = context["easyViewEnabled"] as? Bool ?? false
+        defaults?.set(easyViewEnabled, forKey: "easyViewEnabled")
+
+        if let url = context["easyViewBaseURL"] as? String, !url.isEmpty {
+            defaults?.set(url, forKey: "easyViewBaseURL")
+        } else {
+            defaults?.removeObject(forKey: "easyViewBaseURL")
+        }
+
+        if let session = context["easyViewSession"] as? String, !session.isEmpty {
+            defaults?.set(session, forKey: "easyViewSession")
+        } else {
+            defaults?.removeObject(forKey: "easyViewSession")
+        }
+
+        if let uid = context["easyViewPatientUID"] as? Int {
+            defaults?.set(uid, forKey: "easyViewPatientUID")
+        } else {
+            defaults?.removeObject(forKey: "easyViewPatientUID")
         }
 
         let isMockModeEnabled = context["mockModeEnabled"] as? Bool ?? false


### PR DESCRIPTION
## Summary

- Adds **EasyView** (Medtrum CGM cloud platform) as a fully-integrated data source alongside HealthKit, Nightscout, and Demo.
- Full end-to-end support: iPhone app, Status Widget, and Apple Watch (both app and complication).
- Supports both **caregiver/monitor** accounts (resolves patient UID via `/v2.1/monitor/connections`) and **self-managing patient** accounts (uses own UID directly).

## What changed

### SharedKit
- **`EasyViewClient.swift`** — HTTP client: login, connections, `fetchLatestGlucose` (mg/dL → mmol/L), `fetchLatestCarbs`.
- **`UnifiedDataReader.swift`** — `DataSource.easyView` case + keys; EasyView included in freshest-source resolution logic.
- **`WidgetEasyViewRefresh.swift`** — widget-side throttled fetch; gracefully serves stale data on session expiry (widgets have no Keychain access).

### iOS App
- **`EasyViewManager.swift`** — polling timer, `BGTaskScheduler` background refresh, `fetchAll()` with automatic re-login on session expiry, `testConnection()` for settings UI.
- **`SharedDataManager.swift`** — EasyView config/data keys in App Group; `saveEasyViewGlucose`, `saveEasyViewCarbs`, `clearEasyViewData`; `hasAnyDataSource` updated.
- **`KeychainManager.swift`** — `easyViewPassword` account for secure credential storage.
- **`SettingsView.swift`** — `EasyViewSettingsView` (toggle, base URL, username, password, test button, status row, error display).
- **`SetupChecklistCard.swift`** — EasyView entry in the data-source picker.
- **`App.swift`** — EasyView wired into scene lifecycle (polling start/stop, background refresh scheduling, first-install Keychain clear).
- **`Info.plist`** — `BGTaskSchedulerPermittedIdentifiers` entry for EasyView.
- **`WatchSessionManager.swift`** — EasyView config + session cookie included in WatchConnectivity context payload.

### Apple Watch
- **`WatchEasyViewManager.swift`** — independent polling + watchOS background refresh; no re-login (no Keychain), serves stale data gracefully.
- **`WatchDataManager.swift`** — EasyView config accessors; `updateFromPhoneContext` parses synced keys.
- **`WatchConnectivityReceiver.swift`** — triggers `WatchEasyViewManager.configurationDidChange()` on context updates.
- **`WatchApp.swift`** — EasyView polling wired into watch app lifecycle.

### Status Widget
- **`StatusWidget.swift`** — `WidgetEasyViewRefresh.refreshIfDue()` called in both snapshot and timeline providers.

### Localization
- English and Dutch strings for all EasyView UI (settings screen + setup checklist).

## Credential security model

| Credential | Storage | Accessible by |
|---|---|---|
| Password | Keychain (main app only) | Main app — used for re-login only |
| Session cookie | App Group UserDefaults | Main app, widgets, Watch |

The main app re-authenticates when the session expires and writes the new cookie to the App Group. Widgets and Watch pick it up on their next fetch without needing their own Keychain access.

## Test plan

- [ ] Configure EasyView with a caregiver account → glucose + carbs populate in the app, widget, and Watch.
- [ ] Configure EasyView with a patient account → same result using own UID.
- [ ] Toggle EasyView off → cached values are cleared; other enabled sources are unaffected.
- [ ] Force session expiry → main app re-logs in automatically; widget/Watch serve stale data until session is refreshed.
- [ ] All three data source toggles (HealthKit + Nightscout + EasyView) off → welcome state restored.

Closes #133

Made with [Cursor](https://cursor.com)