### PR TITLE
fix(infra): correct AGENTS.md link in feature request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -52,5 +52,5 @@ body:
       options:
         - label: I have searched [existing issues](https://github.com/FokkeZB/GluWink/issues?q=is%3Aissue) and [discussions](https://github.com/FokkeZB/GluWink/discussions) and this is not already on the table.
           required: true
-        - label: I've read the [security model](../../AGENTS.md#security-design-philosophy) and this proposal does not weaken the passphrase gate or give the child a bypass route.
+        - label: I've read the [security model](../AGENTS.md#security-design-philosophy) and this proposal does not weaken the passphrase gate or give the child a bypass route.
           required: true


### PR DESCRIPTION
## Summary

- The feature request issue template (`.github/ISSUE_TEMPLATE/feature_request.yml`) linked to `../../AGENTS.md#security-design-philosophy`.
- `../../` resolves above the repository root, producing a 404. `AGENTS.md` lives at the repo root, so the correct relative path is `../AGENTS.md`.
- Same root cause as the bug template fix in #175.

## Test plan

- [ ] Open the "New issue" → Feature request form on GitHub and confirm the "security model" link resolves (no 404).

Made with [Cursor](https://cursor.com)