### PR TITLE
fix(watchos): bring LibreLinkUp glucose to the Apple Watch

### DIFF
--- a/iOS/App.xcodeproj/project.pbxproj
+++ b/iOS/App.xcodeproj/project.pbxproj
@@ -211,8 +211,6 @@
 		};
 		332AE5BAE4BDC6CED8A8BAB5 /* WatchShared */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
 			path = WatchShared;
 			sourceTree = "<group>";
 		};

--- a/iOS/App/WatchSessionManager.swift
+++ b/iOS/App/WatchSessionManager.swift
@@ -87,6 +87,18 @@ final class WatchSessionManager: NSObject, WCSessionDelegate {
         if let session = data.easyViewSession { context["easyViewSession"] = session }
         if let uid = data.easyViewPatientUID { context["easyViewPatientUID"] = uid }
 
+        // LibreLinkUp: sync the mirrored auth token (not the Keychain
+        // credentials), region, userId, and patientId so the watch can fetch
+        // independently — same trade-off as EasyView's session cookie. The
+        // watch never re-authenticates; it serves stale on token expiry until
+        // the phone pushes a fresh token.
+        context["librelinkupEnabled"] = data.librelinkupEnabled
+        if let token = data.librelinkupToken, !token.isEmpty { context["librelinkupToken"] = token }
+        if let expiry = data.librelinkupTokenExpiry { context["librelinkupTokenExpiry"] = expiry.ISO8601Format() }
+        if let region = data.librelinkupRegion { context["librelinkupRegion"] = region }
+        if let userId = data.librelinkupUserId { context["librelinkupUserId"] = userId }
+        if let patientId = data.librelinkupPatientId { context["librelinkupPatientId"] = patientId }
+
         if data.isMockModeEnabled {
             if let glucoseReading = data.currentGlucoseReading {
                 context["currentGlucose"] = glucoseReading.mmol

--- a/iOS/WatchApp/WatchApp.swift
+++ b/iOS/WatchApp/WatchApp.swift
@@ -52,6 +52,10 @@ struct CompanionWatchApp: App {
                     WatchEasyViewManager.shared.startPolling()
                     await WatchEasyViewManager.shared.fetchAll()
                     WatchEasyViewManager.shared.scheduleBackgroundRefresh()
+
+                    WatchLibreLinkUpManager.shared.startPolling()
+                    await WatchLibreLinkUpManager.shared.fetchAll()
+                    WatchLibreLinkUpManager.shared.scheduleBackgroundRefresh()
                 }
                 .onChange(of: scenePhase) {
                     #if targetEnvironment(simulator)
@@ -63,10 +67,12 @@ struct CompanionWatchApp: App {
                             await WatchHealthKitManager.shared.fetchLatestCarbs()
                             await WatchNightscoutManager.shared.fetchAll()
                             await WatchEasyViewManager.shared.fetchAll()
+                            await WatchLibreLinkUpManager.shared.fetchAll()
                         }
                     } else if scenePhase == .background {
                         WatchNightscoutManager.shared.scheduleBackgroundRefresh()
                         WatchEasyViewManager.shared.scheduleBackgroundRefresh()
+                        WatchLibreLinkUpManager.shared.scheduleBackgroundRefresh()
                     }
                 }
         }
@@ -81,6 +87,13 @@ struct CompanionWatchApp: App {
             await WatchEasyViewManager.shared.fetchAll()
             await MainActor.run {
                 WatchEasyViewManager.shared.scheduleBackgroundRefresh()
+                WidgetCenter.shared.reloadAllTimelines()
+            }
+        }
+        .backgroundTask(.appRefresh("librelinkup")) {
+            await WatchLibreLinkUpManager.shared.fetchAll()
+            await MainActor.run {
+                WatchLibreLinkUpManager.shared.scheduleBackgroundRefresh()
                 WidgetCenter.shared.reloadAllTimelines()
             }
         }

--- a/iOS/WatchApp/WatchConnectivityReceiver.swift
+++ b/iOS/WatchApp/WatchConnectivityReceiver.swift
@@ -49,6 +49,7 @@ final class WatchConnectivityReceiver: NSObject, WCSessionDelegate {
                 await MainActor.run {
                     WatchNightscoutManager.shared.configurationDidChange()
                     WatchEasyViewManager.shared.configurationDidChange()
+                    WatchLibreLinkUpManager.shared.configurationDidChange()
                 }
             }
         }

--- a/iOS/WatchApp/WatchLibreLinkUpManager.swift
+++ b/iOS/WatchApp/WatchLibreLinkUpManager.swift
@@ -1,0 +1,127 @@
+import Foundation
+import os
+import SharedKit
+import WidgetKit
+#if canImport(WatchKit)
+import WatchKit
+#endif
+
+/// Watch-side LibreLinkUp poller. Mirrors `WatchEasyViewManager`: keeps the
+/// watch App Group glucose keys fresh so complications stay current even when
+/// the paired phone is unreachable.
+///
+/// Config (auth token, expiry, region, userId, patientId) is synced from the
+/// phone via `WatchConnectivity` and stored in the watch-local App Group by
+/// `WatchDataManager.updateFromPhoneContext`. Like the iPhone widget
+/// (`WidgetLibreLinkUpRefresh`), the watch has no Keychain access and therefore
+/// **never re-authenticates** — on an expired or rejected token it logs and
+/// serves stale cached values; the next phone foreground pass refreshes the
+/// token and pushes it via WatchConnectivity.
+///
+/// Glucose only — LibreLinkUp provides no carb data.
+@MainActor
+final class WatchLibreLinkUpManager {
+    static let shared = WatchLibreLinkUpManager()
+
+    static let pollInterval: TimeInterval = 5 * 60
+
+    /// mg/dL → mmol/L divisor (matches `LibreLinkUpManager` / `WidgetLibreLinkUpRefresh`).
+    private static let mgdlPerMmol = 18.01559
+
+    private let logger = Logger(subsystem: Constants.bundlePrefix, category: "WatchLibreLinkUpManager")
+    private var pollTimer: Timer?
+    private var inFlight = false
+
+    private init() {}
+
+    var isConfigured: Bool {
+        WatchDataManager.librelinkupEnabled && WatchDataManager.librelinkupToken != nil
+    }
+
+    func startPolling() {
+        stopPolling()
+        guard isConfigured else { return }
+        let timer = Timer(timeInterval: Self.pollInterval, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                await self?.fetchAll()
+            }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        pollTimer = timer
+        logger.info("Watch LibreLinkUp polling started")
+    }
+
+    func stopPolling() {
+        pollTimer?.invalidate()
+        pollTimer = nil
+    }
+
+    func configurationDidChange() {
+        if isConfigured {
+            startPolling()
+            Task { await fetchAll() }
+        } else {
+            stopPolling()
+        }
+    }
+
+    func fetchAll() async {
+        guard isConfigured, let token = WatchDataManager.librelinkupToken else { return }
+        guard !WatchDataManager.isMockModeEnabled else {
+            logger.info("Watch mock mode active — skipping LibreLinkUp fetch")
+            return
+        }
+        guard !inFlight else { return }
+        inFlight = true
+        defer { inFlight = false }
+
+        // No Keychain access on the watch, so a token at/near expiry means
+        // "serve stale and wait for the phone to push a fresh token" rather
+        // than attempting a login. Matches `WidgetLibreLinkUpRefresh`.
+        if let expiry = WatchDataManager.librelinkupTokenExpiry,
+           expiry.timeIntervalSinceNow < 60 {
+            logger.warning("Watch LibreLinkUp token expired — phone will refresh on next foreground")
+            return
+        }
+
+        let region = WatchDataManager.librelinkupRegion
+        let userId = WatchDataManager.librelinkupUserId
+        let storedPatientId = WatchDataManager.librelinkupPatientId
+
+        do {
+            let connections = try await LibreLinkUpClient.fetchConnections(
+                token: token,
+                region: region,
+                userId: userId
+            )
+            guard !connections.isEmpty else {
+                logger.warning("Watch LibreLinkUp: no connections in account")
+                return
+            }
+            let connection = connections.first(where: { $0.patientId == storedPatientId }) ?? connections[0]
+            let mmol = connection.glucoseMeasurement.valueInMgPerDl / Self.mgdlPerMmol
+            WatchDataManager.storeGlucose(mmol: mmol, at: connection.glucoseMeasurement.timestamp)
+            logger.info("Watch LibreLinkUp glucose: \(String(format: "%.1f", mmol)) mmol/L")
+        } catch LibreLinkUpClient.ClientError.tokenExpired {
+            logger.warning("Watch LibreLinkUp token rejected (401) — phone will refresh on next foreground")
+        } catch {
+            logger.error("Watch LibreLinkUp fetch failed: \(error.localizedDescription)")
+        }
+
+        WidgetCenter.shared.reloadAllTimelines()
+    }
+
+    func scheduleBackgroundRefresh() {
+        guard isConfigured else { return }
+        #if canImport(WatchKit) && !os(iOS)
+        WKExtension.shared().scheduleBackgroundRefresh(
+            withPreferredDate: Date(timeIntervalSinceNow: Self.pollInterval),
+            userInfo: nil
+        ) { [weak self] error in
+            if let error {
+                self?.logger.error("Watch LibreLinkUp background schedule failed: \(error.localizedDescription)")
+            }
+        }
+        #endif
+    }
+}

--- a/iOS/WatchShared/WatchDataManager.swift
+++ b/iOS/WatchShared/WatchDataManager.swift
@@ -159,6 +159,43 @@ enum WatchDataManager {
         defaults?.object(forKey: "easyViewPatientUID") as? Int
     }
 
+    // MARK: - LibreLinkUp config (synced from phone)
+
+    static var librelinkupEnabled: Bool {
+        defaults?.bool(forKey: "librelinkupEnabled") ?? false
+    }
+
+    /// Auth token mirrored from the phone. The watch has no Keychain access, so
+    /// it can only read with this already-issued token — it never logs in.
+    static var librelinkupToken: String? {
+        guard let value = defaults?.string(forKey: "librelinkupToken"),
+              !value.isEmpty else { return nil }
+        return value
+    }
+
+    static var librelinkupTokenExpiry: Date? {
+        guard let iso = defaults?.string(forKey: "librelinkupTokenExpiry") else { return nil }
+        return ISO8601DateFormatter().date(from: iso)
+    }
+
+    static var librelinkupRegion: String? {
+        guard let value = defaults?.string(forKey: "librelinkupRegion"),
+              !value.isEmpty else { return nil }
+        return value
+    }
+
+    static var librelinkupUserId: String? {
+        guard let value = defaults?.string(forKey: "librelinkupUserId"),
+              !value.isEmpty else { return nil }
+        return value
+    }
+
+    static var librelinkupPatientId: String? {
+        guard let value = defaults?.string(forKey: "librelinkupPatientId"),
+              !value.isEmpty else { return nil }
+        return value
+    }
+
     // MARK: - Nightscout config (synced from phone)
 
     static var nightscoutEnabled: Bool {
@@ -227,6 +264,17 @@ enum WatchDataManager {
             defaults?.set(uid, forKey: "easyViewPatientUID")
         } else {
             defaults?.removeObject(forKey: "easyViewPatientUID")
+        }
+
+        let librelinkupEnabled = context["librelinkupEnabled"] as? Bool ?? false
+        defaults?.set(librelinkupEnabled, forKey: "librelinkupEnabled")
+
+        for key in ["librelinkupToken", "librelinkupTokenExpiry", "librelinkupRegion", "librelinkupUserId", "librelinkupPatientId"] {
+            if let value = context[key] as? String, !value.isEmpty {
+                defaults?.set(value, forKey: key)
+            } else {
+                defaults?.removeObject(forKey: key)
+            }
         }
 
         let isMockModeEnabled = context["mockModeEnabled"] as? Bool ?? false


### PR DESCRIPTION
## Summary

Closes #183. LibreLinkUp data never reached the Apple Watch because LibreLinkUp support (#161) was built for the iPhone app + iPhone widget only — the watchOS half was never implemented. Demo, EasyView, Nightscout, and Apple Health all reach the watch; LibreLinkUp had no path.

This mirrors the **EasyView** watch pattern (closest analogue — also a cloud token source):

- **`WatchSessionManager.makeContext`** now syncs `librelinkupEnabled` + the mirrored auth **token**, expiry, region, userId, and patientId over WatchConnectivity. Credentials stay in the iPhone Keychain — only the short-lived bearer token crosses, same trade-off as EasyView's session cookie.
- **`WatchDataManager`** stores those keys and exposes accessors.
- **New `WatchLibreLinkUpManager`** fetches via the shared `LibreLinkUpClient` using the synced token and writes the watch-local `currentGlucose` keys. Like `WidgetLibreLinkUpRefresh`, it **never re-authenticates** — on an expired/rejected token it serves stale and waits for the phone to push a fresh token.
- Wired into `WatchConnectivityReceiver.applyContext`, `WatchApp` startup + scene-phase refresh, and a `librelinkup` background-refresh task.

Glucose only — LibreLinkUp has no carb data, consistent with the iPhone.

## Why it was broken
The watch doesn't use `UnifiedDataReader` / per-source `librelinkupGlucose*` keys (those live in the iPhone App Group, a separate physical container). It reads `currentGlucose`, filled by HealthKit-on-watch or watch-side pollers. LibreLinkUp also never writes to Apple Health, so the HealthKit-sync fallback couldn't carry it either.

## Test plan
- [x] App scheme builds (Release/Debug, watch targets compile as embedded deps)
- [ ] **On device:** enable LibreLinkUp as the only source on iPhone, confirm glucose appears in the Watch app
- [ ] **On device:** confirm Watch complications update with LibreLinkUp data
- [ ] **On device:** confirm it keeps working when the iPhone is unreachable (watch fetches independently with the synced token)
- [ ] **On device:** let the token expire and confirm the watch recovers after the phone next foregrounds and pushes a fresh token

## Notes
- One incidental 2-line `project.pbxproj` normalization (Xcode dropped an empty `exceptions = ()` block when it noticed the new file) — no functional effect.

Made with [Cursor](https://cursor.com)