### PR TITLE
docs(appstore): add v1.1.1 What's New release notes

### DIFF
--- a/AppStore/en-US.md
+++ b/AppStore/en-US.md
@@ -99,11 +99,12 @@ Notes:
 - The plural / singular forms (`carb` vs `carbs`) are also indexed when one is present, so the shorter form is preferred.
 - `loop`, `iaps`, `camaps`, `xdrip` are intentionally omitted to avoid trademark friction; they're mentioned in the description instead.
 
-## What's New (4000) — v1.2
+## What's New (4000) — v1.1.1
 
 ```
+• Fixed LibreLinkUp widgets not updating while the app was closed — your Home Screen and Lock Screen now stay current without having to open GluWink first.
 ```
-*(placeholder)*
+*(~155 / 4000)*
 
 ## What's New (4000) — v1.1
 

--- a/AppStore/nl-NL.md
+++ b/AppStore/nl-NL.md
@@ -101,11 +101,12 @@ Opmerkingen:
 - `koolhydraten` is bewust alleen als meervoud opgenomen: dat wordt het meest gezocht.
 - `health` / `gezondheid` zijn al gedekt door de categorie.
 
-## What's New (4000) — v1.2
+## What's New (4000) — v1.1.1
 
 ```
+• LibreLinkUp-widgets werden niet bijgewerkt zolang de app gesloten was. Opgelost — je beginscherm en toegangsscherm blijven nu actueel zonder dat je GluWink hoeft te openen.
 ```
-*(placeholder)*
+*(~178 / 4000)*
 
 ## What's New (4000) — v1.1
 


### PR DESCRIPTION
## Summary

Fills in the **What's New / changelog** block for **v1.1.1** in both locales (`AppStore/en-US.md`, `AppStore/nl-NL.md`), repurposing the empty `v1.2` placeholder.

- **EN:** Fixed LibreLinkUp widgets not updating while the app was closed — Home/Lock Screen now stay current without opening GluWink.
- **NL:** equivalent.

Kept as the **first** `## What's New` heading so `sync_metadata.rb`'s first-wins parser picks it up as `release_notes.txt`. Verified with `make appstore-sync` — both locales generate the v1.1.1 notes and all fields are within character limits.

This is the changelog step that was missed on the v1.1 release (corrected after the fact in #171); doing it up-front this time.

## Test plan

- [x] `make appstore-sync` passes (no limit violations)
- [x] `iOS/fastlane/metadata/{en-US,nl-NL}/release_notes.txt` contain the v1.1.1 copy

Refs #172

Made with [Cursor](https://cursor.com)