### PR TITLE
fix(easyview): pick up carbs from the ds chart endpoint

### DIFF
--- a/iOS/App/EasyViewManager.swift
+++ b/iOS/App/EasyViewManager.swift
@@ -109,12 +109,10 @@ final class EasyViewManager {
         }
 
         do {
-            // Fetch glucose and carbs concurrently.
-            async let glucoseTask = client.fetchLatestGlucose(patientUID: patientUID)
-            async let carbsTask = client.fetchLatestCarbs(patientUID: patientUID)
-
-            let glucose = try await glucoseTask
-            let carbs = try await carbsTask
+            // One `ds` request returns both glucose and carbs.
+            let latest = try await client.fetchLatest(patientUID: patientUID)
+            let glucose = latest.glucose
+            let carbs = latest.carbs
 
             if let glucose {
                 data.saveEasyViewGlucose(mmol: glucose.mmol, at: glucose.date)
@@ -204,7 +202,7 @@ final class EasyViewManager {
             logger.info("EasyView monitor account: resolved patientUID=\(patientUID) via \(connections.isEmpty ? "login uid fallback" : "connections")")
         }
 
-        let glucose = try await client.fetchLatestGlucose(patientUID: patientUID)
+        let latest = try await client.fetchLatest(patientUID: patientUID)
 
         // Persist on success.
         let data = SharedDataManager.shared
@@ -212,7 +210,7 @@ final class EasyViewManager {
         data.easyViewPatientUID = patientUID
         data.flush()
 
-        return TestResult(glucose: glucose, carbs: nil)
+        return TestResult(glucose: latest.glucose, carbs: latest.carbs)
     }
 
     // MARK: - Background refresh

--- a/iOS/SharedKit/Sources/SharedKit/EasyViewClient.swift
+++ b/iOS/SharedKit/Sources/SharedKit/EasyViewClient.swift
@@ -205,24 +205,30 @@ public struct EasyViewClient: Sendable {
         }
     }
 
-    // MARK: - Glucose
+    // MARK: - Combined latest reading
 
-    /// Fetch the most recent CGM sensor glucose reading from the last `windowHours` hours.
-    /// Prefers the `/v3/api/v2.1/chart/{uid}/data/ds` endpoint which returns continuous
-    /// sensor readings (CGM data), falling back to manually-entered BG events if no
-    /// sensor data is available in the window.
-    /// Returns nil when there are no readings in the window.
-    public func fetchLatestGlucose(patientUID: Int, windowHours: Double = 3) async throws -> GlucoseSample? {
-        if let sensor = try await fetchLatestSensorGlucose(patientUID: patientUID, windowHours: windowHours) {
-            return sensor
-        }
-        return try await fetchLatestGlucoseFromEvents(patientUID: patientUID, windowHours: windowHours)
+    /// The latest glucose + carb entry resolved from a single `ds` chart request.
+    public struct LatestReading: Sendable {
+        public let glucose: GlucoseSample?
+        public let carbs: CarbEntry?
     }
 
-    /// Fetch the most recent CGM sensor reading from the `ds` (day summary) chart endpoint.
-    /// Each reading is `[timestamp, mmol/L, trend, raw_mgdl, status]`.
-    /// Returns nil when there are no sensor readings in the window.
-    private func fetchLatestSensorGlucose(patientUID: Int, windowHours: Double) async throws -> GlucoseSample? {
+    /// Fetch the most recent glucose and carb entry in a single round-trip.
+    ///
+    /// The `ds` (day summary) chart response carries both `sensor_glucose` and
+    /// `carb_event`, so one request covers both metrics. Carbs come purely from
+    /// `carb_event`, which already unifies bolus-wizard and manually-entered
+    /// carbs. When the window holds no CGM sensor reading, glucose falls back to
+    /// the most recent manually-entered BG event (one extra request).
+    ///
+    /// - Parameter windowHours: how far back to look for both metrics. The
+    ///   default (6h) is the trade-off between payload size — the `ds` response
+    ///   is dominated by 5-minute CGM `sensor_glucose` points — and capturing a
+    ///   not-too-recent carb on first fetch / after a cache clear (it comfortably
+    ///   covers the default 4h carb grace window). Once a carb is captured it is
+    ///   persisted and survives later empty windows, so this only bounds the
+    ///   initial capture, not retention.
+    public func fetchLatest(patientUID: Int, windowHours: Double = 6) async throws -> LatestReading {
         let now = Date().timeIntervalSince1970
         let start = now - windowHours * 3600
         let param = encodeDsParam(start: start, end: now)
@@ -231,24 +237,49 @@ public struct EasyViewClient: Sendable {
             URLQueryItem(name: "param", value: param),
         ])
         let data = try await perform(request)
-        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let dataObj = json["data"] as? [String: Any],
-              let sensorGlucose = dataObj["sensor_glucose"] as? [[[Any]]]
-        else { return nil }
+        let json = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+        let dataObj = json?["data"] as? [String: Any]
 
-        // sensorGlucose is [[day0readings], [day1readings], …]; flatten across all day buckets
-        // (the window can span a day boundary) and pick the most recent.
-        let allReadings = sensorGlucose.flatMap { $0 }
-        let sorted = allReadings.sorted { a, b in
-            (a[0] as? Double ?? 0) > (b[0] as? Double ?? 0)
+        let carbs = Self.parseLatestCarb(from: dataObj)
+        if let glucose = Self.parseLatestSensorGlucose(from: dataObj) {
+            return LatestReading(glucose: glucose, carbs: carbs)
         }
 
-        guard let latest = sorted.first,
+        // No CGM sensor reading in the window — fall back to manual BG events.
+        let fallback = try await fetchLatestGlucoseFromEvents(patientUID: patientUID, windowHours: windowHours)
+        return LatestReading(glucose: fallback, carbs: carbs)
+    }
+
+    // MARK: - Parsing (ds chart payload)
+
+    /// Pick the most recent sensor glucose reading from a `ds` `data` object.
+    /// `sensor_glucose` is `[[ [ts, mmol, …] … ]]` — per-day buckets of readings;
+    /// flatten across buckets (the window can span a day boundary) and take the latest.
+    private static func parseLatestSensorGlucose(from dataObj: [String: Any]?) -> GlucoseSample? {
+        guard let sensorGlucose = dataObj?["sensor_glucose"] as? [[[Any]]] else { return nil }
+        let latest = sensorGlucose
+            .flatMap { $0 }
+            .max { ($0.first as? Double ?? 0) < ($1.first as? Double ?? 0) }
+        guard let latest, latest.count >= 2,
               let ts = latest[0] as? Double,
               let mmol = latest[1] as? Double
         else { return nil }
-
         return GlucoseSample(mmol: mmol, date: Date(timeIntervalSince1970: ts))
+    }
+
+    /// Pick the most recent carb entry from a `ds` `data` object.
+    /// `carb_event` is `[[ [ts, grams] … ]]` — per-day buckets unifying
+    /// bolus-wizard and manually-entered carbs.
+    private static func parseLatestCarb(from dataObj: [String: Any]?) -> CarbEntry? {
+        guard let carbEvent = dataObj?["carb_event"] as? [[[Any]]] else { return nil }
+        let latest = carbEvent
+            .flatMap { $0 }
+            .max { ($0.first as? Double ?? 0) < ($1.first as? Double ?? 0) }
+        guard let latest, latest.count >= 2,
+              let ts = latest[0] as? Double,
+              let grams = latest[1] as? Double
+        else { return nil }
+        return CarbEntry(grams: grams, date: Date(timeIntervalSince1970: ts))
     }
 
     /// Fetch the most recent manually-entered BG event from the events endpoint.
@@ -271,29 +302,6 @@ public struct EasyViewClient: Sendable {
         return GlucoseSample(mmol: mgdl / 18.018, date: Date(timeIntervalSince1970: ts))
     }
 
-    // MARK: - Carbs
-
-    /// Fetch the most recent CARB event from the last `windowHours` hours.
-    /// Returns nil when there are no carb events in the window.
-    public func fetchLatestCarbs(patientUID: Int, windowHours: Double = 12) async throws -> CarbEntry? {
-        let items = try await fetchEvents(patientUID: patientUID, windowHours: windowHours)
-        let carbEvents = items.filter { event in
-            guard event.count > 2 else { return false }
-            return (event[2] as? String) == "CARB"
-        }
-        .sorted { a, b in
-            (a[1] as? Double ?? 0) > (b[1] as? Double ?? 0)
-        }
-
-        guard let latest = carbEvents.first,
-              let ts = latest[1] as? Double,
-              let dataDict = latest[3] as? [String: Any],
-              let grams = dataDict["value"] as? Double
-        else { return nil }
-
-        return CarbEntry(grams: grams, date: Date(timeIntervalSince1970: ts))
-    }
-
     // MARK: - Private: events
 
     /// Fetch raw events for `patientUID` over the last `windowHours` hours.
@@ -303,7 +311,7 @@ public struct EasyViewClient: Sendable {
         let start = now - windowHours * 3600
         let param = encodeEventsParam(start: start, end: now)
 
-        let request = makeRequest(path: "/api/v2.0/events/\(patientUID)", query: [
+        let request = makeRequest(path: "/v3/api/v2.0/events/\(patientUID)", query: [
             URLQueryItem(name: "param", value: param),
             URLQueryItem(name: "per_page", value: "9999"),
             URLQueryItem(name: "page", value: "1"),

--- a/iOS/SharedKit/Sources/SharedKit/WidgetEasyViewRefresh.swift
+++ b/iOS/SharedKit/Sources/SharedKit/WidgetEasyViewRefresh.swift
@@ -53,31 +53,22 @@ public enum WidgetEasyViewRefresh {
             requestTimeout: requestTimeout
         )
 
-        async let glucoseTask: EasyViewClient.GlucoseSample? = {
-            do {
-                return try await client.fetchLatestGlucose(patientUID: patientUID)
-            } catch EasyViewClient.ClientError.sessionExpired {
-                logger.warning("Widget EasyView session expired — serving stale cached values")
-                return nil
-            } catch {
-                logger.error("Widget EasyView glucose fetch failed: \(error.localizedDescription, privacy: .public)")
-                return nil
-            }
-        }()
-
-        async let carbsTask: EasyViewClient.CarbEntry? = {
-            do {
-                return try await client.fetchLatestCarbs(patientUID: patientUID)
-            } catch EasyViewClient.ClientError.sessionExpired {
-                return nil
-            } catch {
-                logger.error("Widget EasyView carbs fetch failed: \(error.localizedDescription, privacy: .public)")
-                return nil
-            }
-        }()
-
-        let glucose = await glucoseTask
-        let carbs = await carbsTask
+        // One `ds` request returns both glucose and carbs.
+        let glucose: EasyViewClient.GlucoseSample?
+        let carbs: EasyViewClient.CarbEntry?
+        do {
+            let latest = try await client.fetchLatest(patientUID: patientUID)
+            glucose = latest.glucose
+            carbs = latest.carbs
+        } catch EasyViewClient.ClientError.sessionExpired {
+            logger.warning("Widget EasyView session expired — serving stale cached values")
+            glucose = nil
+            carbs = nil
+        } catch {
+            logger.error("Widget EasyView fetch failed: \(error.localizedDescription, privacy: .public)")
+            glucose = nil
+            carbs = nil
+        }
 
         if let glucose {
             saveIfNewer(

--- a/iOS/WatchApp/WatchEasyViewManager.swift
+++ b/iOS/WatchApp/WatchEasyViewManager.swift
@@ -83,25 +83,20 @@ final class WatchEasyViewManager {
         }
 
         do {
-            if let sample = try await client.fetchLatestGlucose(patientUID: patientUID) {
+            // One `ds` request returns both glucose and carbs.
+            let latest = try await client.fetchLatest(patientUID: patientUID)
+            if let sample = latest.glucose {
                 WatchDataManager.storeGlucose(mmol: sample.mmol, at: sample.date)
                 logger.info("Watch EasyView glucose: \(String(format: "%.1f", sample.mmol)) mmol/L")
             }
-        } catch EasyViewClient.ClientError.sessionExpired {
-            logger.warning("Watch EasyView session expired — phone will refresh on next foreground")
-        } catch {
-            logger.error("Watch EasyView glucose fetch failed: \(error.localizedDescription)")
-        }
-
-        do {
-            if let entry = try await client.fetchLatestCarbs(patientUID: patientUID) {
+            if let entry = latest.carbs {
                 WatchDataManager.storeCarbs(grams: entry.grams, at: entry.date)
                 logger.info("Watch EasyView carbs: \(String(format: "%.0f", entry.grams))g")
             }
         } catch EasyViewClient.ClientError.sessionExpired {
-            // Already logged above.
+            logger.warning("Watch EasyView session expired — phone will refresh on next foreground")
         } catch {
-            logger.error("Watch EasyView carbs fetch failed: \(error.localizedDescription)")
+            logger.error("Watch EasyView fetch failed: \(error.localizedDescription)")
         }
 
         WidgetCenter.shared.reloadAllTimelines()


### PR DESCRIPTION
## Summary

EasyView carbs were never picked up. Investigated via a captured HAR of the EasyView web app and found two compounding bugs:

- **Wrong events path** — the events endpoint URL was missing the `/v3` prefix (`/api/v2.0/events` → `/v3/api/v2.0/events`), so the manually-entered `CARB` events it carries were never returned.
- **Bolus-wizard carbs were ignored** — pump/bolus-wizard carbs (the ones the user actually sees on the chart) don't appear in the events endpoint at all. They live in the `ds` chart endpoint's `carb_event` field.

The HAR proved `carb_event` is the **unified** carb source — it carries both bolus-wizard carbs *and* manually-entered carbs (`[ts, grams]` per-day buckets). Since `ds` already returns `sensor_glucose` in the same payload, glucose + carbs now resolve from a **single** `fetchLatest` request instead of two.

### Changes

- New `EasyViewClient.fetchLatest(patientUID:windowHours:)` → `LatestReading { glucose, carbs }`: one `ds` request, parses both `sensor_glucose` and `carb_event` (shared static parse helpers). Glucose falls back to manual BG events only when the window holds no CGM reading.
- Removed the redundant standalone `fetchLatestGlucose` / `fetchLatestCarbs` (forward-only — no dead code). The events code stays solely for the glucose BG fallback, now on the corrected `/v3` path.
- All three callers switched to `fetchLatest`: `EasyViewManager.performFetch`, `EasyViewManager.testConnection` (now also surfaces carbs in the Settings test result), `WatchEasyViewManager.fetchAll`, `WidgetEasyViewRefresh.refreshIfDue`.
- 6h default window — enough to capture a carb up to the default 4h grace window on first fetch / after a cache clear, while halving the `ds` payload (dominated by 5-minute CGM points). Captured carbs persist via save-if-newer, so the window only bounds initial capture, not retention.

## Test plan

- [x] `swift build` (SharedKit) clean
- [x] `xcodebuild` `App` scheme (app + all extensions) — BUILD SUCCEEDED
- [x] `xcodebuild` `WatchApp` scheme — BUILD SUCCEEDED
- [x] Parsing verified against captured HAR: bolus-wizard carbs (40g/20g) and manual carb (50g) both resolve from `ds carb_event`
- [ ] Verify on device with live EasyView data: recent carbs appear on home screen, shield, widget, and watch

Made with [Cursor](https://cursor.com)