### PR TITLE
fix(appstore): correct release notes sync and add v1.2 placeholder

### DIFF
--- a/.claude/skills/publish-release/SKILL.md
+++ b/.claude/skills/publish-release/SKILL.md
@@ -82,6 +82,8 @@ If it reports limit violations, fix `AppStore/en-US.md` and `AppStore/nl-NL.md` 
 
 Also check that **What's New** for the upcoming version is filled in for both locales in the per-locale `.md` files. Users see it in the App Store update prompt.
 
+**Convention:** the upcoming block must be the **first** `## What's New` heading in each file — `sync_metadata.rb` uses first-wins, so whichever block appears first becomes `release_notes.txt`. Older blocks are kept below as history. The heading format is `## What's New (4000) — vX.Y`; do **not** put parenthesised labels like `(upcoming)` in the heading — the parser strips everything after `—` but only handles simple suffixes cleanly.
+
 Commit any copy fixes before proceeding:
 
 ```bash
@@ -163,7 +165,14 @@ After the lane succeeds:
    ```bash
    gh project item-edit --id <item-id> --field-id PVTSSF_lAHOACkwkc4BVH4yzhQl0Wc --single-select-option-id a17042c6 --project-id PVT_kwHOACkwkc4BVH4y
    ```
-4. **Update `AppStore/<locale>.md`** — move the "What's New — upcoming" block to "What's New — vX.Y" and add a fresh "upcoming" placeholder for next time.
+4. **Update `AppStore/<locale>.md`** — the shipped block is already titled `## What's New (4000) — vX.Y`. Add a new empty placeholder **above it** for the next release:
+   ```
+   ## What's New (4000) — vX.Z
+   
+   ```
+   *(placeholder — fill in before next release)*
+   
+   This keeps the first-wins convention intact: the topmost block is always the one `sync_metadata.rb` will pick up.
 
 ---
 

--- a/AppStore/en-US.md
+++ b/AppStore/en-US.md
@@ -99,13 +99,14 @@ Notes:
 - The plural / singular forms (`carb` vs `carbs`) are also indexed when one is present, so the shorter form is preferred.
 - `loop`, `iaps`, `camaps`, `xdrip` are intentionally omitted to avoid trademark friction; they're mentioned in the description instead.
 
-## What's New (4000) — v1.1 (upcoming)
+## What's New (4000) — v1.1
 
 ```
 New in this release:
 • LibreLinkUp support: connect your FreeStyle Libre follower account as a glucose data source — reads direct from Abbott's cloud.
+• Carb tracking is now optional — disable it in settings if you don't log carbs and keep the shield focused on glucose.
 ```
-*(~148 / 4000)*
+*(~296 / 4000)*
 
 ## What's New (4000) — v1.0 launch
 

--- a/AppStore/en-US.md
+++ b/AppStore/en-US.md
@@ -99,6 +99,12 @@ Notes:
 - The plural / singular forms (`carb` vs `carbs`) are also indexed when one is present, so the shorter form is preferred.
 - `loop`, `iaps`, `camaps`, `xdrip` are intentionally omitted to avoid trademark friction; they're mentioned in the description instead.
 
+## What's New (4000) — v1.2
+
+```
+```
+*(placeholder)*
+
 ## What's New (4000) — v1.1
 
 ```

--- a/AppStore/nl-NL.md
+++ b/AppStore/nl-NL.md
@@ -101,13 +101,14 @@ Opmerkingen:
 - `koolhydraten` is bewust alleen als meervoud opgenomen: dat wordt het meest gezocht.
 - `health` / `gezondheid` zijn al gedekt door de categorie.
 
-## What's New (4000) — 1.1 (binnenkort)
+## What's New (4000) — v1.1
 
 ```
 Nieuw in deze release:
 • LibreLinkUp-ondersteuning: verbind je FreeStyle Libre-volgersaccount als glucosebron — leest rechtstreeks uit Abbott's cloud.
+• Koolhydraten bijhouden is nu optioneel — schakel het uit in de instellingen als je geen koolhydraten bijhoudt en houd het schild gefocust op glucose.
 ```
-*(~148 / 4000)*
+*(~311 / 4000)*
 
 ## What's New (4000) — 1.0-release
 

--- a/AppStore/nl-NL.md
+++ b/AppStore/nl-NL.md
@@ -101,6 +101,12 @@ Opmerkingen:
 - `koolhydraten` is bewust alleen als meervoud opgenomen: dat wordt het meest gezocht.
 - `health` / `gezondheid` zijn al gedekt door de categorie.
 
+## What's New (4000) — v1.2
+
+```
+```
+*(placeholder)*
+
 ## What's New (4000) — v1.1
 
 ```

--- a/iOS/fastlane/scripts/sync_metadata.rb
+++ b/iOS/fastlane/scripts/sync_metadata.rb
@@ -91,7 +91,7 @@ def normalize_heading(raw)
   s = raw.dup
   loop do
     before = s
-    s = s.sub(/\s*\(\d+\)\s*$/, "").sub(/\s*[—–-]\s*[^()]*$/, "")
+    s = s.sub(/\s*\(\d+\)\s*$/, "").sub(/\s*[—–-]\s*.*$/, "")
     break if s == before
   end
   s.strip.downcase
@@ -101,6 +101,7 @@ def flush(fields, heading, buffer)
   return unless heading && !buffer.empty?
   filename = FIELD_MAP[heading]
   return unless filename
+  return if fields.key?(filename) # first-wins: earlier blocks take precedence
   fields[filename] = buffer.join.strip
 end
 


### PR DESCRIPTION
## Summary

- **Bug fix:** `sync_metadata.rb` was always writing the v1.0 release notes for every release, due to two compounding bugs:
  1. `normalize_heading` used `[^()]*` which couldn't strip version suffixes containing parentheses (e.g. `(upcoming)`, `(binnenkort)`), so the current-version block was silently skipped.
  2. `flush` used last-wins semantics, so even if both blocks parsed correctly, the older one lower in the file would overwrite the newer one.
- **Fix:** regex changed to `.*` (strip everything after `—`); `flush` now guards with `fields.key?` (first-wins).
- **Copy:** adds the carbs-optional bullet to the v1.1 What's New text; retitles the heading from `(upcoming)` to `v1.1`.
- **Placeholder:** adds empty `v1.2` What's New block at the top of both locale files.
- **Skill:** `publish-release` updated to document the first-wins convention and the post-release placeholder workflow.

## Impact

The v1.1.0 release notes in the App Store are stuck as the v1.0 text (Apple locks them after publish). This fix ensures v1.2.0 and beyond get the correct notes.

Made with [Cursor](https://cursor.com)