### PR TITLE
feat(settings): add per-scenario restore defaults in Attention Checks

### DIFF
--- a/iOS/App/SettingsView.swift
+++ b/iOS/App/SettingsView.swift
@@ -1413,6 +1413,7 @@ struct EasyViewSettingsView: View {
 struct AttentionChecksSettingsView: View {
     @State private var checks: [AttentionScenario: [String]]
     @State private var showRestoreAlert = false
+    @State private var restoreScenario: AttentionScenario?
 
     static let defaultChecks: [AttentionScenario: [String]] = {
         ShieldContent.Strings.fromPackage().scenarioChecks
@@ -1439,7 +1440,15 @@ struct AttentionChecksSettingsView: View {
                         Label(String(localized: "settings.addCheck"), systemImage: "plus.circle")
                     }
                 } header: {
-                    Text(scenarioName(scenario))
+                    HStack {
+                        Text(scenarioName(scenario))
+                        Spacer()
+                        Button(String(localized: "settings.restoreDefaults")) {
+                            restoreScenario = scenario
+                        }
+                        .textCase(nil)
+                        .font(.caption)
+                    }
                 }
             }
         }
@@ -1459,6 +1468,18 @@ struct AttentionChecksSettingsView: View {
             Button(String(localized: "settings.cancel"), role: .cancel) {}
         } message: {
             Text(String(localized: "settings.restoreDefaultsConfirm"))
+        }
+        .alert(
+            String(localized: "settings.restoreDefaults"),
+            isPresented: Binding(get: { restoreScenario != nil }, set: { if !$0 { restoreScenario = nil } })
+        ) {
+            Button(String(localized: "settings.restoreDefaults"), role: .destructive) {
+                if let s = restoreScenario { restore(s) }
+                restoreScenario = nil
+            }
+            Button(String(localized: "settings.cancel"), role: .cancel) { restoreScenario = nil }
+        } message: {
+            Text(String(localized: "settings.restoreScenarioDefaultsConfirm"))
         }
         .onDisappear { saveAll() }
     }
@@ -1508,6 +1529,11 @@ struct AttentionChecksSettingsView: View {
         for scenario in AttentionScenario.allCases {
             save(scenario)
         }
+    }
+
+    private func restore(_ scenario: AttentionScenario) {
+        SharedDataManager.shared.saveCustomChecks(nil, for: scenario)
+        checks[scenario] = Self.defaultChecks[scenario] ?? []
     }
 
     private func restoreDefaults() {

--- a/iOS/App/en.lproj/Localizable.strings
+++ b/iOS/App/en.lproj/Localizable.strings
@@ -127,6 +127,7 @@
 "settings.scenario.noGlucoseData" = "No Glucose Data";
 "settings.scenario.noCarbData" = "No Carb Data";
 "settings.addCheck" = "Add Check";
+"settings.restoreScenarioDefaultsConfirm" = "This will restore the built-in defaults for this scenario.";
 "settings.checkPlaceholder" = "Check text";
 "settings.restoreDefaults" = "Restore Defaults";
 "settings.restoreDefaultsConfirm" = "This will discard all custom checks and restore the built-in defaults.";

--- a/iOS/App/nl.lproj/Localizable.strings
+++ b/iOS/App/nl.lproj/Localizable.strings
@@ -127,6 +127,7 @@
 "settings.scenario.noGlucoseData" = "Geen Glucosedata";
 "settings.scenario.noCarbData" = "Geen KH-data";
 "settings.addCheck" = "Check Toevoegen";
+"settings.restoreScenarioDefaultsConfirm" = "De standaardchecks voor dit scenario worden hersteld.";
 "settings.checkPlaceholder" = "Checktekst";
 "settings.restoreDefaults" = "Herstel Standaard";
 "settings.restoreDefaultsConfirm" = "Alle aangepaste checks worden gewist en de standaardwaarden worden hersteld.";


### PR DESCRIPTION
## Summary

- Adds a **Restore Defaults** button to each scenario section header in `AttentionChecksSettingsView`
- Tapping it shows a confirmation alert and resets only that scenario's checks to factory defaults
- The existing bottom-bar **Restore Defaults** button (reset all at once) is untouched

## Test plan

- [ ] Open Settings → Attention Checks
- [ ] Customise checks for one scenario (add, edit, or delete a check)
- [ ] Tap **Restore Defaults** next to that section header → confirm → checks for that group revert to defaults, other groups unchanged
- [ ] Tap the bottom-bar **Restore Defaults** → confirm → all groups reset

Closes #148

Made with [Cursor](https://cursor.com)