### PR TITLE
fix(ios): use .username textContentType on EasyView credential field

### DIFF
--- a/iOS/App/SettingsView.swift
+++ b/iOS/App/SettingsView.swift
@@ -1230,7 +1230,7 @@ struct EasyViewSettingsView: View {
                     String(localized: "settings.easyViewUsernamePlaceholder"),
                     text: $username
                 )
-                .textContentType(.emailAddress)
+                .textContentType(.username)
                 .keyboardType(.emailAddress)
                 .autocorrectionDisabled()
                 .textInputAutocapitalization(.never)

--- a/iOS/App/en.lproj/Localizable.strings
+++ b/iOS/App/en.lproj/Localizable.strings
@@ -175,8 +175,8 @@
 "settings.easyViewRequiresCredentials" = "Provide your EasyView username and password above before enabling.";
 "settings.easyViewVerifying" = "Verifying connection…";
 "settings.easyViewConfigHeader" = "Credentials";
-"settings.easyViewConfigFooter" = "Enter your EasyView account username and password.";
-"settings.easyViewUsernamePlaceholder" = "Username or email";
+"settings.easyViewConfigFooter" = "Enter your EasyView account email and password.";
+"settings.easyViewUsernamePlaceholder" = "Email";
 "settings.easyViewPasswordPlaceholder" = "Password";
 "settings.easyViewTest" = "Test Connection";
 "settings.easyViewTestSuccess" = "Connected";

--- a/iOS/App/nl.lproj/Localizable.strings
+++ b/iOS/App/nl.lproj/Localizable.strings
@@ -175,8 +175,8 @@
 "settings.easyViewRequiresCredentials" = "Vul hierboven eerst een gebruikersnaam en wachtwoord in voordat je dit kunt inschakelen.";
 "settings.easyViewVerifying" = "Verbinding controleren…";
 "settings.easyViewConfigHeader" = "Inloggegevens";
-"settings.easyViewConfigFooter" = "Vul je EasyView-gebruikersnaam en wachtwoord in.";
-"settings.easyViewUsernamePlaceholder" = "Gebruikersnaam of e-mailadres";
+"settings.easyViewConfigFooter" = "Vul je EasyView-e-mailadres en wachtwoord in.";
+"settings.easyViewUsernamePlaceholder" = "E-mailadres";
 "settings.easyViewPasswordPlaceholder" = "Wachtwoord";
 "settings.easyViewTest" = "Verbinding testen";
 "settings.easyViewTestSuccess" = "Verbonden";


### PR DESCRIPTION
## Summary

- Changes `.textContentType(.emailAddress)` → `.textContentType(.username)` on the EasyView username `TextField` so iOS and third-party password managers (1Password, Bitwarden, iCloud Keychain) recognise the username+password pair as a login form and offer to fill credentials saved for `easyview.medtrum.eu`.
- `.keyboardType(.emailAddress)` is kept — it only controls the keyboard layout, not autofill behaviour.
- Tightens placeholder and footer copy from "Username or email" / "username and password" to "Email" / "email and password" in both EN and NL, since EasyView always uses email as the login identifier.

## Test plan

- [ ] Open EasyView settings — keyboard should still show the email layout
- [ ] Tap the email field — password manager should offer to fill credentials saved for `easyview.medtrum.eu`
- [ ] Verify placeholder reads "Email" (EN) / "E-mailadres" (NL)

Closes #150

Made with [Cursor](https://cursor.com)