### PR TITLE
docs(appstore): add empty What's New placeholder for next release

### DIFF
--- a/AppStore/en-US.md
+++ b/AppStore/en-US.md
@@ -99,6 +99,12 @@ Notes:
 - The plural / singular forms (`carb` vs `carbs`) are also indexed when one is present, so the shorter form is preferred.
 - `loop`, `iaps`, `camaps`, `xdrip` are intentionally omitted to avoid trademark friction; they're mentioned in the description instead.
 
+## What's New (4000) — v1.2
+
+```
+```
+*(placeholder)*
+
 ## What's New (4000) — v1.1.1
 
 ```

--- a/AppStore/nl-NL.md
+++ b/AppStore/nl-NL.md
@@ -101,6 +101,12 @@ Opmerkingen:
 - `koolhydraten` is bewust alleen als meervoud opgenomen: dat wordt het meest gezocht.
 - `health` / `gezondheid` zijn al gedekt door de categorie.
 
+## What's New (4000) — v1.2
+
+```
+```
+*(placeholder)*
+
 ## What's New (4000) — v1.1.1
 
 ```


### PR DESCRIPTION
## Summary

Post-release housekeeping after v1.1.1 shipped. Adds an empty `## What's New (4000) — v1.2` placeholder as the topmost block in both locales so `sync_metadata.rb`'s first-wins parser doesn't re-ship v1.1.1's release notes on the next run. The label is renamed/filled at the next release.

## Test plan

- [x] v1.1.1 notes preserved below the placeholder in both `en-US.md` and `nl-NL.md`

Made with [Cursor](https://cursor.com)