### PR TITLE
fix(infra): correct SECURITY.md link in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,7 +8,7 @@ body:
       value: |
         Thanks for taking the time to report a bug. The more concrete this is, the faster it gets fixed.
 
-        For security issues (shielding bypass, passphrase / Keychain handling, App Group data exposure, anything that could let a child circumvent the shield without the configured passphrase), please use the security policy in [`SECURITY.md`](../../SECURITY.md) instead — those go through GitHub's private vulnerability reporting, not this public form.
+        For security issues (shielding bypass, passphrase / Keychain handling, App Group data exposure, anything that could let a child circumvent the shield without the configured passphrase), please use the security policy in [`SECURITY.md`](../SECURITY.md) instead — those go through GitHub's private vulnerability reporting, not this public form.
 
   - type: textarea
     id: summary
@@ -96,5 +96,5 @@ body:
       options:
         - label: I have searched [existing issues](https://github.com/FokkeZB/GluWink/issues?q=is%3Aissue) and this is not a duplicate.
           required: true
-        - label: This is not a security issue (those go through [`SECURITY.md`](../../SECURITY.md)).
+        - label: This is not a security issue (those go through [`SECURITY.md`](../SECURITY.md)).
           required: true


### PR DESCRIPTION
## Summary

- The bug report issue template (`.github/ISSUE_TEMPLATE/bug_report.yml`) linked to `../../SECURITY.md` in two places — the intro blurb and the "This is not a security issue" confirmation checkbox.
- `../../` resolves above the repository root, producing a 404. `SECURITY.md` lives at the repo root, so the correct relative path is `../SECURITY.md`.
- Fixed both occurrences.

Closes #173

## Note (out of scope)

`feature_request.yml` has the same pattern with `[security model](../../AGENTS.md#…)`. Left untouched to keep this PR scoped to the bug template reported in #173 — happy to fix it here or in a follow-up if you'd like.

## Test plan

- [ ] Open the "New issue" → Bug report form on GitHub and confirm the `SECURITY.md` links resolve (no 404).

Made with [Cursor](https://cursor.com)