### PR TITLE
fix(fastlane): use max(latest_tf, current_build)+1 to avoid no-op build bump

### DIFF
--- a/iOS/fastlane/Fastfile
+++ b/iOS/fastlane/Fastfile
@@ -172,11 +172,13 @@ platform :ios do
       xcodeproj: "App.xcodeproj",
     )
 
-    next_build_number = latest_testflight_build_number(
+    latest_tf_build = latest_testflight_build_number(
       api_key_path: api_key_path,
       initial_build_number: 0,
-    ) + 1
-    UI.message("Next build number: #{next_build_number}")
+    )
+    current_build = get_build_number(xcodeproj: "App.xcodeproj").to_i
+    next_build_number = [latest_tf_build, current_build].max + 1
+    UI.message("Next build number: #{next_build_number} (latest TF: #{latest_tf_build}, current: #{current_build})")
 
     increment_build_number(
       build_number: next_build_number,


### PR DESCRIPTION
## Summary

When the version-bump commit lands on `main` before `make release` runs (as happened with the 1.1.0 fix PR), `latest_testflight_build_number + 1` equals the already-committed build number, making `increment_build_number` a no-op and causing `commit_version_bump` to fail with "No file changes picked up".

Fix: use `max(latest_tf_build, current_build) + 1` so the build number always increments regardless of prior commits.

Hotfix to unblock the 1.1.0 release.

Made with [Cursor](https://cursor.com)