### PR TITLE
feat(easyview): meal label storage — localized labels for meal-only carb events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,16 @@ XCODE_PROJECT := iOS/App.xcodeproj
 SCHEME := App
 # `devicectl list devices` reports state as `available (paired)` / `unavailable`
 # on Xcode 16+; the older `connected` keyword is gone. Filter on `iPhone` AND
-# `available` so we ignore paired Apple Watches and offline iPhones, then pick
-# the first UUID-shaped field on the matching line.
-DEVICE_ID = $(shell xcrun devicectl list devices 2>/dev/null | awk '/iPhone/ && /available/ {for(i=1;i<=NF;i++) if($$i ~ /^[0-9A-F].*-/) {print $$i; exit}}')
+# `available` so we ignore paired Apple Watches and offline iPhones. When
+# multiple iPhones are connected (e.g. a child's test device) prefer
+# "iPhone Fokke" so we never accidentally deploy to the wrong device.
+# Falls back to the first available iPhone if that name isn't found.
+# Override on the command line: make install DEVICE_ID=<uuid>
+DEVICE_ID = $(shell xcrun devicectl list devices 2>/dev/null | awk ' \
+  /iPhone Fokke/ && /available/ { for(i=1;i<=NF;i++) if($$i ~ /^[0-9A-F]{8}-/) { preferred=$$i } } \
+  /iPhone/ && /available/ { for(i=1;i<=NF;i++) if($$i ~ /^[0-9A-F]{8}-/ && !fallback) { fallback=$$i } } \
+  END { print (preferred ? preferred : fallback) } \
+')
 DERIVED_DATA := $(HOME)/Library/Developer/Xcode/DerivedData
 # Lazy assignment (`=`) so APP_PATH is re-evaluated at recipe time — this matters
 # for `make deploy: build install`, otherwise APP_PATH is resolved before `build`

--- a/iOS/App/EasyViewManager.swift
+++ b/iOS/App/EasyViewManager.swift
@@ -119,11 +119,11 @@ final class EasyViewManager {
                 logger.info("EasyView glucose: \(String(format: "%.1f", glucose.mmol)) mmol/L at \(glucose.date)")
             }
             if let carbs {
-                data.saveEasyViewCarbs(grams: carbs.grams, at: carbs.date)
+                data.saveEasyViewCarbs(grams: carbs.grams, label: carbs.label, at: carbs.date)
                 if let g = carbs.grams {
                     logger.info("EasyView carbs: \(String(format: "%.0f", g))g at \(carbs.date)")
                 } else {
-                    logger.info("EasyView meal event (no gram count) at \(carbs.date)")
+                    logger.info("EasyView meal event (\(carbs.label ?? "no label")) at \(carbs.date)")
                 }
             }
             data.easyViewLastError = nil

--- a/iOS/App/EasyViewManager.swift
+++ b/iOS/App/EasyViewManager.swift
@@ -120,7 +120,11 @@ final class EasyViewManager {
             }
             if let carbs {
                 data.saveEasyViewCarbs(grams: carbs.grams, at: carbs.date)
-                logger.info("EasyView carbs: \(String(format: "%.0f", carbs.grams))g at \(carbs.date)")
+                if let g = carbs.grams {
+                    logger.info("EasyView carbs: \(String(format: "%.0f", g))g at \(carbs.date)")
+                } else {
+                    logger.info("EasyView meal event (no gram count) at \(carbs.date)")
+                }
             }
             data.easyViewLastError = nil
         } catch EasyViewClient.ClientError.sessionExpired where retryOnExpiry {

--- a/iOS/App/HealthKitSettingsView.swift
+++ b/iOS/App/HealthKitSettingsView.swift
@@ -48,7 +48,7 @@ struct HealthKitSettingsView: View {
                 )
                 latestSampleRow(
                     label: String(localized: "healthkit.settings.latestCarbs"),
-                    value: latestCarbs.map { "\(Int($0.grams)) g" },
+                    value: latestCarbs.map { $0.grams.map { "\(Int($0)) g" } ?? "·" },
                     at: latestCarbs?.sampleAt,
                     emptyMessage: String(localized: "healthkit.settings.noCarbsYet")
                 )

--- a/iOS/App/HomeView.swift
+++ b/iOS/App/HomeView.swift
@@ -118,6 +118,7 @@ struct HomeView: View {
             glucose: glucoseReading?.mmol ?? 0,
             glucoseFetchedAt: glucoseReading?.sampleAt,
             lastCarbGrams: carbsReading?.grams,
+            lastCarbLabel: carbsReading?.label,
             lastCarbEntryAt: carbsReading?.sampleAt,
             highGlucoseThreshold: highThreshold,
             lowGlucoseThreshold: lowThreshold,
@@ -480,7 +481,7 @@ struct HomeView: View {
     private func carbValueText(for content: ShieldContent) -> String {
         guard let carbs = content.carbs else { return "--" }
         if let grams = carbs.grams { return "\(grams) g" }
-        return String(localized: "home.carbsMealOnly")
+        return carbs.label ?? String(localized: "home.carbsMealOnly")
     }
 
     private func relativeTimeText(from date: Date?, hasData: Bool, fallback: String) -> Text {

--- a/iOS/App/HomeView.swift
+++ b/iOS/App/HomeView.swift
@@ -478,7 +478,9 @@ struct HomeView: View {
     }
 
     private func carbValueText(for content: ShieldContent) -> String {
-        "\(content.carbs.map { String($0.grams) } ?? "--") g"
+        guard let carbs = content.carbs else { return "--" }
+        if let grams = carbs.grams { return "\(grams) g" }
+        return String(localized: "home.carbsMealOnly")
     }
 
     private func relativeTimeText(from date: Date?, hasData: Bool, fallback: String) -> Text {

--- a/iOS/App/ScreenshotHarness.swift
+++ b/iOS/App/ScreenshotHarness.swift
@@ -254,6 +254,8 @@ extension ScreenshotHarness {
             defaults.removeObject(forKey: UnifiedDataReader.carbsValueKey(for: .demo))
             defaults.removeObject(forKey: UnifiedDataReader.carbsDateKey(for: .demo))
         }
+        // Screenshot presets always have gram counts; clear any stale label from a previous demo run.
+        defaults.removeObject(forKey: UnifiedDataReader.carbsLabelKey(for: .demo))
 
         // Reset "data source / shielding configured" flags on every run
         // and re-apply them only where a scene actually wants them. Without

--- a/iOS/App/SettingsView.swift
+++ b/iOS/App/SettingsView.swift
@@ -689,9 +689,10 @@ struct MockDataSettingsView: View {
     @State private var mockGlucose: Double
     @State private var glucoseDate: Date
     @State private var hasCarbData: Bool
-    /// When true, the demo entry is a meal acknowledgment with no gram count
-    /// (simulates an EasyView `auto_mode_event` or similar meal-only marker).
-    @State private var mealOnly: Bool
+    /// When non-empty, the demo entry is a meal acknowledgment with no gram
+    /// count — the label is stored as the display string (e.g. "B'fast").
+    /// Demo is its own provider so any free-form text is accepted.
+    @State private var mealLabel: String
     @State private var mockCarbGrams: Double
     @State private var carbDate: Date
 
@@ -712,7 +713,7 @@ struct MockDataSettingsView: View {
         _mockGlucose = State(initialValue: u.displayValue(demoGlucose?.mmol ?? 6.4))
         _glucoseDate = State(initialValue: demoGlucose?.sampleAt ?? Date().addingTimeInterval(-5 * 60))
         _hasCarbData = State(initialValue: demoCarbs != nil)
-        _mealOnly = State(initialValue: demoCarbs?.grams == nil)
+        _mealLabel = State(initialValue: demoCarbs?.label ?? "")
         _mockCarbGrams = State(initialValue: demoCarbs?.grams ?? 20.0)
         _carbDate = State(initialValue: demoCarbs?.sampleAt ?? Date().addingTimeInterval(-120 * 60))
     }
@@ -727,7 +728,7 @@ struct MockDataSettingsView: View {
                         if newValue && !hasGlucoseData && !hasCarbData {
                             hasGlucoseData = true
                             hasCarbData = true
-                            mealOnly = false
+                            mealLabel = ""
                             mockGlucose = unit.displayValue(6.4)
                             glucoseDate = Date().addingTimeInterval(-5 * 60)
                             mockCarbGrams = 20
@@ -778,14 +779,13 @@ struct MockDataSettingsView: View {
                         }
                     ))
                     if hasCarbData {
-                        Toggle(String(localized: "settings.demoMealOnly"), isOn: Binding(
-                            get: { mealOnly },
-                            set: { newValue in
-                                mealOnly = newValue
-                                saveMockData()
-                            }
-                        ))
-                        if !mealOnly {
+                        TextField(
+                            String(localized: "settings.demoMealLabel"),
+                            text: $mealLabel
+                        )
+                        .autocorrectionDisabled()
+                        .onChange(of: mealLabel) { saveMockData() }
+                        if mealLabel.trimmingCharacters(in: .whitespaces).isEmpty {
                             HStack {
                                 Slider(value: $mockCarbGrams, in: 1...200, step: 1)
                                 Text("\(Int(mockCarbGrams))g").monospacedDigit()
@@ -809,6 +809,7 @@ struct MockDataSettingsView: View {
         .onChange(of: glucoseDate) { saveMockData() }
         .onChange(of: mockCarbGrams) { saveMockData() }
         .onChange(of: carbDate) { saveMockData() }
+        .onDisappear { saveMockData() }
     }
 
     private func saveMockData() {
@@ -826,7 +827,12 @@ struct MockDataSettingsView: View {
             }
 
             if hasCarbData {
-                data.saveDemoCarbs(grams: mealOnly ? nil : mockCarbGrams, at: carbDate)
+                let trimmedLabel = mealLabel.trimmingCharacters(in: .whitespaces)
+                if trimmedLabel.isEmpty {
+                    data.saveDemoCarbs(grams: mockCarbGrams, label: nil, at: carbDate)
+                } else {
+                    data.saveDemoCarbs(grams: nil, label: trimmedLabel, at: carbDate)
+                }
             } else {
                 data.clearDemoCarbs()
             }
@@ -992,7 +998,10 @@ struct NightscoutSettingsView: View {
                 )
                 latestSampleRow(
                     label: String(localized: "settings.nightscoutLatestCarbs"),
-                    value: latestCarbs.map { $0.grams.map { "\(Int($0)) g" } ?? "·" },
+                    value: latestCarbs.map { carbs in
+                        if let g = carbs.grams { return "\(Int(g)) g" }
+                        return carbs.label ?? "·"
+                    },
                     at: latestCarbs?.sampleAt,
                     emptyMessage: String(localized: "settings.nightscoutNoCarbsYet")
                 )
@@ -1278,7 +1287,10 @@ struct EasyViewSettingsView: View {
                 )
                 latestSampleRow(
                     label: String(localized: "settings.easyViewLatestCarbs"),
-                    value: latestCarbs.map { $0.grams.map { "\(Int($0)) g" } ?? "·" },
+                    value: latestCarbs.map { carbs in
+                        if let g = carbs.grams { return "\(Int(g)) g" }
+                        return carbs.label ?? "·"
+                    },
                     at: latestCarbs?.sampleAt,
                     emptyMessage: String(localized: "settings.easyViewNoCarbsYet")
                 )

--- a/iOS/App/SettingsView.swift
+++ b/iOS/App/SettingsView.swift
@@ -689,6 +689,9 @@ struct MockDataSettingsView: View {
     @State private var mockGlucose: Double
     @State private var glucoseDate: Date
     @State private var hasCarbData: Bool
+    /// When true, the demo entry is a meal acknowledgment with no gram count
+    /// (simulates an EasyView `auto_mode_event` or similar meal-only marker).
+    @State private var mealOnly: Bool
     @State private var mockCarbGrams: Double
     @State private var carbDate: Date
 
@@ -709,7 +712,8 @@ struct MockDataSettingsView: View {
         _mockGlucose = State(initialValue: u.displayValue(demoGlucose?.mmol ?? 6.4))
         _glucoseDate = State(initialValue: demoGlucose?.sampleAt ?? Date().addingTimeInterval(-5 * 60))
         _hasCarbData = State(initialValue: demoCarbs != nil)
-        _mockCarbGrams = State(initialValue: demoCarbs?.grams ?? 20)
+        _mealOnly = State(initialValue: demoCarbs?.grams == nil)
+        _mockCarbGrams = State(initialValue: demoCarbs?.grams ?? 20.0)
         _carbDate = State(initialValue: demoCarbs?.sampleAt ?? Date().addingTimeInterval(-120 * 60))
     }
 
@@ -723,6 +727,7 @@ struct MockDataSettingsView: View {
                         if newValue && !hasGlucoseData && !hasCarbData {
                             hasGlucoseData = true
                             hasCarbData = true
+                            mealOnly = false
                             mockGlucose = unit.displayValue(6.4)
                             glucoseDate = Date().addingTimeInterval(-5 * 60)
                             mockCarbGrams = 20
@@ -773,9 +778,18 @@ struct MockDataSettingsView: View {
                         }
                     ))
                     if hasCarbData {
-                        HStack {
-                            Slider(value: $mockCarbGrams, in: 0...100, step: 1)
-                            Text("\(Int(mockCarbGrams))g").monospacedDigit()
+                        Toggle(String(localized: "settings.demoMealOnly"), isOn: Binding(
+                            get: { mealOnly },
+                            set: { newValue in
+                                mealOnly = newValue
+                                saveMockData()
+                            }
+                        ))
+                        if !mealOnly {
+                            HStack {
+                                Slider(value: $mockCarbGrams, in: 1...200, step: 1)
+                                Text("\(Int(mockCarbGrams))g").monospacedDigit()
+                            }
                         }
                         DatePicker(
                             String(localized: "settings.demoAt"),
@@ -812,7 +826,7 @@ struct MockDataSettingsView: View {
             }
 
             if hasCarbData {
-                data.saveDemoCarbs(grams: mockCarbGrams, at: carbDate)
+                data.saveDemoCarbs(grams: mealOnly ? nil : mockCarbGrams, at: carbDate)
             } else {
                 data.clearDemoCarbs()
             }
@@ -978,7 +992,7 @@ struct NightscoutSettingsView: View {
                 )
                 latestSampleRow(
                     label: String(localized: "settings.nightscoutLatestCarbs"),
-                    value: latestCarbs.map { "\(Int($0.grams)) g" },
+                    value: latestCarbs.map { $0.grams.map { "\(Int($0)) g" } ?? "·" },
                     at: latestCarbs?.sampleAt,
                     emptyMessage: String(localized: "settings.nightscoutNoCarbsYet")
                 )
@@ -1264,7 +1278,7 @@ struct EasyViewSettingsView: View {
                 )
                 latestSampleRow(
                     label: String(localized: "settings.easyViewLatestCarbs"),
-                    value: latestCarbs.map { "\(Int($0.grams)) g" },
+                    value: latestCarbs.map { $0.grams.map { "\(Int($0)) g" } ?? "·" },
                     at: latestCarbs?.sampleAt,
                     emptyMessage: String(localized: "settings.easyViewNoCarbsYet")
                 )

--- a/iOS/App/SharedDataManager.swift
+++ b/iOS/App/SharedDataManager.swift
@@ -74,23 +74,24 @@ final class SharedDataManager {
     }
 
     func saveHealthKitCarbs(grams: Double, at date: Date, force: Bool = false) {
-        saveCarbs(source: .healthKit, grams: grams, at: date, force: force)
+        saveCarbs(source: .healthKit, grams: grams, label: nil, at: date, force: force)
     }
 
     func saveNightscoutCarbs(grams: Double, at date: Date, force: Bool = false) {
-        saveCarbs(source: .nightscout, grams: grams, at: date, force: force)
+        saveCarbs(source: .nightscout, grams: grams, label: nil, at: date, force: force)
     }
 
     /// Save an EasyView carb or meal-acknowledgment entry. Pass `nil` for
-    /// `grams` when the source logged only that a meal occurred (no carb count).
-    func saveEasyViewCarbs(grams: Double?, at date: Date, force: Bool = false) {
-        saveCarbs(source: .easyView, grams: grams, at: date, force: force)
+    /// `grams` when the source logged only that a meal occurred (no carb count),
+    /// and supply the provider-localized `label` (e.g. "B'fast") for display.
+    func saveEasyViewCarbs(grams: Double?, label: String? = nil, at date: Date, force: Bool = false) {
+        saveCarbs(source: .easyView, grams: grams, label: label, at: date, force: force)
     }
 
     /// Save a demo carb or meal-acknowledgment entry. Pass `nil` for `grams`
-    /// to simulate a meal marker without a gram count.
-    func saveDemoCarbs(grams: Double?, at date: Date, force: Bool = true) {
-        saveCarbs(source: .demo, grams: grams, at: date, force: force)
+    /// and a non-nil `label` to simulate a labelled meal marker without a gram count.
+    func saveDemoCarbs(grams: Double?, label: String? = nil, at date: Date, force: Bool = true) {
+        saveCarbs(source: .demo, grams: grams, label: label, at: date, force: force)
     }
 
     /// Clear every cached value for a single source. Used when:
@@ -116,6 +117,7 @@ final class SharedDataManager {
     func clearDemoCarbs() {
         defaults?.removeObject(forKey: UnifiedDataReader.carbsValueKey(for: .demo))
         defaults?.removeObject(forKey: UnifiedDataReader.carbsDateKey(for: .demo))
+        defaults?.removeObject(forKey: UnifiedDataReader.carbsLabelKey(for: .demo))
     }
 
     private func saveGlucose(source: DataSource, mmol: Double, at date: Date, force: Bool) {
@@ -128,9 +130,10 @@ final class SharedDataManager {
         defaults?.set(date.ISO8601Format(), forKey: dateKey)
     }
 
-    private func saveCarbs(source: DataSource, grams: Double?, at date: Date, force: Bool) {
+    private func saveCarbs(source: DataSource, grams: Double?, label: String?, at date: Date, force: Bool) {
         let valueKey = UnifiedDataReader.carbsValueKey(for: source)
         let dateKey = UnifiedDataReader.carbsDateKey(for: source)
+        let labelKey = UnifiedDataReader.carbsLabelKey(for: source)
         if !force, let existingIso = defaults?.string(forKey: dateKey),
            let existing = ISO8601DateFormatter().date(from: existingIso),
            date <= existing { return }
@@ -139,6 +142,11 @@ final class SharedDataManager {
         // maps value == 0 back to grams: nil.
         defaults?.set(grams ?? 0.0, forKey: valueKey)
         defaults?.set(date.ISO8601Format(), forKey: dateKey)
+        if let label {
+            defaults?.set(label, forKey: labelKey)
+        } else {
+            defaults?.removeObject(forKey: labelKey)
+        }
     }
 
     private func clearSource(_ source: DataSource) {
@@ -146,6 +154,7 @@ final class SharedDataManager {
         defaults?.removeObject(forKey: UnifiedDataReader.glucoseDateKey(for: source))
         defaults?.removeObject(forKey: UnifiedDataReader.carbsValueKey(for: source))
         defaults?.removeObject(forKey: UnifiedDataReader.carbsDateKey(for: source))
+        defaults?.removeObject(forKey: UnifiedDataReader.carbsLabelKey(for: source))
     }
 
     // MARK: - Attention Badge
@@ -170,6 +179,7 @@ final class SharedDataManager {
             glucose: glucose,
             glucoseFetchedAt: glucoseReading?.sampleAt,
             lastCarbGrams: carbsReading?.grams,
+            lastCarbLabel: carbsReading?.label,
             lastCarbEntryAt: carbsReading?.sampleAt,
             highGlucoseThreshold: effectiveHighGlucoseThreshold,
             lowGlucoseThreshold: effectiveLowGlucoseThreshold,

--- a/iOS/App/SharedDataManager.swift
+++ b/iOS/App/SharedDataManager.swift
@@ -81,11 +81,15 @@ final class SharedDataManager {
         saveCarbs(source: .nightscout, grams: grams, at: date, force: force)
     }
 
-    func saveEasyViewCarbs(grams: Double, at date: Date, force: Bool = false) {
+    /// Save an EasyView carb or meal-acknowledgment entry. Pass `nil` for
+    /// `grams` when the source logged only that a meal occurred (no carb count).
+    func saveEasyViewCarbs(grams: Double?, at date: Date, force: Bool = false) {
         saveCarbs(source: .easyView, grams: grams, at: date, force: force)
     }
 
-    func saveDemoCarbs(grams: Double, at date: Date, force: Bool = true) {
+    /// Save a demo carb or meal-acknowledgment entry. Pass `nil` for `grams`
+    /// to simulate a meal marker without a gram count.
+    func saveDemoCarbs(grams: Double?, at date: Date, force: Bool = true) {
         saveCarbs(source: .demo, grams: grams, at: date, force: force)
     }
 
@@ -124,13 +128,16 @@ final class SharedDataManager {
         defaults?.set(date.ISO8601Format(), forKey: dateKey)
     }
 
-    private func saveCarbs(source: DataSource, grams: Double, at date: Date, force: Bool) {
+    private func saveCarbs(source: DataSource, grams: Double?, at date: Date, force: Bool) {
         let valueKey = UnifiedDataReader.carbsValueKey(for: source)
         let dateKey = UnifiedDataReader.carbsDateKey(for: source)
         if !force, let existingIso = defaults?.string(forKey: dateKey),
            let existing = ISO8601DateFormatter().date(from: existingIso),
            date <= existing { return }
-        defaults?.set(grams, forKey: valueKey)
+        // Store 0 as the sentinel for "meal acknowledged, no gram count".
+        // UnifiedDataReader.carbsReading checks the date key for presence and
+        // maps value == 0 back to grams: nil.
+        defaults?.set(grams ?? 0.0, forKey: valueKey)
         defaults?.set(date.ISO8601Format(), forKey: dateKey)
     }
 

--- a/iOS/App/WatchSessionManager.swift
+++ b/iOS/App/WatchSessionManager.swift
@@ -92,7 +92,10 @@ final class WatchSessionManager: NSObject, WCSessionDelegate {
                 context["glucoseFetchedAt"] = glucoseReading.sampleAt.ISO8601Format()
             }
             if let carbsReading = data.currentCarbsReading {
-                context["lastCarbGrams"] = carbsReading.grams
+                // grams is Optional — only include the key when a gram count
+                // exists. The watch maps a missing / 0 grams value to nil,
+                // while still honoring lastCarbEntryAt for the grace-period check.
+                if let grams = carbsReading.grams { context["lastCarbGrams"] = grams }
                 context["lastCarbEntryAt"] = carbsReading.sampleAt.ISO8601Format()
             }
         }

--- a/iOS/App/WatchSessionManager.swift
+++ b/iOS/App/WatchSessionManager.swift
@@ -96,6 +96,7 @@ final class WatchSessionManager: NSObject, WCSessionDelegate {
                 // exists. The watch maps a missing / 0 grams value to nil,
                 // while still honoring lastCarbEntryAt for the grace-period check.
                 if let grams = carbsReading.grams { context["lastCarbGrams"] = grams }
+                if let label = carbsReading.label { context["lastCarbLabel"] = label }
                 context["lastCarbEntryAt"] = carbsReading.sampleAt.ISO8601Format()
             }
         }

--- a/iOS/App/en.lproj/Localizable.strings
+++ b/iOS/App/en.lproj/Localizable.strings
@@ -102,7 +102,7 @@
 "settings.demoHasData" = "Has data";
 "settings.demoGlucose" = "Glucose";
 "settings.demoCarbs" = "Carbs";
-"settings.demoMealOnly" = "No gram count (meal only)";
+"settings.demoMealLabel" = "Meal label (optional)";
 "settings.demoAt" = "At";
 "settings.setPassphrase" = "Set a Passphrase";
 "settings.changePassphrase" = "Change Passphrase";

--- a/iOS/App/en.lproj/Localizable.strings
+++ b/iOS/App/en.lproj/Localizable.strings
@@ -3,6 +3,9 @@
 "setup.passphraseConfirmField" = "Confirm passphrase";
 "setup.passphraseMismatch" = "Passphrases do not match.";
 
+/* Home - Status */
+"home.carbsMealOnly" = "Meal";
+
 /* Home - Welcome */
 "home.welcome.title %@" = "Welcome to %@";
 "home.welcome.tagline %@" = "Turn your iPhone and Apple Watch from your biggest distraction into your best tool. Glucose and carbs everywhere. Apps blocked when something needs your attention.";
@@ -99,6 +102,7 @@
 "settings.demoHasData" = "Has data";
 "settings.demoGlucose" = "Glucose";
 "settings.demoCarbs" = "Carbs";
+"settings.demoMealOnly" = "No gram count (meal only)";
 "settings.demoAt" = "At";
 "settings.setPassphrase" = "Set a Passphrase";
 "settings.changePassphrase" = "Change Passphrase";

--- a/iOS/App/nl.lproj/Localizable.strings
+++ b/iOS/App/nl.lproj/Localizable.strings
@@ -3,6 +3,9 @@
 "setup.passphraseConfirmField" = "Bevestig wachtwoord";
 "setup.passphraseMismatch" = "Wachtwoorden komen niet overeen.";
 
+/* Home - Status */
+"home.carbsMealOnly" = "Maaltijd";
+
 /* Home - Welkom */
 "home.welcome.title %@" = "Welkom bij %@";
 "home.welcome.tagline %@" = "Verander je iPhone en Apple Watch van je grootste afleider in je beste hulpmiddel. Glucose en koolhydraten overal zichtbaar. Apps blokkeren als iets je aandacht vraagt.";
@@ -99,6 +102,7 @@
 "settings.demoHasData" = "Heeft data";
 "settings.demoGlucose" = "Glucose";
 "settings.demoCarbs" = "Koolhydraten";
+"settings.demoMealOnly" = "Geen grammen (alleen maaltijdmelding)";
 "settings.demoAt" = "Op";
 "settings.setPassphrase" = "Wachtwoord Instellen";
 "settings.changePassphrase" = "Wachtwoord Wijzigen";

--- a/iOS/App/nl.lproj/Localizable.strings
+++ b/iOS/App/nl.lproj/Localizable.strings
@@ -102,7 +102,7 @@
 "settings.demoHasData" = "Heeft data";
 "settings.demoGlucose" = "Glucose";
 "settings.demoCarbs" = "Koolhydraten";
-"settings.demoMealOnly" = "Geen grammen (alleen maaltijdmelding)";
+"settings.demoMealLabel" = "Maaltijdlabel (optioneel)";
 "settings.demoAt" = "Op";
 "settings.setPassphrase" = "Wachtwoord Instellen";
 "settings.changePassphrase" = "Wachtwoord Wijzigen";

--- a/iOS/SharedKit/Sources/SharedKit/EasyViewClient.swift
+++ b/iOS/SharedKit/Sources/SharedKit/EasyViewClient.swift
@@ -54,7 +54,9 @@ public struct EasyViewClient: Sendable {
     }
 
     public struct CarbEntry: Sendable {
-        public let grams: Double
+        /// Gram count, or `nil` when the entry is a meal acknowledgment
+        /// without a carb amount (e.g. from `auto_mode_event`).
+        public let grams: Double?
         public let date: Date
     }
 
@@ -240,7 +242,7 @@ public struct EasyViewClient: Sendable {
         let json = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
         let dataObj = json?["data"] as? [String: Any]
 
-        let carbs = Self.parseLatestCarb(from: dataObj)
+        let carbs = Self.parseLatestCarbOrMeal(from: dataObj)
         if let glucose = Self.parseLatestSensorGlucose(from: dataObj) {
             return LatestReading(glucose: glucose, carbs: carbs)
         }
@@ -267,19 +269,63 @@ public struct EasyViewClient: Sendable {
         return GlucoseSample(mmol: mmol, date: Date(timeIntervalSince1970: ts))
     }
 
-    /// Pick the most recent carb entry from a `ds` `data` object.
-    /// `carb_event` is `[[ [ts, grams] … ]]` — per-day buckets unifying
-    /// bolus-wizard and manually-entered carbs.
-    private static func parseLatestCarb(from dataObj: [String: Any]?) -> CarbEntry? {
-        guard let carbEvent = dataObj?["carb_event"] as? [[[Any]]] else { return nil }
-        let latest = carbEvent
-            .flatMap { $0 }
-            .max { ($0.first as? Double ?? 0) < ($1.first as? Double ?? 0) }
-        guard let latest, latest.count >= 2,
-              let ts = latest[0] as? Double,
-              let grams = latest[1] as? Double
-        else { return nil }
-        return CarbEntry(grams: grams, date: Date(timeIntervalSince1970: ts))
+    /// Pick the most recent carb or meal entry from a `ds` `data` object.
+    ///
+    /// Two fields are checked:
+    /// - `carb_event`: `[[ [ts, grams] … ]]` — bolus-wizard + manually-entered
+    ///   carbs. Always has a gram amount.
+    /// - `auto_mode_event`: `[[ slot0, slot1, slot2, … ]]` where each slot is
+    ///   an array of `[ts, size_code]` entries for that meal type (0 = breakfast,
+    ///   1 = lunch, 2 = dinner, 3 = snack, …). The `size_code` encodes meal size
+    ///   (0 = Regular, 1 = Large, …), **not** grams. These are returned with
+    ///   `grams: nil` to signal "meal acknowledged, amount unknown".
+    ///
+    /// When both sources have entries the most-recent timestamp wins; on a tie
+    /// the `carb_event` entry is preferred because it carries more information.
+    private static func parseLatestCarbOrMeal(from dataObj: [String: Any]?) -> CarbEntry? {
+        var latestCarb: CarbEntry?
+        var latestMeal: CarbEntry?
+
+        if let carbEvent = dataObj?["carb_event"] as? [[[Any]]] {
+            let best = carbEvent
+                .flatMap { $0 }
+                .max { ($0.first as? Double ?? 0) < ($1.first as? Double ?? 0) }
+            if let best, best.count >= 2,
+               let ts = best[0] as? Double,
+               let grams = best[1] as? Double, grams > 0 {
+                latestCarb = CarbEntry(grams: grams, date: Date(timeIntervalSince1970: ts))
+            }
+        }
+
+        // auto_mode_event structure: [ dayBucket, … ]
+        // dayBucket: [ slot0, slot1, slot2, … ] (0=breakfast, 1=lunch, 2=dinner, …)
+        // slot: [ [ts, size_code], … ] — array of meal events for that meal type
+        // We want the highest timestamp across all slots in all day buckets.
+        if let autoModeEvent = dataObj?["auto_mode_event"] as? [Any] {
+            var bestTs: Double = 0
+            for dayBucket in autoModeEvent {
+                guard let slots = dayBucket as? [Any] else { continue }
+                for slot in slots {
+                    guard let entries = slot as? [[Any]] else { continue }
+                    for entry in entries {
+                        guard let ts = entry.first as? Double, ts > bestTs else { continue }
+                        bestTs = ts
+                    }
+                }
+            }
+            if bestTs > 0 {
+                latestMeal = CarbEntry(grams: nil, date: Date(timeIntervalSince1970: bestTs))
+            }
+        }
+
+        switch (latestCarb, latestMeal) {
+        case let (carb?, meal?):
+            // Prefer carb_event on a tie (it has gram information).
+            return carb.date >= meal.date ? carb : meal
+        case let (carb?, nil): return carb
+        case let (nil, meal?): return meal
+        case (nil, nil): return nil
+        }
     }
 
     /// Fetch the most recent manually-entered BG event from the events endpoint.

--- a/iOS/SharedKit/Sources/SharedKit/EasyViewClient.swift
+++ b/iOS/SharedKit/Sources/SharedKit/EasyViewClient.swift
@@ -57,6 +57,12 @@ public struct EasyViewClient: Sendable {
         /// Gram count, or `nil` when the entry is a meal acknowledgment
         /// without a carb amount (e.g. from `auto_mode_event`).
         public let grams: Double?
+        /// Provider-localized display label for a meal-only entry (e.g.
+        /// "B'fast", "Lunch"). Non-nil only when `grams` is nil. Already
+        /// localized at parse time using the `easyview.carbLabel.*` keys
+        /// from SharedKit's bundle so all callers receive a display-ready
+        /// string without any further lookup.
+        public let label: String?
         public let date: Date
     }
 
@@ -293,28 +299,35 @@ public struct EasyViewClient: Sendable {
             if let best, best.count >= 2,
                let ts = best[0] as? Double,
                let grams = best[1] as? Double, grams > 0 {
-                latestCarb = CarbEntry(grams: grams, date: Date(timeIntervalSince1970: ts))
+                latestCarb = CarbEntry(grams: grams, label: nil, date: Date(timeIntervalSince1970: ts))
             }
         }
 
         // auto_mode_event structure: [ dayBucket, … ]
         // dayBucket: [ slot0, slot1, slot2, … ] (0=breakfast, 1=lunch, 2=dinner, …)
         // slot: [ [ts, size_code], … ] — array of meal events for that meal type
-        // We want the highest timestamp across all slots in all day buckets.
+        // We want the highest timestamp across all slots, tracking which slot it
+        // came from so we can produce a localized label at parse time.
         if let autoModeEvent = dataObj?["auto_mode_event"] as? [Any] {
             var bestTs: Double = 0
+            var bestSlotIndex: Int = -1
             for dayBucket in autoModeEvent {
                 guard let slots = dayBucket as? [Any] else { continue }
-                for slot in slots {
+                for (slotIndex, slot) in slots.enumerated() {
                     guard let entries = slot as? [[Any]] else { continue }
                     for entry in entries {
                         guard let ts = entry.first as? Double, ts > bestTs else { continue }
                         bestTs = ts
+                        bestSlotIndex = slotIndex
                     }
                 }
             }
             if bestTs > 0 {
-                latestMeal = CarbEntry(grams: nil, date: Date(timeIntervalSince1970: bestTs))
+                latestMeal = CarbEntry(
+                    grams: nil,
+                    label: localizedMealLabel(for: bestSlotIndex),
+                    date: Date(timeIntervalSince1970: bestTs)
+                )
             }
         }
 
@@ -326,6 +339,21 @@ public struct EasyViewClient: Sendable {
         case let (nil, meal?): return meal
         case (nil, nil): return nil
         }
+    }
+
+    /// Map an `auto_mode_event` slot index to a localized display label.
+    /// Localized at parse time using SharedKit's bundle so the stored string
+    /// is display-ready for all callers (App, widget extension, Watch).
+    private static func localizedMealLabel(for slotIndex: Int) -> String {
+        let key: String
+        switch slotIndex {
+        case 0: key = "easyview.carbLabel.breakfast"
+        case 1: key = "easyview.carbLabel.lunch"
+        case 2: key = "easyview.carbLabel.dinner"
+        case 3: key = "easyview.carbLabel.snack"
+        default: key = "easyview.carbLabel.meal"
+        }
+        return String(localized: String.LocalizationValue(key), bundle: .module)
     }
 
     /// Fetch the most recent manually-entered BG event from the events endpoint.

--- a/iOS/SharedKit/Sources/SharedKit/Resources/en.lproj/Localizable.strings
+++ b/iOS/SharedKit/Sources/SharedKit/Resources/en.lproj/Localizable.strings
@@ -39,8 +39,16 @@
 "shield.glucose %@ %@ %@" = "%@ · %@ (%@)";
 "shield.glucoseNoData" = "No glucose data";
 "shield.carbsEntry %d %@ %@" = "%d g · %@ (%@)";
-"shield.carbsMealOnly %@ %@" = "Meal · %@ (%@)";
+"shield.carbsMealOnly %@ %@ %@" = "%@ · %@ (%@)";
+"shield.mealLabel" = "Meal";
 "shield.carbsNoData" = "No carb data";
+
+/* EasyView meal-type labels — stored at write time, opaque to all other SharedKit code */
+"easyview.carbLabel.breakfast" = "B'fast";
+"easyview.carbLabel.lunch" = "Lunch";
+"easyview.carbLabel.dinner" = "Dinner";
+"easyview.carbLabel.snack" = "Snack";
+"easyview.carbLabel.meal" = "Meal";
 "shield.agoMinutes %d" = "%dm ago";
 "shield.agoHoursMinutes %d %d" = "%dh %dm ago";
 

--- a/iOS/SharedKit/Sources/SharedKit/Resources/en.lproj/Localizable.strings
+++ b/iOS/SharedKit/Sources/SharedKit/Resources/en.lproj/Localizable.strings
@@ -78,3 +78,6 @@
 "widget.noData" = "No data";
 /* Suffix around a DateComponentsFormatter duration (e.g. "3 min" or "1 hr, 30 min") for the simulator-only screenshot showcase. Production widgets use SwiftUI's auto-updating Text(date, style: .relative) instead. */
 "widget.relative.ago %@" = "%@ ago";
+/* Unit labels for the meal-only carb age displayed in the circular/inline lock screen widget */
+"widget.carbsMeal.minuteUnit" = "min";
+"widget.carbsMeal.hourUnit" = "hour";

--- a/iOS/SharedKit/Sources/SharedKit/Resources/en.lproj/Localizable.strings
+++ b/iOS/SharedKit/Sources/SharedKit/Resources/en.lproj/Localizable.strings
@@ -39,6 +39,7 @@
 "shield.glucose %@ %@ %@" = "%@ · %@ (%@)";
 "shield.glucoseNoData" = "No glucose data";
 "shield.carbsEntry %d %@ %@" = "%d g · %@ (%@)";
+"shield.carbsMealOnly %@ %@" = "Meal · %@ (%@)";
 "shield.carbsNoData" = "No carb data";
 "shield.agoMinutes %d" = "%dm ago";
 "shield.agoHoursMinutes %d %d" = "%dh %dm ago";

--- a/iOS/SharedKit/Sources/SharedKit/Resources/nl.lproj/Localizable.strings
+++ b/iOS/SharedKit/Sources/SharedKit/Resources/nl.lproj/Localizable.strings
@@ -39,6 +39,7 @@
 "shield.glucose %@ %@ %@" = "%@ · %@ (%@)";
 "shield.glucoseNoData" = "Geen glucosedata";
 "shield.carbsEntry %d %@ %@" = "%d g · %@ (%@)";
+"shield.carbsMealOnly %@ %@" = "Maaltijd · %@ (%@)";
 "shield.carbsNoData" = "Geen KH-data";
 "shield.agoMinutes %d" = "%dm";
 "shield.agoHoursMinutes %d %d" = "%du %dm";

--- a/iOS/SharedKit/Sources/SharedKit/Resources/nl.lproj/Localizable.strings
+++ b/iOS/SharedKit/Sources/SharedKit/Resources/nl.lproj/Localizable.strings
@@ -39,8 +39,16 @@
 "shield.glucose %@ %@ %@" = "%@ · %@ (%@)";
 "shield.glucoseNoData" = "Geen glucosedata";
 "shield.carbsEntry %d %@ %@" = "%d g · %@ (%@)";
-"shield.carbsMealOnly %@ %@" = "Maaltijd · %@ (%@)";
+"shield.carbsMealOnly %@ %@ %@" = "%@ · %@ (%@)";
+"shield.mealLabel" = "Maaltijd";
 "shield.carbsNoData" = "Geen KH-data";
+
+/* EasyView maaltijdtypes — opgeslagen bij schrijven, onbekend voor overige SharedKit-code */
+"easyview.carbLabel.breakfast" = "Ontbijt";
+"easyview.carbLabel.lunch" = "Lunch";
+"easyview.carbLabel.dinner" = "Diner";
+"easyview.carbLabel.snack" = "Snack";
+"easyview.carbLabel.meal" = "Eten";
 "shield.agoMinutes %d" = "%dm";
 "shield.agoHoursMinutes %d %d" = "%du %dm";
 

--- a/iOS/SharedKit/Sources/SharedKit/Resources/nl.lproj/Localizable.strings
+++ b/iOS/SharedKit/Sources/SharedKit/Resources/nl.lproj/Localizable.strings
@@ -78,3 +78,6 @@
 "widget.noData" = "Geen data";
 /* Suffix around a DateComponentsFormatter duration (e.g. "3 min" or "1 u, 30 min") for the simulator-only screenshot showcase. Production widgets use SwiftUI's auto-updating Text(date, style: .relative) instead. */
 "widget.relative.ago %@" = "%@ geleden";
+/* Unit labels for the meal-only carb age displayed in the circular/inline lock screen widget */
+"widget.carbsMeal.minuteUnit" = "min";
+"widget.carbsMeal.hourUnit" = "uur";

--- a/iOS/SharedKit/Sources/SharedKit/ShieldContent.swift
+++ b/iOS/SharedKit/Sources/SharedKit/ShieldContent.swift
@@ -123,16 +123,20 @@ public struct ShieldContent: Sendable {
         let isMorningGrace = currentHour < carbGraceHour
             || (currentHour == carbGraceHour && currentMinute < carbGraceMinute)
 
-        if let carbDate = lastCarbEntryAt, let grams = lastCarbGrams {
+        if let carbDate = lastCarbEntryAt {
             let cMins = Int(now.timeIntervalSince(carbDate) / 60)
             self.carbs = Carbs(
-                grams: Int(grams),
+                grams: lastCarbGrams.map { Int($0) },
                 sampleDate: carbDate,
                 agoMinutes: cMins
             )
             let timeStr = timeFormatter.string(from: carbDate)
             let agoStr = Self.shortAgo(cMins, strings: strings)
-            dataLines.append(String(format: strings.carbsEntry, Int(grams), timeStr, agoStr))
+            if let grams = lastCarbGrams {
+                dataLines.append(String(format: strings.carbsEntry, Int(grams), timeStr, agoStr))
+            } else {
+                dataLines.append(String(format: strings.carbsMealOnly, timeStr, agoStr))
+            }
             if !isMorningGrace && now.timeIntervalSince(carbDate) / 3600 > 4 {
                 scenarios.append(.carbGap)
             }
@@ -251,8 +255,12 @@ public extension ShieldContent {
     /// A carb entry paired indivisibly with its timestamp. Mirrors
     /// `Glucose`'s atomic contract — `ShieldContent.carbs == nil` means
     /// render the no-data state, full stop.
+    ///
+    /// `grams` is `nil` when the source logged only that a meal occurred
+    /// (e.g. EasyView `auto_mode_event`) — the grace-period and carb-gap
+    /// checks are still based on `sampleDate`.
     struct Carbs: Sendable, Equatable {
-        public let grams: Int
+        public let grams: Int?
         public let sampleDate: Date
         public let agoMinutes: Int
     }
@@ -325,6 +333,9 @@ public extension ShieldContent {
         public let glucose: String
         public let glucoseNoData: String
         public let carbsEntry: String
+        /// Displayed when a meal was acknowledged without a gram count (e.g.
+        /// EasyView `auto_mode_event`). Format: time, ago string.
+        public let carbsMealOnly: String
         public let carbsNoData: String
         public let agoMinutes: String
         public let agoHoursMinutes: String
@@ -360,6 +371,7 @@ public extension ShieldContent {
                 glucose: bundle.localizedString(forKey: "shield.glucose %@ %@ %@", value: "%@ · %@ (%@ ago)", table: nil),
                 glucoseNoData: bundle.localizedString(forKey: "shield.glucoseNoData", value: "No glucose data available.", table: nil),
                 carbsEntry: bundle.localizedString(forKey: "shield.carbsEntry %d %@ %@", value: "%d g · %@ (%@ ago)", table: nil),
+                carbsMealOnly: bundle.localizedString(forKey: "shield.carbsMealOnly %@ %@", value: "Meal · %@ (%@ ago)", table: nil),
                 carbsNoData: bundle.localizedString(forKey: "shield.carbsNoData", value: "No carb data", table: nil),
                 agoMinutes: bundle.localizedString(forKey: "shield.agoMinutes %d", value: "%dm ago", table: nil),
                 agoHoursMinutes: bundle.localizedString(forKey: "shield.agoHoursMinutes %d %d", value: "%dh %dm ago", table: nil),

--- a/iOS/SharedKit/Sources/SharedKit/ShieldContent.swift
+++ b/iOS/SharedKit/Sources/SharedKit/ShieldContent.swift
@@ -51,6 +51,7 @@ public struct ShieldContent: Sendable {
         glucose: Double,
         glucoseFetchedAt: Date?,
         lastCarbGrams: Double?,
+        lastCarbLabel: String? = nil,
         lastCarbEntryAt: Date?,
         highGlucoseThreshold: Double,
         lowGlucoseThreshold: Double,
@@ -127,6 +128,7 @@ public struct ShieldContent: Sendable {
             let cMins = Int(now.timeIntervalSince(carbDate) / 60)
             self.carbs = Carbs(
                 grams: lastCarbGrams.map { Int($0) },
+                label: lastCarbLabel,
                 sampleDate: carbDate,
                 agoMinutes: cMins
             )
@@ -135,7 +137,8 @@ public struct ShieldContent: Sendable {
             if let grams = lastCarbGrams {
                 dataLines.append(String(format: strings.carbsEntry, Int(grams), timeStr, agoStr))
             } else {
-                dataLines.append(String(format: strings.carbsMealOnly, timeStr, agoStr))
+                let displayLabel = lastCarbLabel ?? strings.mealLabel
+                dataLines.append(String(format: strings.carbsMealOnly, displayLabel, timeStr, agoStr))
             }
             if !isMorningGrace && now.timeIntervalSince(carbDate) / 3600 > 4 {
                 scenarios.append(.carbGap)
@@ -259,8 +262,14 @@ public extension ShieldContent {
     /// `grams` is `nil` when the source logged only that a meal occurred
     /// (e.g. EasyView `auto_mode_event`) — the grace-period and carb-gap
     /// checks are still based on `sampleDate`.
+    ///
+    /// When `grams` is `nil`, `label` may carry a provider-supplied display
+    /// string (e.g. "B'fast"). Display surfaces should prefer `label` over a
+    /// generic fallback when available. Both may be `nil` simultaneously for
+    /// legacy or non-labelling sources.
     struct Carbs: Sendable, Equatable {
         public let grams: Int?
+        public let label: String?
         public let sampleDate: Date
         public let agoMinutes: Int
     }
@@ -334,8 +343,13 @@ public extension ShieldContent {
         public let glucoseNoData: String
         public let carbsEntry: String
         /// Displayed when a meal was acknowledged without a gram count (e.g.
-        /// EasyView `auto_mode_event`). Format: time, ago string.
+        /// EasyView `auto_mode_event`). Format: label, time, ago string.
+        /// The label arg receives `carbs.label` when available, or `mealLabel`
+        /// as a generic fallback.
         public let carbsMealOnly: String
+        /// Generic fallback label used in `carbsMealOnly` when no
+        /// provider-specific label is stored (e.g. "Meal" / "Maaltijd").
+        public let mealLabel: String
         public let carbsNoData: String
         public let agoMinutes: String
         public let agoHoursMinutes: String
@@ -371,7 +385,8 @@ public extension ShieldContent {
                 glucose: bundle.localizedString(forKey: "shield.glucose %@ %@ %@", value: "%@ · %@ (%@ ago)", table: nil),
                 glucoseNoData: bundle.localizedString(forKey: "shield.glucoseNoData", value: "No glucose data available.", table: nil),
                 carbsEntry: bundle.localizedString(forKey: "shield.carbsEntry %d %@ %@", value: "%d g · %@ (%@ ago)", table: nil),
-                carbsMealOnly: bundle.localizedString(forKey: "shield.carbsMealOnly %@ %@", value: "Meal · %@ (%@ ago)", table: nil),
+                carbsMealOnly: bundle.localizedString(forKey: "shield.carbsMealOnly %@ %@ %@", value: "%@ · %@ (%@ ago)", table: nil),
+                mealLabel: bundle.localizedString(forKey: "shield.mealLabel", value: "Meal", table: nil),
                 carbsNoData: bundle.localizedString(forKey: "shield.carbsNoData", value: "No carb data", table: nil),
                 agoMinutes: bundle.localizedString(forKey: "shield.agoMinutes %d", value: "%dm ago", table: nil),
                 agoHoursMinutes: bundle.localizedString(forKey: "shield.agoHoursMinutes %d %d", value: "%dh %dm ago", table: nil),

--- a/iOS/SharedKit/Sources/SharedKit/UnifiedDataReader.swift
+++ b/iOS/SharedKit/Sources/SharedKit/UnifiedDataReader.swift
@@ -48,6 +48,9 @@ public enum DataSourceKeys {
     public static let easyViewGlucoseSampleAt = "easyViewGlucoseSampleAt"
     public static let easyViewCarbs = "easyViewCarbs"
     public static let easyViewCarbsSampleAt = "easyViewCarbsSampleAt"
+    public static let easyViewCarbsLabel = "easyViewCarbsLabel"
+
+    public static let demoCarbsLabel = "demoCarbsLabel"
 
     public static let healthKitEnabled = "healthKitEnabled"
     public static let nightscoutEnabled = "nightscoutEnabled"
@@ -71,11 +74,17 @@ public struct CarbsReading: Sendable, Equatable {
     /// Gram count of the carb entry, or `nil` when the source logged a meal
     /// acknowledgment without a carb amount (e.g. EasyView `auto_mode_event`).
     public let grams: Double?
+    /// Provider-supplied display label for a meal-only entry (e.g. "B'fast",
+    /// "Lunch"). Non-nil only when `grams` is nil. Stored at write time by
+    /// the provider so it is already localized. SharedKit treats this as an
+    /// opaque string — it never inspects or transforms it.
+    public let label: String?
     public let sampleAt: Date
     public let source: DataSource
 
-    public init(grams: Double?, sampleAt: Date, source: DataSource) {
+    public init(grams: Double?, label: String? = nil, sampleAt: Date, source: DataSource) {
         self.grams = grams
+        self.label = label
         self.sampleAt = sampleAt
         self.source = source
     }
@@ -175,7 +184,8 @@ public enum UnifiedDataReader {
         guard let date = defaults.iso8601(forKey: carbsDateKey(for: source)) else { return nil }
         let value = defaults.double(forKey: carbsValueKey(for: source))
         let grams: Double? = value > 0 ? value : nil
-        return CarbsReading(grams: grams, sampleAt: date, source: source)
+        let label = grams == nil ? defaults.string(forKey: carbsLabelKey(for: source)) : nil
+        return CarbsReading(grams: grams, label: label, sampleAt: date, source: source)
     }
 
     public static func glucoseValueKey(for source: DataSource) -> String {
@@ -211,6 +221,17 @@ public enum UnifiedDataReader {
         case .nightscout: return DataSourceKeys.nightscoutCarbsSampleAt
         case .easyView: return DataSourceKeys.easyViewCarbsSampleAt
         case .demo: return DataSourceKeys.demoCarbsSampleAt
+        }
+    }
+
+    /// Key where a provider-supplied meal label string is stored for a source.
+    /// Only written for sources that support label-only meal entries (EasyView, Demo).
+    public static func carbsLabelKey(for source: DataSource) -> String {
+        switch source {
+        case .healthKit: return "healthKitCarbsLabel"
+        case .nightscout: return "nightscoutCarbsLabel"
+        case .easyView: return DataSourceKeys.easyViewCarbsLabel
+        case .demo: return DataSourceKeys.demoCarbsLabel
         }
     }
 }

--- a/iOS/SharedKit/Sources/SharedKit/UnifiedDataReader.swift
+++ b/iOS/SharedKit/Sources/SharedKit/UnifiedDataReader.swift
@@ -68,11 +68,13 @@ public struct GlucoseReading: Sendable, Equatable {
 }
 
 public struct CarbsReading: Sendable, Equatable {
-    public let grams: Double
+    /// Gram count of the carb entry, or `nil` when the source logged a meal
+    /// acknowledgment without a carb amount (e.g. EasyView `auto_mode_event`).
+    public let grams: Double?
     public let sampleAt: Date
     public let source: DataSource
 
-    public init(grams: Double, sampleAt: Date, source: DataSource) {
+    public init(grams: Double?, sampleAt: Date, source: DataSource) {
         self.grams = grams
         self.sampleAt = sampleAt
         self.source = source
@@ -166,9 +168,14 @@ public enum UnifiedDataReader {
 
     public static func carbsReading(source: DataSource, from defaults: UserDefaults?) -> CarbsReading? {
         guard let defaults else { return nil }
+        // The date key is the authoritative sentinel: if it's present an entry
+        // was recorded. The value key holds grams when > 0, or 0 when the
+        // source logged a meal acknowledgment without a carb count (e.g.
+        // EasyView auto_mode_event). In the latter case grams is nil.
+        guard let date = defaults.iso8601(forKey: carbsDateKey(for: source)) else { return nil }
         let value = defaults.double(forKey: carbsValueKey(for: source))
-        guard value > 0, let date = defaults.iso8601(forKey: carbsDateKey(for: source)) else { return nil }
-        return CarbsReading(grams: value, sampleAt: date, source: source)
+        let grams: Double? = value > 0 ? value : nil
+        return CarbsReading(grams: grams, sampleAt: date, source: source)
     }
 
     public static func glucoseValueKey(for source: DataSource) -> String {

--- a/iOS/SharedKit/Sources/SharedKit/WidgetEasyViewRefresh.swift
+++ b/iOS/SharedKit/Sources/SharedKit/WidgetEasyViewRefresh.swift
@@ -84,7 +84,7 @@ public enum WidgetEasyViewRefresh {
                 defaults: defaults,
                 valueKey: UnifiedDataReader.carbsValueKey(for: .easyView),
                 dateKey: UnifiedDataReader.carbsDateKey(for: .easyView),
-                value: carbs.grams,
+                value: carbs.grams ?? 0.0,
                 date: carbs.date
             )
         }

--- a/iOS/SharedKit/Sources/SharedKit/WidgetEasyViewRefresh.swift
+++ b/iOS/SharedKit/Sources/SharedKit/WidgetEasyViewRefresh.swift
@@ -84,7 +84,9 @@ public enum WidgetEasyViewRefresh {
                 defaults: defaults,
                 valueKey: UnifiedDataReader.carbsValueKey(for: .easyView),
                 dateKey: UnifiedDataReader.carbsDateKey(for: .easyView),
+                labelKey: UnifiedDataReader.carbsLabelKey(for: .easyView),
                 value: carbs.grams ?? 0.0,
+                label: carbs.label,
                 date: carbs.date
             )
         }
@@ -96,7 +98,9 @@ public enum WidgetEasyViewRefresh {
         defaults: UserDefaults,
         valueKey: String,
         dateKey: String,
+        labelKey: String? = nil,
         value: Double,
+        label: String? = nil,
         date: Date
     ) {
         if let existingIso = defaults.string(forKey: dateKey),
@@ -106,5 +110,12 @@ public enum WidgetEasyViewRefresh {
         }
         defaults.set(value, forKey: valueKey)
         defaults.set(date.ISO8601Format(), forKey: dateKey)
+        if let labelKey {
+            if let label {
+                defaults.set(label, forKey: labelKey)
+            } else {
+                defaults.removeObject(forKey: labelKey)
+            }
+        }
     }
 }

--- a/iOS/SharedKit/Sources/SharedKit/WidgetTileViews.swift
+++ b/iOS/SharedKit/Sources/SharedKit/WidgetTileViews.swift
@@ -169,7 +169,7 @@ private func widgetGlucoseValue(_ c: ShieldContent) -> String {
 }
 
 private func widgetCarbsValue(_ c: ShieldContent) -> String {
-    c.carbs.map { "\($0.grams)" } ?? "--"
+    c.carbs.map { $0.grams.map { "\($0)" } ?? "·" } ?? "--"
 }
 
 // MARK: - Small tile

--- a/iOS/SharedKit/Sources/SharedKit/WidgetTileViews.swift
+++ b/iOS/SharedKit/Sources/SharedKit/WidgetTileViews.swift
@@ -169,11 +169,13 @@ private func widgetGlucoseValue(_ c: ShieldContent) -> String {
 }
 
 private func widgetCarbsValue(_ c: ShieldContent) -> String {
-    c.carbs.map { $0.grams.map { "\($0)" } ?? "·" } ?? "--"
+    guard let carbs = c.carbs else { return "--" }
+    if let grams = carbs.grams { return "\(grams)" }
+    return carbs.label ?? "·"
 }
 
 /// Returns "g" when a gram count is available, empty string for meal-only
-/// entries so the unit label doesn't appear next to the "·" placeholder.
+/// entries (labelled or unlabelled) so the unit label doesn't crowd the label.
 private func widgetCarbsUnit(_ c: ShieldContent) -> String {
     c.carbs?.grams != nil ? "g" : ""
 }

--- a/iOS/SharedKit/Sources/SharedKit/WidgetTileViews.swift
+++ b/iOS/SharedKit/Sources/SharedKit/WidgetTileViews.swift
@@ -180,6 +180,45 @@ private func widgetCarbsUnit(_ c: ShieldContent) -> String {
     c.carbs?.grams != nil ? "g" : ""
 }
 
+/// Computes the text label for the carbs inline accessory widget.
+/// - Glucose mode: the formatted glucose value with no unit suffix.
+/// - Carbs with grams: "Xg".
+/// - Meal-only carbs (no grams): compact age "X min" / "X h".
+private func widgetInlineCarbsText(
+    _ c: ShieldContent,
+    content: WidgetTileContent,
+    forGlucose: Bool
+) -> String {
+    if forGlucose { return c.glucose?.formatted ?? "--" }
+    if c.carbs != nil && c.carbs?.grams == nil {
+        let (val, unit) = widgetCarbsMealAgoComponents(from: content.carbDate, relativeTo: content.referenceDate)
+        return unit.isEmpty ? val : "\(val) \(unit)"
+    }
+    return "\(widgetCarbsValue(c))\(widgetCarbsUnit(c))"
+}
+
+/// Breaks the carb-entry age into a `(value, unit)` pair for the circular
+/// accessory widget's two-line layout.
+/// - < 1 hour → `("X", "min")`
+/// - ≥ 1 hour → `("X", "h")`
+/// Falls back to `("--", "")` when the date is missing or in the future.
+/// Uses `referenceDate` when set (screenshot path); otherwise `Date()`.
+private func widgetCarbsMealAgoComponents(
+    from date: Date?,
+    relativeTo referenceDate: Date?
+) -> (value: String, unit: String) {
+    let minUnit = String(localized: "widget.carbsMeal.minuteUnit", bundle: .module)
+    let hourUnit = String(localized: "widget.carbsMeal.hourUnit", bundle: .module)
+    guard let date else { return ("--", "") }
+    let interval = (referenceDate ?? Date()).timeIntervalSince(date)
+    guard interval > 0 else { return ("<1", minUnit) }
+    if interval < 3600 {
+        return ("\(max(1, Int(interval / 60)))", minUnit)
+    } else {
+        return ("\(Int(interval / 3600))", hourUnit)
+    }
+}
+
 // MARK: - Small tile
 
 public struct SmallWidgetTile: View {
@@ -308,12 +347,20 @@ public struct AccessoryCircularTile: View {
 
     public var body: some View {
         let c = content.shieldContent
+        // For a meal-only carb entry (grams == nil, but a reading exists)
+        // the label is not glanceable in the tight circular frame — show
+        // how long ago the meal was recorded instead, split across the
+        // two-line value/unit layout the tile uses for glucose.
+        let isCarbMealOnly = !forGlucose && c.carbs != nil && c.carbs?.grams == nil
+        let (agoValue, agoUnit) = isCarbMealOnly
+            ? widgetCarbsMealAgoComponents(from: content.carbDate, relativeTo: content.referenceDate)
+            : ("", "")
         VStack(spacing: -2) {
-            Text(forGlucose ? widgetGlucoseValue(c) : widgetCarbsValue(c))
+            Text(isCarbMealOnly ? agoValue : (forGlucose ? widgetGlucoseValue(c) : widgetCarbsValue(c)))
                 .font(.system(.title2, design: .rounded).bold())
                 .minimumScaleFactor(0.6)
                 .lineLimit(1)
-            Text(forGlucose ? c.glucoseUnit.shortLabel : widgetCarbsUnit(c))
+            Text(isCarbMealOnly ? agoUnit : (forGlucose ? c.glucoseUnit.shortLabel : widgetCarbsUnit(c)))
                 .font(.system(.caption, design: .rounded))
         }
         .multilineTextAlignment(.center)
@@ -390,11 +437,10 @@ public struct AccessoryInlineTile: View {
         let icon = needsAttention ? "exclamationmark.triangle" : "checkmark.circle"
         // Inline is space-constrained on the Lock Screen so we drop the
         // unit suffix from glucose — the value alone (e.g. "115" or "6.4")
-        // is what the user glances for. Carbs always carry the "g" suffix
-        // because the bare number reads as ambiguous.
-        let text: String = forGlucose
-            ? (c.glucose?.formatted ?? "--")
-            : "\(widgetCarbsValue(c))\(widgetCarbsUnit(c))"
+        // is what the user glances for. Carbs carry the "g" suffix when a
+        // gram count is present. For meal-only entries (no grams) we show
+        // the age ("5 min", "2 h") — the label is not glanceable here.
+        let text: String = widgetInlineCarbsText(c, content: content, forGlucose: forGlucose)
         Label(text, systemImage: icon)
     }
 }

--- a/iOS/SharedKit/Sources/SharedKit/WidgetTileViews.swift
+++ b/iOS/SharedKit/Sources/SharedKit/WidgetTileViews.swift
@@ -172,6 +172,12 @@ private func widgetCarbsValue(_ c: ShieldContent) -> String {
     c.carbs.map { $0.grams.map { "\($0)" } ?? "·" } ?? "--"
 }
 
+/// Returns "g" when a gram count is available, empty string for meal-only
+/// entries so the unit label doesn't appear next to the "·" placeholder.
+private func widgetCarbsUnit(_ c: ShieldContent) -> String {
+    c.carbs?.grams != nil ? "g" : ""
+}
+
 // MARK: - Small tile
 
 public struct SmallWidgetTile: View {
@@ -202,7 +208,7 @@ public struct SmallWidgetTile: View {
 
             widgetValueWithUnit(
                 value: widgetCarbsValue(c),
-                unit: "g",
+                unit: widgetCarbsUnit(c),
                 valueFont: .system(.title, design: .rounded).bold(),
                 unitFont: .system(.caption, design: .rounded).weight(.semibold)
             )
@@ -253,7 +259,7 @@ public struct MediumWidgetTile: View {
             VStack(alignment: .leading, spacing: 4) {
                 widgetValueWithUnit(
                     value: widgetCarbsValue(c),
-                    unit: "g",
+                    unit: widgetCarbsUnit(c),
                     valueFont: .system(size: 44, weight: .bold, design: .rounded),
                     unitFont: .system(size: 18, weight: .semibold, design: .rounded)
                 )
@@ -305,7 +311,7 @@ public struct AccessoryCircularTile: View {
                 .font(.system(.title2, design: .rounded).bold())
                 .minimumScaleFactor(0.6)
                 .lineLimit(1)
-            Text(forGlucose ? c.glucoseUnit.shortLabel : "g")
+            Text(forGlucose ? c.glucoseUnit.shortLabel : widgetCarbsUnit(c))
                 .font(.system(.caption, design: .rounded))
         }
         .multilineTextAlignment(.center)
@@ -350,7 +356,7 @@ public struct AccessoryRectangularTile: View {
                 HStack(spacing: 2) {
                     Text(widgetCarbsValue(c))
                         .font(.system(.headline, design: .rounded).bold())
-                    Text("g")
+                    Text(widgetCarbsUnit(c))
                         .font(.caption2)
                 }
                 .lineLimit(1)
@@ -386,7 +392,7 @@ public struct AccessoryInlineTile: View {
         // because the bare number reads as ambiguous.
         let text: String = forGlucose
             ? (c.glucose?.formatted ?? "--")
-            : "\(widgetCarbsValue(c))g"
+            : "\(widgetCarbsValue(c))\(widgetCarbsUnit(c))"
         Label(text, systemImage: icon)
     }
 }

--- a/iOS/SharedKit/Tests/SharedKitTests/ShieldContentAttentionTests.swift
+++ b/iOS/SharedKit/Tests/SharedKitTests/ShieldContentAttentionTests.swift
@@ -20,6 +20,7 @@ final class ShieldContentAttentionTests: XCTestCase {
         glucose: "%@ · %@ (%@ ago)",
         glucoseNoData: "No glucose data",
         carbsEntry: "%d g · %@ (%@ ago)",
+        carbsMealOnly: "Meal · %@ (%@ ago)",
         carbsNoData: "No carb data",
         agoMinutes: "%dm",
         agoHoursMinutes: "%dh %dm",
@@ -75,6 +76,22 @@ final class ShieldContentAttentionTests: XCTestCase {
     }
 
     // MARK: - Attention (the badge must match these)
+
+    /// A meal acknowledgment without a gram count (lastCarbEntryAt set but
+    /// lastCarbGrams nil) must NOT fire `.noCarbData`. The child told the
+    /// system they ate — GluWink must respect that signal.
+    func testMealOnlyEntryIsNotNoCarbData() {
+        let now = morning
+        let content = make(
+            glucoseFetchedAt: now.addingTimeInterval(-5 * 60),
+            lastCarbGrams: nil,
+            lastCarbEntryAt: now.addingTimeInterval(-30 * 60),
+            now: now
+        )
+        XCTAssertFalse(content.needsAttention, "meal-only entry within grace window must not need attention")
+        XCTAssertNotNil(content.carbs, "carbs must be non-nil when a date is present, even without grams")
+        XCTAssertNil(content.carbs?.grams, "carbs.grams must be nil when no gram count was recorded")
+    }
 
     func testNoCarbDataEverIsAttention() {
         let now = morning

--- a/iOS/SharedKit/Tests/SharedKitTests/ShieldContentAttentionTests.swift
+++ b/iOS/SharedKit/Tests/SharedKitTests/ShieldContentAttentionTests.swift
@@ -20,7 +20,8 @@ final class ShieldContentAttentionTests: XCTestCase {
         glucose: "%@ · %@ (%@ ago)",
         glucoseNoData: "No glucose data",
         carbsEntry: "%d g · %@ (%@ ago)",
-        carbsMealOnly: "Meal · %@ (%@ ago)",
+        carbsMealOnly: "%@ · %@ (%@ ago)",
+        mealLabel: "Meal",
         carbsNoData: "No carb data",
         agoMinutes: "%dm",
         agoHoursMinutes: "%dh %dm",
@@ -42,6 +43,7 @@ final class ShieldContentAttentionTests: XCTestCase {
         glucose: Double = 6.5,
         glucoseFetchedAt: Date?,
         lastCarbGrams: Double? = 20,
+        lastCarbLabel: String? = nil,
         lastCarbEntryAt: Date?,
         now: Date
     ) -> ShieldContent {
@@ -49,6 +51,7 @@ final class ShieldContentAttentionTests: XCTestCase {
             glucose: glucose,
             glucoseFetchedAt: glucoseFetchedAt,
             lastCarbGrams: lastCarbGrams,
+            lastCarbLabel: lastCarbLabel,
             lastCarbEntryAt: lastCarbEntryAt,
             highGlucoseThreshold: 14.0,
             lowGlucoseThreshold: 4.0,
@@ -85,12 +88,14 @@ final class ShieldContentAttentionTests: XCTestCase {
         let content = make(
             glucoseFetchedAt: now.addingTimeInterval(-5 * 60),
             lastCarbGrams: nil,
+            lastCarbLabel: "B'fast",
             lastCarbEntryAt: now.addingTimeInterval(-30 * 60),
             now: now
         )
         XCTAssertFalse(content.needsAttention, "meal-only entry within grace window must not need attention")
         XCTAssertNotNil(content.carbs, "carbs must be non-nil when a date is present, even without grams")
         XCTAssertNil(content.carbs?.grams, "carbs.grams must be nil when no gram count was recorded")
+        XCTAssertEqual(content.carbs?.label, "B'fast", "label must be threaded through to ShieldContent.Carbs")
     }
 
     func testNoCarbDataEverIsAttention() {

--- a/iOS/SharedKit/Tests/SharedKitTests/UnifiedDataReaderTests.swift
+++ b/iOS/SharedKit/Tests/SharedKitTests/UnifiedDataReaderTests.swift
@@ -61,7 +61,35 @@ final class UnifiedDataReaderTests: XCTestCase {
 
         let reading = UnifiedDataReader.currentCarbsReading(from: defaults)
         XCTAssertEqual(reading?.source, .demo)
-        XCTAssertEqual(reading?.grams, 30)
+        XCTAssertEqual(reading?.grams, 30.0)
+    }
+
+    // MARK: - Meal-only entries (grams == nil)
+
+    /// A stored date with value == 0 represents a meal-acknowledgment without
+    /// a gram count (e.g. EasyView `auto_mode_event`). The reader must return
+    /// a non-nil `CarbsReading` with `grams: nil`.
+    func testMealOnlyEntryReturnsReadingWithNilGrams() {
+        defaults.set(true, forKey: DataSourceKeys.easyViewEnabled)
+        writeCarbs(source: .easyView, value: 0, minutesAgo: 30)
+
+        let reading = UnifiedDataReader.currentCarbsReading(from: defaults)
+        XCTAssertNotNil(reading, "A stored date with 0g value must still produce a reading")
+        XCTAssertNil(reading?.grams, "0g stored value must map to grams: nil")
+        XCTAssertEqual(reading?.source, .easyView)
+    }
+
+    /// A meal-only entry still participates in the freshness competition.
+    func testMealOnlyEntryWinsWhenFresherThanGramEntry() {
+        defaults.set(true, forKey: DataSourceKeys.easyViewEnabled)
+        defaults.set(true, forKey: DataSourceKeys.nightscoutEnabled)
+
+        writeCarbs(source: .easyView, value: 0, minutesAgo: 30)   // meal-only, recent
+        writeCarbs(source: .nightscout, value: 25, minutesAgo: 60) // gram entry, older
+
+        let reading = UnifiedDataReader.currentCarbsReading(from: defaults)
+        XCTAssertEqual(reading?.source, .easyView)
+        XCTAssertNil(reading?.grams)
     }
 
     func testDemoModeReturnsNilWhenDemoHasNoStoredGlucose() {

--- a/iOS/SharedKit/Tests/SharedKitTests/UnifiedDataReaderTests.swift
+++ b/iOS/SharedKit/Tests/SharedKitTests/UnifiedDataReaderTests.swift
@@ -79,6 +79,16 @@ final class UnifiedDataReaderTests: XCTestCase {
         XCTAssertEqual(reading?.source, .easyView)
     }
 
+    /// A stored label is returned as part of the CarbsReading when grams is nil.
+    func testMealOnlyEntryReturnsStoredLabel() {
+        defaults.set(true, forKey: DataSourceKeys.easyViewEnabled)
+        writeCarbs(source: .easyView, value: 0, minutesAgo: 30, label: "B'fast")
+
+        let reading = UnifiedDataReader.currentCarbsReading(from: defaults)
+        XCTAssertNil(reading?.grams)
+        XCTAssertEqual(reading?.label, "B'fast")
+    }
+
     /// A meal-only entry still participates in the freshness competition.
     func testMealOnlyEntryWinsWhenFresherThanGramEntry() {
         defaults.set(true, forKey: DataSourceKeys.easyViewEnabled)
@@ -191,9 +201,12 @@ final class UnifiedDataReaderTests: XCTestCase {
         defaults.set(date.ISO8601Format(), forKey: UnifiedDataReader.glucoseDateKey(for: source))
     }
 
-    private func writeCarbs(source: DataSource, value: Double, minutesAgo: Double) {
+    private func writeCarbs(source: DataSource, value: Double, minutesAgo: Double, label: String? = nil) {
         let date = Date().addingTimeInterval(-minutesAgo * 60)
         defaults.set(value, forKey: UnifiedDataReader.carbsValueKey(for: source))
         defaults.set(date.ISO8601Format(), forKey: UnifiedDataReader.carbsDateKey(for: source))
+        if let label {
+            defaults.set(label, forKey: UnifiedDataReader.carbsLabelKey(for: source))
+        }
     }
 }

--- a/iOS/ShieldConfig/ShieldConfigurationExtension.swift
+++ b/iOS/ShieldConfig/ShieldConfigurationExtension.swift
@@ -50,6 +50,7 @@ class ShieldConfigurationExtension: ShieldConfigurationDataSource {
             glucose: glucoseReading?.mmol ?? 0,
             glucoseFetchedAt: glucoseReading?.sampleAt,
             lastCarbGrams: carbsReading?.grams,
+            lastCarbLabel: carbsReading?.label,
             lastCarbEntryAt: carbsReading?.sampleAt,
             highGlucoseThreshold: ThresholdResolver.highGlucose(defaults: defaults, fallback: Self.fallbackHighGlucose),
             lowGlucoseThreshold: ThresholdResolver.lowGlucose(defaults: defaults, fallback: Self.fallbackLowGlucose),

--- a/iOS/StatusWidget/StatusWidget.swift
+++ b/iOS/StatusWidget/StatusWidget.swift
@@ -55,6 +55,7 @@ private enum EntryBuilder {
             glucose: glucoseReading?.mmol ?? 0,
             glucoseFetchedAt: glucoseDate,
             lastCarbGrams: carbsReading?.grams,
+            lastCarbLabel: carbsReading?.label,
             lastCarbEntryAt: carbDate,
             highGlucoseThreshold: ThresholdResolver.highGlucose(defaults: defaults, fallback: fallbackHighGlucose),
             lowGlucoseThreshold: ThresholdResolver.lowGlucose(defaults: defaults, fallback: fallbackLowGlucose),

--- a/iOS/WatchApp/WatchContentView.swift
+++ b/iOS/WatchApp/WatchContentView.swift
@@ -51,7 +51,7 @@ struct WatchContentView: View {
     private func carbsValueText(for content: ShieldContent) -> String {
         guard let carbs = content.carbs else { return "--" }
         if let grams = carbs.grams { return "\(grams) g" }
-        return "·"
+        return carbs.label ?? "·"
     }
 
     private func relativeTimeText(from date: Date?) -> Text {

--- a/iOS/WatchApp/WatchContentView.swift
+++ b/iOS/WatchApp/WatchContentView.swift
@@ -49,7 +49,9 @@ struct WatchContentView: View {
     }
 
     private func carbsValueText(for content: ShieldContent) -> String {
-        "\(content.carbs.map { String($0.grams) } ?? "--") g"
+        guard let carbs = content.carbs else { return "--" }
+        if let grams = carbs.grams { return "\(grams) g" }
+        return "·"
     }
 
     private func relativeTimeText(from date: Date?) -> Text {

--- a/iOS/WatchApp/WatchEasyViewManager.swift
+++ b/iOS/WatchApp/WatchEasyViewManager.swift
@@ -91,7 +91,11 @@ final class WatchEasyViewManager {
             }
             if let entry = latest.carbs {
                 WatchDataManager.storeCarbs(grams: entry.grams, at: entry.date)
-                logger.info("Watch EasyView carbs: \(String(format: "%.0f", entry.grams))g")
+                if let g = entry.grams {
+                    logger.info("Watch EasyView carbs: \(String(format: "%.0f", g))g")
+                } else {
+                    logger.info("Watch EasyView meal event (no gram count) at \(entry.date)")
+                }
             }
         } catch EasyViewClient.ClientError.sessionExpired {
             logger.warning("Watch EasyView session expired — phone will refresh on next foreground")

--- a/iOS/WatchApp/WatchEasyViewManager.swift
+++ b/iOS/WatchApp/WatchEasyViewManager.swift
@@ -90,7 +90,7 @@ final class WatchEasyViewManager {
                 logger.info("Watch EasyView glucose: \(String(format: "%.1f", sample.mmol)) mmol/L")
             }
             if let entry = latest.carbs {
-                WatchDataManager.storeCarbs(grams: entry.grams, at: entry.date)
+                WatchDataManager.storeCarbs(grams: entry.grams, label: entry.label, at: entry.date)
                 if let g = entry.grams {
                     logger.info("Watch EasyView carbs: \(String(format: "%.0f", g))g")
                 } else {

--- a/iOS/WatchApp/WatchScreenshotHarness.swift
+++ b/iOS/WatchApp/WatchScreenshotHarness.swift
@@ -100,6 +100,8 @@ enum WatchScreenshotHarness {
         defaults.set(glucoseDate.ISO8601Format(), forKey: "glucoseFetchedAt")
         defaults.set(p.carbGrams, forKey: "lastCarbGrams")
         defaults.set(carbDate.ISO8601Format(), forKey: "lastCarbEntryAt")
+        // Screenshot presets always have gram counts; clear any stale label from a previous demo run.
+        defaults.removeObject(forKey: "lastCarbLabel")
 
         // Flip mock-mode on so the resolver ignores any stale Nightscout
         // config that happened to be synced from the phone in a past run,

--- a/iOS/WatchShared/WatchDataManager.swift
+++ b/iOS/WatchShared/WatchDataManager.swift
@@ -32,6 +32,12 @@ enum WatchDataManager {
         let lastCarbGrams = bridgeMockDouble(forKey: "lastCarbGrams", bridge: bridgeContext)
             ?? (defaults?.double(forKey: "lastCarbGrams") ?? 0)
         let lastCarbEntryAt = bridgeOrDefaultsDate(forKey: "lastCarbEntryAt", bridge: bridgeContext)
+        let lastCarbLabel: String? = {
+            if (bridgeContext?["mockModeEnabled"] as? Bool) == true {
+                return bridgeContext?["lastCarbLabel"] as? String
+            }
+            return defaults?.string(forKey: "lastCarbLabel")
+        }()
 
         let unit: GlucoseUnit = (bridgeContext?["glucoseUnit"] as? String)
             .flatMap { GlucoseUnit(rawValue: $0) }
@@ -56,6 +62,7 @@ enum WatchDataManager {
             glucose: glucose,
             glucoseFetchedAt: glucoseFetchedAt,
             lastCarbGrams: lastCarbGrams > 0 ? lastCarbGrams : nil,
+            lastCarbLabel: lastCarbGrams > 0 ? nil : lastCarbLabel,
             lastCarbEntryAt: lastCarbEntryAt,
             highGlucoseThreshold: high,
             lowGlucoseThreshold: low,
@@ -121,10 +128,15 @@ enum WatchDataManager {
     /// when the source logged only that a meal occurred (no carb count).
     /// 0 is stored as the sentinel value so `content(now:)` maps it back to
     /// `lastCarbGrams: nil` via its existing `> 0` guard.
-    static func storeCarbs(grams: Double?, at date: Date, force: Bool = false) {
+    static func storeCarbs(grams: Double?, label: String? = nil, at date: Date, force: Bool = false) {
         if !force, let existing = lastCarbEntryAt, date <= existing { return }
         defaults?.set(grams ?? 0.0, forKey: "lastCarbGrams")
         defaults?.set(date.ISO8601Format(), forKey: "lastCarbEntryAt")
+        if let label {
+            defaults?.set(label, forKey: "lastCarbLabel")
+        } else {
+            defaults?.removeObject(forKey: "lastCarbLabel")
+        }
     }
 
     // MARK: - EasyView config (synced from phone)
@@ -238,11 +250,18 @@ enum WatchDataManager {
             } else {
                 defaults?.removeObject(forKey: "lastCarbEntryAt")
             }
+
+            if let lastCarbLabel = context["lastCarbLabel"] as? String {
+                defaults?.set(lastCarbLabel, forKey: "lastCarbLabel")
+            } else {
+                defaults?.removeObject(forKey: "lastCarbLabel")
+            }
         } else {
             defaults?.removeObject(forKey: "currentGlucose")
             defaults?.removeObject(forKey: "glucoseFetchedAt")
             defaults?.removeObject(forKey: "lastCarbGrams")
             defaults?.removeObject(forKey: "lastCarbEntryAt")
+            defaults?.removeObject(forKey: "lastCarbLabel")
         }
 
         let customChecks = context["customChecks"] as? [String: [String]] ?? [:]

--- a/iOS/WatchShared/WatchDataManager.swift
+++ b/iOS/WatchShared/WatchDataManager.swift
@@ -117,9 +117,13 @@ enum WatchDataManager {
         defaults?.set(date.ISO8601Format(), forKey: "glucoseFetchedAt")
     }
 
-    static func storeCarbs(grams: Double, at date: Date, force: Bool = false) {
+    /// Store a carb or meal-acknowledgment sample. Pass `nil` for `grams`
+    /// when the source logged only that a meal occurred (no carb count).
+    /// 0 is stored as the sentinel value so `content(now:)` maps it back to
+    /// `lastCarbGrams: nil` via its existing `> 0` guard.
+    static func storeCarbs(grams: Double?, at date: Date, force: Bool = false) {
         if !force, let existing = lastCarbEntryAt, date <= existing { return }
-        defaults?.set(grams, forKey: "lastCarbGrams")
+        defaults?.set(grams ?? 0.0, forKey: "lastCarbGrams")
         defaults?.set(date.ISO8601Format(), forKey: "lastCarbEntryAt")
     }
 

--- a/iOS/WatchWidget/WatchComplications.swift
+++ b/iOS/WatchWidget/WatchComplications.swift
@@ -40,7 +40,7 @@ private func metricUnit(_ entry: WatchEntry) -> String {
     case .glucose:
         return entry.content.glucoseUnit.shortLabel
     case .carbs:
-        return "g"
+        return entry.content.carbs?.grams != nil ? "g" : ""
     }
 }
 
@@ -144,6 +144,7 @@ struct WatchRectangularEntryView: View {
         let content = entry.content
         let glucoseText = content.glucose?.formatted ?? "--"
         let carbsText = content.carbs.map { $0.grams.map { String($0) } ?? "·" } ?? "--"
+        let carbsUnit = content.carbs?.grams != nil ? "g" : ""
 
         VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 4) {
@@ -160,7 +161,7 @@ struct WatchRectangularEntryView: View {
             HStack(spacing: 4) {
                 Image(systemName: content.carbsNeedsAttention ? "exclamationmark.triangle.fill" : "checkmark.circle.fill")
                     .font(.caption.bold())
-                Text("\(carbsText) g")
+                Text(carbsUnit.isEmpty ? carbsText : "\(carbsText) \(carbsUnit)")
                     .font(.system(.headline, design: .rounded).bold())
                 Spacer(minLength: 4)
                 relativeAgoText(from: content.carbs?.sampleDate)

--- a/iOS/WatchWidget/WatchComplications.swift
+++ b/iOS/WatchWidget/WatchComplications.swift
@@ -31,7 +31,7 @@ private func metricValue(_ entry: WatchEntry) -> String {
     case .glucose:
         return entry.content.glucose?.formatted ?? "--"
     case .carbs:
-        return entry.content.carbs.map { String($0.grams) } ?? "--"
+        return entry.content.carbs.map { $0.grams.map { String($0) } ?? "·" } ?? "--"
     }
 }
 
@@ -143,7 +143,7 @@ struct WatchRectangularEntryView: View {
     var body: some View {
         let content = entry.content
         let glucoseText = content.glucose?.formatted ?? "--"
-        let carbsText = content.carbs.map { String($0.grams) } ?? "--"
+        let carbsText = content.carbs.map { $0.grams.map { String($0) } ?? "·" } ?? "--"
 
         VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 4) {

--- a/iOS/WatchWidget/WatchComplications.swift
+++ b/iOS/WatchWidget/WatchComplications.swift
@@ -31,7 +31,9 @@ private func metricValue(_ entry: WatchEntry) -> String {
     case .glucose:
         return entry.content.glucose?.formatted ?? "--"
     case .carbs:
-        return entry.content.carbs.map { $0.grams.map { String($0) } ?? "·" } ?? "--"
+        guard let carbs = entry.content.carbs else { return "--" }
+        if let grams = carbs.grams { return String(grams) }
+        return carbs.label ?? "·"
     }
 }
 
@@ -143,7 +145,11 @@ struct WatchRectangularEntryView: View {
     var body: some View {
         let content = entry.content
         let glucoseText = content.glucose?.formatted ?? "--"
-        let carbsText = content.carbs.map { $0.grams.map { String($0) } ?? "·" } ?? "--"
+        let carbsText: String = {
+            guard let carbs = content.carbs else { return "--" }
+            if let grams = carbs.grams { return String(grams) }
+            return carbs.label ?? "·"
+        }()
         let carbsUnit = content.carbs?.grams != nil ? "g" : ""
 
         VStack(alignment: .leading, spacing: 4) {


### PR DESCRIPTION
## Summary

EasyView (and future providers) can log a meal event with a timestamp but no carbohydrate count. Previously these were stored as `grams: nil` with no further context, causing displays to fall back to a "·" dot or a generic "Meal" string.

This PR replaces that with an explicit **localized label** stored at write time by the data provider:

- `EasyViewClient` maps `auto_mode_event` slot indices (`0–3`) to localized strings (`easyview.carbLabel.{breakfast,lunch,dinner,snack,meal}`) via SharedKit's bundle, so the label is display-ready everywhere without complex bundle-passing.
- `CarbsReading` and `ShieldContent.Carbs` each gain a `label: String?` field. SharedKit treats it as an opaque string — no inspection, no transformation.
- **Demo mode** replaces the old boolean "meal only" toggle with a free-form `TextField`, letting testers simulate any future provider's arbitrary labels.

## What changes

### Data layer (SharedKit)
- `CarbsReading.label: String?` + `UnifiedDataReader.carbsLabelKey(for:)` — per-source storage key
- `ShieldContent.Carbs.label` + `lastCarbLabel: String?` parameter on `ShieldContent.init`
- `EasyViewClient.CarbEntry.label` — populated at parse time from `auto_mode_event` slot index
- `WidgetEasyViewRefresh` threads the label into the App Group write

### App / Watch / Extensions
- `SharedDataManager.saveCarbs` persists and clears the label key; all `saveEasyViewCarbs` / `saveDemoCarbs` / `saveHealthKitCarbs` signatures updated
- All `ShieldContent.init` call sites pass `lastCarbLabel: carbsReading?.label`
- `HomeView`, `WatchContentView`, `WatchComplications` display the label when `grams` is `nil`
- `WatchDataManager` / `WatchSessionManager` / `WatchEasyViewManager` sync the label to the Watch
- `MockDataSettingsView`: free-form label `TextField` replaces the old boolean toggle
- `ScreenshotHarness` / `WatchScreenshotHarness` clear stale label keys when seeding gram-only data

### Lock screen widgets
- **Circular + inline** accessory widgets: meal-only entries show the age (`"5 / min"`, `"2 / uur"`) instead of the label — more glanceable in the compact frame. Units are localized: EN `hour` / NL `uur`, both `min`.
- **Rectangular** widget: unchanged — label + time-ago column gives full context in the wider layout.

### Tests
- `ShieldContentAttentionTests`: fixture updated to 3-arg `carbsMealOnly` format; `testMealOnlyEntryIsNotNoCarbData` passes and asserts the label
- `UnifiedDataReaderTests`: `writeCarbs()` helper accepts optional label; new `testMealOnlyEntryReturnsStoredLabel`

Closes #145