### PR TITLE
docs(appstore): add empty What's New placeholder for next release

### DIFF
--- a/AppStore/en-US.md
+++ b/AppStore/en-US.md
@@ -99,6 +99,12 @@ Notes:
 - The plural / singular forms (`carb` vs `carbs`) are also indexed when one is present, so the shorter form is preferred.
 - `loop`, `iaps`, `camaps`, `xdrip` are intentionally omitted to avoid trademark friction; they're mentioned in the description instead.
 
+## What's New (4000) — v1.2
+
+```
+```
+*(placeholder)*
+
 ## What's New (4000) — v1.1.2
 
 ```

--- a/AppStore/nl-NL.md
+++ b/AppStore/nl-NL.md
@@ -101,6 +101,12 @@ Opmerkingen:
 - `koolhydraten` is bewust alleen als meervoud opgenomen: dat wordt het meest gezocht.
 - `health` / `gezondheid` zijn al gedekt door de categorie.
 
+## What's New (4000) — v1.2
+
+```
+```
+*(placeholder)*
+
 ## What's New (4000) — v1.1.2
 
 ```


### PR DESCRIPTION
## Summary

- Adds a fresh empty `## What's New (4000) — v1.2` placeholder above the shipped 1.1.2 block in `AppStore/en-US.md` and `AppStore/nl-NL.md`.

## Context

1.1.2 (14) shipped to App Review with the LibreLinkUp-on-watch fix folded in. This keeps the first-wins convention intact so the next release's notes land at the top.

## Test plan

- [x] Topmost `## What's New` heading is the empty placeholder
- [ ] Merge

Made with [Cursor](https://cursor.com)