### PR TITLE
fix(appstore): Xcode 26 upload workarounds — skip encryption dialog, document altool behaviour

### DIFF
--- a/QUIRKS.md
+++ b/QUIRKS.md
@@ -160,22 +160,23 @@ If visual verification is genuinely necessary and the owner isn't in the loop fo
 
 ## Fastlane / App Store Upload
 
-### altool "Cannot determine the 'platform'" on Xcode 26 / macOS 26
+### altool upload failures on Xcode 26 / macOS 26
 
-`make appstore-beta` (and any lane that calls `upload_to_testflight`) may fail during the upload step with:
+Fastlane's default uploader uses `altool` from inside `ContentDelivery.framework`. On Xcode 26 it has two separate bugs:
 
-```
-[altool.BE70485C0] Cannot determine the 'platform' from the info.plist. (19)
-[altool.101086D60] ExitFailure (31)
-```
+- **New altool path** fails with `Cannot determine the 'platform' from the info.plist. (19)`.
+- **`--use-old-altool` path** connects but then hangs silently for 20+ minutes on the upload.
 
-This is a known compatibility issue between fastlane's use of the `altool` binary bundled inside `Xcode.app/Contents/SharedFrameworks/ContentDelivery.framework` and Xcode 26 / macOS 26. The archive and IPA export succeed — only the upload step fails.
+**Fix (already applied to `Fastfile`):** `DELIVER_ALTOOL_ADDITIONAL_UPLOAD_PARAMETERS = "--use-old-altool"` routes through altool's legacy upload code path, which still works on Xcode 26. **The upload takes ~20 minutes. Do not interrupt it** — if you `Ctrl-C`, the underlying `altool` process keeps running as an orphan and the upload completes anyway (which is why builds appear in ASC even after an "aborted" run).
 
-**Workarounds (in order of preference):**
-1. **Apple Transporter app** (Mac App Store, free) — drag the IPA from `iOS/build/App.ipa` into Transporter and click Deliver. Completely bypasses altool.
-2. **Xcode Organizer** — open **Xcode → Window → Organizer**, select the archive that `make appstore-beta` just produced (saved to `~/Library/Developer/Xcode/Archives/<date>/`), and use **Distribute App → App Store Connect → Upload**.
+Other approaches tried and why they don't work on Xcode 26:
+- **Default altool path** — fails with `Cannot determine the 'platform' from the info.plist. (19)`.
+- **`FASTLANE_ITUNES_TRANSPORTER_PATH` → Xcode `usr/bin/iTMSTransporter`** — that binary is a Java wrapper; Xcode 26 doesn't bundle a JVM, so it fails immediately with "No such file or directory".
+- **`FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT=1`** — fastlane looks for the old `ContentDelivery.framework` shell script transporter, which Xcode 26 has removed or restructured; fails with "Could not find transporter".
 
-`bundle update fastlane` does not fix this — the bug is in Xcode 26's `altool` binary inside `ContentDelivery.framework`, not in fastlane itself.
+If the `--use-old-altool` approach ever stops working, the manual fallback is **Xcode Organizer** — open **Xcode → Window → Organizer**, select the archive (saved to `~/Library/Developer/Xcode/Archives/<date>/`), and use **Distribute App → App Store Connect → Upload**.
+
+`bundle update fastlane` does not fix either bug — they are in Xcode 26's bundled binaries, not in fastlane itself.
 
 ## Naming
 

--- a/iOS/Config.xcconfig
+++ b/iOS/Config.xcconfig
@@ -33,3 +33,7 @@ GLUCOSE_STALE_MINUTES = 30
 // Before this hour+minute, missing carb entries are not flagged
 CARB_GRACE_HOUR = 9
 CARB_GRACE_MINUTE = 30
+
+// The app only uses encryption within Apple's OS (URLSession TLS, Keychain,
+// CryptoKit). No custom or proprietary encryption is implemented.
+INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO

--- a/iOS/fastlane/Fastfile
+++ b/iOS/fastlane/Fastfile
@@ -7,8 +7,11 @@
 default_platform(:ios)
 opt_out_usage
 
-# Xcode 26's new altool has a bug where it cannot determine the platform from
-# the IPA's Info.plist. Force the legacy altool path until Apple ships a fix.
+# Xcode 26 has broken the default altool upload path ("Cannot determine the
+# 'platform' from the info.plist"). --use-old-altool routes through the legacy
+# code path that still works, but is slow (~20 min). Do NOT interrupt the
+# script — the upload completes even if it looks hung; interrupting spawns an
+# orphan altool process that uploads in the background anyway.
 # https://github.com/fastlane/fastlane/issues/29739
 ENV["DELIVER_ALTOOL_ADDITIONAL_UPLOAD_PARAMETERS"] = "--use-old-altool"
 


### PR DESCRIPTION
## Summary

- **`build(appstore)`** — Add `INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO` to `Config.xcconfig`. Embeds the key in every IPA so App Store Connect skips the export-compliance dialog automatically. GluWink uses only Apple OS encryption (URLSession TLS, Keychain, CryptoKit) so the answer is always "None of the above".
- **`docs(appstore)`** — Update Fastfile comment and `QUIRKS.md` with a comprehensive account of the Xcode 26 `altool` situation, including the key finding: the `--use-old-altool` upload takes ~20 min but **completes even if you Ctrl-C** (altool orphan keeps running). Three other approaches were tried and documented as dead ends for Xcode 26.

## Xcode 26 altool dead ends (for future reference)

| Approach | Result |
|---|---|
| Default altool | `Cannot determine the 'platform' from the info.plist. (19)` |
| `FASTLANE_ITUNES_TRANSPORTER_PATH` → `Xcode/…/usr/bin` | Java wrapper, no JVM bundled → immediate fail |
| `FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT=1` | `ContentDelivery.framework` shell transporter removed in Xcode 26 |
| `--use-old-altool` ✅ | Works; ~20 min; survives Ctrl-C (orphan uploads anyway) |

## Test plan

- [ ] Run `make appstore-beta` and confirm the upload step starts (altool output visible) — actual 20-min wait not required to verify the fix
- [ ] On next upload to ASC, verify no export-compliance dialog appears for build 5+

Made with [Cursor](https://cursor.com)