### PR TITLE
build: fastlane release lane — one-command App Store release

### DIFF
--- a/AppStore/README.md
+++ b/AppStore/README.md
@@ -193,6 +193,8 @@ The Markdown files in this folder are the source of truth. They get converted to
 | `make appstore-push` | Sync, then push to App Store Connect. Updates the **editable** version (most recent draft / "Prepare for Submission"). Does **not** submit for review. |
 | `make appstore-pull` | Download Apple's current copy into `iOS/fastlane/metadata/` — handy for diffing or bootstrapping a new locale. Read-only; never overwrite the Markdown from this. |
 | `make appstore-beta` | Archive a Release build and upload to TestFlight. Auto-bumps the build number from ASC. See "Releasing a TestFlight build" below. |
+| `make release VERSION=x.y.z` | Bump version, build, push metadata, upload binary to ASC. Dry-run path — no submission. See "Shipping a release" below. |
+| `make release VERSION=x.y.z SUBMIT=1` | Same as above, plus runs precheck and submits for review with phased release enabled. |
 
 What gets pushed (per locale, from each `<locale>.md`):
 
@@ -271,6 +273,67 @@ Running it again picks a new build number automatically — the lane is safe to 
 
 ---
 
+## Shipping a release
+
+`make release VERSION=x.y.z` takes the current `main` checkout all the way to a staged App Store version — version bump, binary upload, metadata push — in one command. Add `SUBMIT=1` to also submit for review.
+
+### What it does
+
+1. Verifies the working tree is clean and the current branch is `main` (or a `release/*` branch). Fails fast if either check fails.
+2. Bumps `MARKETING_VERSION` to the given version and auto-increments `CURRENT_PROJECT_VERSION` to one above the highest build number currently in App Store Connect (same strategy as `make appstore-beta`, so beta and release builds never collide).
+3. Commits both changes with message `chore: bump to v<version> (<build>)`.
+4. Creates the new App Store version in ASC if it doesn't exist yet. Errors if a different editable version is already open — resolve it in App Store Connect first.
+5. Archives and exports a Release `.ipa` using Xcode-managed signing (`-allowProvisioningUpdates`), same build config as `make appstore-beta`.
+6. Pushes text metadata and screenshots against the new version (equivalent to running `make appstore-push` first — regenerates from `AppStore/*.md` and delivers to ASC).
+7. Uploads the binary and attaches it to the new version. `phased_release: true` is always on so any accidental submission rolls out gradually rather than all at once.
+8. If `SUBMIT=1` was passed: runs `precheck` to validate the listing, then submits for review with phased release enabled. If not passed: leaves everything staged in ASC so you can review before clicking Submit yourself.
+9. Tags the version-bump commit `v<version>` and pushes the branch + tag to `origin`.
+
+### Prerequisites
+
+Same as `make appstore-beta` — see "Releasing a TestFlight build → Prerequisites" above. Additionally:
+
+- `private/asc-review-info.json` should be complete (first name, last name, phone, email). The lane warns and skips the contact-info upload if the file is absent, but ASC will reject submission for review until the info is set (either via the file or directly in App Store Connect).
+- Run `make appstore-screenshots` first if screenshots need refreshing — `make release` pushes whatever is currently in `iOS/fastlane/screenshots/`.
+
+### Running it
+
+**Dry run** — stages everything in ASC; you review the version, build, and metadata before clicking Submit:
+
+```sh
+make release VERSION=1.2.0
+```
+
+**Submit for review** — stages everything and triggers App Review:
+
+```sh
+make release VERSION=1.2.0 SUBMIT=1
+```
+
+First run takes 5–10 minutes (clean archive + binary upload + metadata push). The lane is safe to re-run as often as needed: if the version-bump commit and tag already exist, `ensure_git_status_clean` will catch the uncommitted changes and abort before any side effects occur.
+
+### Precheck
+
+`precheck` runs automatically when `SUBMIT=1` is passed (`run_precheck_before_submit: true`). It validates the listing metadata before upload and will abort the lane on any failures, so a bad description or a forbidden keyword never makes it to App Review. `precheck_include_in_app_purchases` is `false` (set in `Deliverfile`) — GluWink has no in-app purchases.
+
+Precheck does **not** run on dry-run invocations (`make release VERSION=x.y.z` without `SUBMIT=1`) — the lane completes quickly so you can review metadata in ASC before committing to the full check.
+
+### After a dry run
+
+1. Open [App Store Connect](https://appstoreconnect.apple.com) and verify the version, metadata, screenshots, and attached build.
+2. When satisfied, run `make release VERSION=<same version> SUBMIT=1`.
+   - The lane will error on `ensure_git_status_clean` because the version-bump commit is already present, or on `ensure_app_store_version!` because the version already exists. **This is the intended signal that setup is done.** Submit directly in App Store Connect instead, or use `bundle exec fastlane deliver submit_for_review:true` from the `iOS/` directory.
+
+### When it fails
+
+- **"Working directory is not clean"** — commit or stash local changes before running.
+- **"Not on main branch"** — run from `main` or a `release/*` branch.
+- **"An editable App Store version X.Y.Z already exists"** — submit or delete the existing version in App Store Connect before creating a new one.
+- **Binary upload / provisioning errors** — same as `make appstore-beta`; see "When it fails" in the TestFlight section above.
+- **Precheck failure** — fix the flagged metadata in `AppStore/<locale>.md`, run `make appstore-sync` to validate locally, then re-run `make release VERSION=... SUBMIT=1`.
+
+---
+
 ## Submission checklist
 
 Before tapping **Submit for Review**:
@@ -283,6 +346,6 @@ Before tapping **Submit for Review**:
 - [ ] Age rating questionnaire completed (4+, mild medical info).
 - [ ] Sign-in info / demo account section: explicitly say "no account required" and point the reviewer at Demo mode.
 - [ ] Reviewer notes: mention that Screen Time + Family Controls require a real device and that the reviewer can use Demo mode in Settings → Data Sources to populate glucose without a CGM.
-- [ ] Build uploaded (run `make appstore-beta`) and selected for the version.
+- [ ] Build uploaded and selected for the version — `make release VERSION=x.y.z` does this; `make appstore-beta` uploads to TestFlight only.
 - [ ] Pricing set to Free.
 - [ ] Availability set to all territories where the listing is localized (at minimum: US, NL, BE).

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ venv-clean:
 
 # --- App Store listing (fastlane deliver) ---
 
-.PHONY: appstore-bootstrap appstore-sync appstore-push appstore-pull appstore-screenshots appstore-beta watchface-prepare watchface-capture docs-sync-screenshots docs-bootstrap docs-serve docs-clean docs-build docs-publish-check docs-audit docs-check docs-og-images
+.PHONY: appstore-bootstrap appstore-sync appstore-push appstore-pull appstore-screenshots appstore-beta release watchface-prepare watchface-capture docs-sync-screenshots docs-bootstrap docs-serve docs-clean docs-build docs-publish-check docs-audit docs-check docs-og-images
 
 ## One-time: install fastlane into iOS/vendor/bundle (uses iOS/Gemfile)
 appstore-bootstrap:
@@ -259,3 +259,13 @@ docs-og-images:
 ## See AppStore/README.md → "Releasing a TestFlight build".
 appstore-beta:
 	cd iOS && $(RUN_RUBY) bundle exec fastlane beta
+
+## Bump version, push metadata, upload binary to App Store Connect, and
+## optionally submit for review. VERSION is required. Pass SUBMIT=1 to
+## submit for review; omit it to stage everything in ASC first (dry run).
+## Requires private/asc-api-key.json and being signed into Xcode with
+## the development team. See AppStore/README.md → "Shipping a release".
+## Usage: make release VERSION=1.2.0 [SUBMIT=1]
+release:
+	@if [ -z "$(VERSION)" ]; then echo "ERROR: VERSION is required (e.g. make release VERSION=1.2.0)" >&2; exit 1; fi
+	cd iOS && $(RUN_RUBY) bundle exec fastlane release version:$(VERSION) submit:$(if $(SUBMIT),true,false)

--- a/iOS/fastlane/Fastfile
+++ b/iOS/fastlane/Fastfile
@@ -148,6 +148,143 @@ platform :ios do
     end
   end
 
+  desc "Archive, push metadata, and optionally submit to App Store."
+  desc "Args: version: (required, e.g. 1.2.0), submit: (optional, default false)."
+  desc "Dry-run path: omit submit: to stage everything in ASC and review before clicking Submit."
+  lane :release do |options|
+    version = options[:version].to_s.strip
+    UI.user_error!("version: is required, e.g. fastlane release version:1.2.0") if version.empty?
+
+    do_submit = options[:submit].to_s == "true"
+    api_key_path = require_api_key!
+
+    # 1. Preconditions: clean working tree, on main or a release/* branch.
+    ensure_git_status_clean
+    ensure_git_branch(branch: /^(main|release\/.+)$/)
+
+    # 2. Bump MARKETING_VERSION and CURRENT_PROJECT_VERSION, commit the bump
+    #    before archiving so the binary and the tag share the same git SHA.
+    increment_version_number(
+      version_number: version,
+      xcodeproj: "App.xcodeproj",
+    )
+
+    next_build_number = latest_testflight_build_number(
+      api_key_path: api_key_path,
+      initial_build_number: 0,
+    ) + 1
+    UI.message("Next build number: #{next_build_number}")
+
+    increment_build_number(
+      build_number: next_build_number,
+      xcodeproj: "App.xcodeproj",
+    )
+
+    commit_version_bump(
+      message: "chore: bump to v#{version} (#{next_build_number})",
+      xcodeproj: "App.xcodeproj",
+      force: true,
+    )
+
+    # 3. Create the App Store version in ASC if it doesn't exist yet.
+    ensure_app_store_version!(api_key_path, version)
+
+    # 4. Archive and export the .ipa (same config as beta, no xcargs version
+    #    override — versions are now committed in the xcodeproj).
+    build_app(
+      project: "App.xcodeproj",
+      scheme: "App",
+      configuration: "Release",
+      export_method: "app-store",
+      output_directory: "build",
+      output_name: "App.ipa",
+      clean: true,
+      xcargs: "-allowProvisioningUpdates",
+    )
+
+    # 5. Push text metadata + screenshots against the new ASC version.
+    #    Reuses the existing push_metadata lane (sync from Markdown,
+    #    bootstrap review-detail record, deliver with skip_binary_upload).
+    push_metadata
+
+    # 6. Upload the binary and attach it to the version; optionally submit.
+    #    skip_binary_upload: false overrides the Deliverfile default.
+    #    phased_release: true is always on so accidental submits roll out slowly.
+    #    precheck runs only when we actually submit so dry-runs stay fast.
+    review_info = load_review_info
+    deliver_options = {
+      api_key_path: api_key_path,
+      app_version: version,
+      force: true,
+      skip_metadata: true,
+      skip_screenshots: true,
+      skip_binary_upload: false,
+      submit_for_review: do_submit,
+      phased_release: true,
+      automatic_release: false,
+      run_precheck_before_submit: do_submit,
+      precheck_include_in_app_purchases: false,
+    }
+    deliver_options[:app_review_information] = review_info if review_info
+    deliver(**deliver_options)
+
+    # 7. Tag the version-bump commit and push branch + tag together.
+    add_git_tag(tag: "v#{version}")
+    push_to_git_remote(tags: true)
+
+    if do_submit
+      UI.success("v#{version} (#{next_build_number}) submitted for review with phased release.")
+    else
+      UI.success(
+        "v#{version} (#{next_build_number}) staged in App Store Connect. " \
+        "Review metadata and the attached build at https://appstoreconnect.apple.com, " \
+        "then run `make release VERSION=#{version} SUBMIT=1` to submit for review.",
+      )
+    end
+  end
+
+  # Create a new App Store version in ASC for the given version string if one
+  # doesn't already exist. Errors if a different editable version is open so
+  # the owner can decide whether to delete or submit it before proceeding.
+  def ensure_app_store_version!(api_key_path, version)
+    require "spaceship"
+    require "json"
+
+    key = JSON.parse(File.read(api_key_path))
+    Spaceship::ConnectAPI.token = Spaceship::ConnectAPI::Token.create(
+      key_id: key["key_id"],
+      issuer_id: key["issuer_id"],
+      key: key["key"],
+    )
+
+    app = Spaceship::ConnectAPI::App.find("nl.fokkezb.GluWink")
+    UI.user_error!("App nl.fokkezb.GluWink not found in App Store Connect") unless app
+
+    edit_version = app.get_edit_app_store_version
+
+    if edit_version
+      if edit_version.version_string == version
+        UI.message("App Store version #{version} already exists — skipping creation.")
+        return
+      end
+
+      UI.user_error!(
+        "An editable App Store version #{edit_version.version_string} already exists in ASC. " \
+        "Submit or delete it in App Store Connect before creating #{version}.",
+      )
+    end
+
+    UI.message("Creating App Store version #{version} in ASC…")
+    Spaceship::ConnectAPI::AppStoreVersion.create(
+      app_id: app.id,
+      attributes: {
+        "versionString" => version,
+        "platform" => "IOS",
+      },
+    )
+    UI.success("Created App Store version #{version}.")
+  end
+
   desc "Build a Release archive and upload it to TestFlight."
   desc "Uses Xcode-managed signing (-allowProvisioningUpdates) and auto-bumps"
   desc "CURRENT_PROJECT_VERSION from the latest TestFlight build so successive"


### PR DESCRIPTION
## Summary

- Adds a `release` lane to `iOS/fastlane/Fastfile` that takes the current `main` checkout all the way to a staged (or submitted) App Store version in one command.
- Adds `make release VERSION=x.y.z [SUBMIT=1]` Makefile target.
- Documents the full flow in `AppStore/README.md` under a new "Shipping a release" section.

## What the lane does

1. **Preconditions** — `ensure_git_status_clean` + `ensure_git_branch` (must be on `main` or `release/*`). Fails fast if either check fails.
2. **Version bump** — `increment_version_number` sets `MARKETING_VERSION`; `latest_testflight_build_number + 1` drives `increment_build_number`. Both changes are committed with `commit_version_bump` before archiving so the binary and the tag share the same git SHA.
3. **ASC version creation** — new `ensure_app_store_version!` Spaceship helper creates the App Store version if it doesn't exist. Errors if a _different_ editable version is already open (mirrors the `ensure_review_detail!` pattern already in the file).
4. **Build** — same `build_app` call as the `beta` lane (clean, Release, app-store, `-allowProvisioningUpdates`); no xcargs version override since versions are committed.
5. **Metadata push** — calls the existing `push_metadata` lane (sync from Markdown → `deliver` with `skip_binary_upload: true`).
6. **Binary upload + optional submission** — `deliver` with `skip_binary_upload: false` (overrides `Deliverfile` default), `phased_release: true` always on, `run_precheck_before_submit: true` only when `submit: true` so dry-runs stay fast.
7. **Tag + push** — `add_git_tag(tag: "v<version>")` then `push_to_git_remote(tags: true)`.

## Verification (code review)

- `make release VERSION=1.2.0` on a clean `main` would: commit the bump → create the ASC version → build → push metadata → attach the binary → tag → **no** review submission.
- `make release VERSION=1.2.0 SUBMIT=1` additionally runs precheck and submits.
- Non-clean tree or non-`main` branch fails on step 1.
- Existing editable version at a different version string fails on step 3 with a clear error.
- Running `push_metadata` afterwards is a no-op on binaries and safe.

This is a config/tooling change with no Swift code — no device build needed for review.

Closes #33

Made with [Cursor](https://cursor.com)