### PR TITLE
fix(shield): prevent shields from arming when shielding is disabled

### DIFF
--- a/iOS/App/SettingsView.swift
+++ b/iOS/App/SettingsView.swift
@@ -225,7 +225,7 @@ struct SettingsView: View {
                     shieldingEnabled = SharedDataManager.shared.shieldingEnabled
                     demoEnabled = false
                     ShieldManager.shared.reevaluateShields()
-                    ActivityScheduler.shared.startMonitoring()
+                    ActivityScheduler.shared.stopMonitoring()
                     SharedDataManager.shared.refreshAttentionBadge()
                     WidgetCenter.shared.reloadAllTimelines()
                     showResetSuccess = true

--- a/iOS/App/ShieldManager.swift
+++ b/iOS/App/ShieldManager.swift
@@ -184,7 +184,7 @@ final class ShieldManager {
             logger.info("Pending re-arm time already passed — re-arming now")
             defaults?.removeObject(forKey: "rearmShieldsAt")
             defaults?.removeObject(forKey: "shieldDismissedAt")
-            applyShields()
+            reevaluateShields()
             return
         }
 
@@ -194,7 +194,7 @@ final class ShieldManager {
             self.logger.info("Re-arm timer fired — re-arming shields")
             self.defaults?.removeObject(forKey: "rearmShieldsAt")
             self.defaults?.removeObject(forKey: "shieldDismissedAt")
-            self.applyShields()
+            self.reevaluateShields()
         }
     }
 }

--- a/iOS/DeviceActivityMonitor/DeviceActivityMonitorExtension.swift
+++ b/iOS/DeviceActivityMonitor/DeviceActivityMonitorExtension.swift
@@ -34,8 +34,16 @@ class DeviceActivityMonitorExtension: DeviceActivityMonitor {
     }
 
     private func rearmIfNeeded(activity: DeviceActivityName) {
-        if defaults?.object(forKey: "shieldingEnabled") as? Bool == false {
+        guard defaults?.object(forKey: "shieldingEnabled") as? Bool == true else {
             logger.info("Shielding disabled — skipping re-arm")
+            return
+        }
+
+        let hasAnySource = [DataSourceKeys.healthKitEnabled, DataSourceKeys.nightscoutEnabled,
+                            DataSourceKeys.easyViewEnabled, DataSourceKeys.mockModeEnabled]
+            .contains { defaults?.bool(forKey: $0) == true }
+        guard hasAnySource else {
+            logger.info("No data source configured — skipping re-arm")
             return
         }
 


### PR DESCRIPTION
## Summary

- **DeviceActivityMonitorExtension**: `nil` (absent key after reset) was not caught by the `== false` guard — changed to `!= true` so absent is treated as disabled. Added a missing data-source check using `DataSourceKeys.*Enabled` flags.
- **ShieldManager.scheduleRearm()**: both the "already passed" branch and the timer callback called `applyShields()` directly, bypassing the `shieldingEnabled` guard — replaced with `reevaluateShields()`.
- **SettingsView reset path**: `ActivityScheduler.startMonitoring()` was called unconditionally after a full reset — changed to `stopMonitoring()` since shielding is off after a reset.

Closes #147

Made with [Cursor](https://cursor.com)